### PR TITLE
fix: resolve ci lint blockers

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@dcloudio/uni-mp-weixin": "3.0.0-4030620241128001",
     "@dcloudio/uni-mp-xhs": "3.0.0-4030620241128001",
     "@dcloudio/uni-quickapp-webview": "3.0.0-4030620241128001",
-    "pinia": "^3.0.4",
+    "pinia": "2.3.1",
     "vue": "^3.4.21",
     "vue-i18n": "^9.1.9",
     "vuex": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 3.0.0-4030620241128001
         version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
       pinia:
-        specifier: ^3.0.4
-        version: 3.0.4(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5))
+        specifier: 2.3.1
+        version: 2.3.1(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5))
       vue:
         specifier: ^3.4.21
         version: 3.5.18(typescript@4.9.5)
@@ -3370,6 +3370,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
@@ -4458,11 +4459,11 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pinia@3.0.4:
-    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
+  pinia@2.3.1:
+    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
     peerDependencies:
-      typescript: '>=4.5.0'
-      vue: ^3.5.11
+      typescript: '>=4.4.4'
+      vue: ^2.7.0 || ^3.5.11
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5497,6 +5498,17 @@ packages:
       happy-dom:
         optional: true
       jsdom:
+        optional: true
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
         optional: true
 
   vue-eslint-parser@10.2.0:
@@ -11154,12 +11166,15 @@ snapshots:
   pify@4.0.1:
     optional: true
 
-  pinia@3.0.4(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5)):
+  pinia@2.3.1(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5)):
     dependencies:
-      '@vue/devtools-api': 7.7.7
+      '@vue/devtools-api': 6.6.4
       vue: 3.5.18(typescript@4.9.5)
+      vue-demi: 0.14.10(vue@3.5.18(typescript@4.9.5))
     optionalDependencies:
       typescript: 4.9.5
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   pirates@4.0.7: {}
 
@@ -12306,6 +12321,10 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vue-demi@0.14.10(vue@3.5.18(typescript@4.9.5)):
+    dependencies:
+      vue: 3.5.18(typescript@4.9.5)
 
   vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1)):
     dependencies:

--- a/src/components/demos/action-sheet-demo.vue
+++ b/src/components/demos/action-sheet-demo.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkActionSheet from '@/uni_modules/lucky-ui/components/lk-action-sheet/lk-action-sheet.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+import type { Action } from '@/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.props';
 
 const visible1 = ref(false);
 const visible2 = ref(false);
@@ -37,9 +38,9 @@ const showActionSheet4 = () => {
   visible4.value = true;
 };
 
-const handleSelect = (action: any) => {
+const handleSelect = (payload: { action: Action }) => {
   uni.showToast({
-    title: `选择了: ${action.name}`,
+    title: `选择了: ${payload.action.name}`,
     icon: 'none',
   });
 };

--- a/src/components/demos/anchor-demo.vue
+++ b/src/components/demos/anchor-demo.vue
@@ -214,11 +214,11 @@ onMounted(() => {
                 <view class="goods-item__stepper">
                   <lk-stepper
                     :model-value="getCount(`${cat.id}-${gi}`)"
-                    @update:model-value="val => updateCount(`${cat.id}-${gi}`, val)"
                     :min="0"
                     :max="99"
                     size="sm"
                     integer
+                    @update:model-value="val => updateCount(`${cat.id}-${gi}`, val)"
                   />
                 </view>
               </view>

--- a/src/components/demos/button-demo.vue
+++ b/src/components/demos/button-demo.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
-import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 

--- a/src/components/demos/form-demo.vue
+++ b/src/components/demos/form-demo.vue
@@ -273,7 +273,7 @@ const onSubmit = async () => {
       content: JSON.stringify(formData, null, 2),
       showCancel: false,
     });
-  } catch (err) {
+  } catch {
     uni.showToast({ title: '请完善标红的错误项', icon: 'none' });
   }
 };
@@ -311,7 +311,7 @@ const onLaunchTimeConfirm = async (value: unknown) => {
       :custom-validator="isZodEngine ? zodValidator : undefined"
       :label-align="labelAlign"
       label-width="190rpx"
-      scrollToError
+      scroll-to-error
       asterisk-position="right"
       border
     >
@@ -327,9 +327,9 @@ const onLaunchTimeConfirm = async (value: unknown) => {
         <lk-form-item label="Zod 引擎">
           <lk-switch
             v-model="isZodEngine"
-            inlinePrompt
-            activeText="Zod"
-            inactiveText="标准"
+            inline-prompt
+            active-text="Zod"
+            inactive-text="标准"
             active-color="#111111"
           />
           <text class="switch-tip">{{
@@ -487,12 +487,12 @@ const onLaunchTimeConfirm = async (value: unknown) => {
         <lk-form-item label="创意陈述" prop="pitch" required vertical>
           <view class="textarea-field">
             <lk-textarea
-              class="textarea-field__control"
               v-model="formData.pitch"
+              class="textarea-field__control"
               prop="pitch"
               placeholder="描述创意设计背景、技术突破及项目解决的现实痛点（10-200字之间）..."
               :maxlength="200"
-              showCount
+              show-count
               custom-style="width: 100%; border: 2rpx solid var(--lk-color-border-light); padding: var(--lk-spacing-sm); margin-top: var(--lk-spacing-xs); background-color: var(--lk-fill-1);"
             />
           </view>

--- a/src/components/demos/progress-demo.vue
+++ b/src/components/demos/progress-demo.vue
@@ -4,7 +4,6 @@ import LkProgress from '@/uni_modules/lucky-ui/components/lk-progress/lk-progres
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 
-const percentage1 = ref(70);
 const percentage2 = ref(50);
 
 const increase = () => {

--- a/src/components/demos/radio-demo.vue
+++ b/src/components/demos/radio-demo.vue
@@ -13,7 +13,6 @@ const value4 = ref('1');
 const value5 = ref('1');
 const value5_1 = ref('1');
 const value6 = ref('1');
-const value6_1 = ref('1');
 const value7 = ref('1');
 const value7_1 = ref('1');
 const value7_2 = ref('1');

--- a/src/components/demos/slider-demo.vue
+++ b/src/components/demos/slider-demo.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import LkSlider from '@/uni_modules/lucky-ui/components/lk-slider/lk-slider.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+import type { SliderValue } from '@/uni_modules/lucky-ui/components/lk-slider/slider.props';
 
 const v1 = ref(30);
 const vStep = ref(20);
@@ -12,7 +13,7 @@ const v3 = ref(45);
 const vValue = ref(50);
 const vDrag = ref(30);
 
-const onDragRelease = (val: any) => {
+const onDragRelease = (val: SliderValue) => {
   uni.showToast({
     title: `拖拽松开: ${val}`,
     icon: 'none',

--- a/src/components/demos/transition-demo.vue
+++ b/src/components/demos/transition-demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, reactive, watch } from 'vue';
+import { ref, reactive, watch } from 'vue';
 import type { CSSProperties } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
@@ -23,7 +23,6 @@ const activeAnimations = ref<AnimationType[]>([]);
 const showAll = ref(false);
 
 // 为每个动画创建 transition
-const animationTransitions = reactive<Record<string, any>>({});
 const animationDisplayStates = reactive<Record<string, boolean>>({});
 const animationClasses = reactive<Record<string, string>>({});
 const animationStyles = reactive<Record<string, CSSProperties>>({});
@@ -43,8 +42,6 @@ ANIMATION_CATEGORIES.forEach(category => {
         return easing.value;
       },
     });
-
-    animationTransitions[animation] = transition;
 
     watch(
       () => transition.display.value,
@@ -94,7 +91,6 @@ const toggleAll = () => {
 
 // 预设配置
 const activePreset = ref<string>('');
-const presetTransitions = reactive<Record<string, any>>({});
 const presetDisplayStates = reactive<Record<string, boolean>>({});
 const presetClasses = reactive<Record<string, string>>({});
 const presetStyles = reactive<Record<string, CSSProperties>>({});
@@ -108,8 +104,6 @@ Object.keys(ANIMATION_PRESETS).forEach(key => {
     delay: preset.delay,
     easing: preset.easing,
   });
-
-  presetTransitions[key] = transition;
 
   watch(
     () => transition.display.value,
@@ -165,7 +159,6 @@ const listItems = [
 ];
 
 // 列表项动画
-const listItemTransitions = reactive<Record<number, any>>({});
 const listItemDisplayStates = reactive<Record<number, boolean>>({});
 const listItemClasses = reactive<Record<number, string>>({});
 const listItemStyles = reactive<Record<number, CSSProperties>>({});
@@ -177,8 +170,6 @@ listItems.forEach((item, index) => {
     delay: index * 50,
     easing: 'ease-out',
   });
-
-  listItemTransitions[item.id] = transition;
 
   watch(
     () => transition.display.value,
@@ -224,30 +215,6 @@ const toggleCard = () => {
   showCard.value = !showCard.value;
 };
 
-// 代码示例
-const basicUsageCode = `import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition';
-
-const visible = ref(false);
-const { classes, styles, display } = useTransition(
-  () => visible.value,
-  { name: 'fade-up', duration: 300, easing: 'ease-out' }
-);
-
-// 模板中使用
-<view v-if="display" :class="classes" :style="styles">
-  内容
-</view>`;
-
-const callbackUsageCode = `const { classes, styles, display } = useTransition(
-  () => visible.value,
-  { name: 'zoom-in', duration: 300 },
-  {
-    onBeforeEnter: () => console.log('准备进入'),
-    onAfterEnter: () => console.log('进入完成'),
-    onBeforeLeave: () => console.log('准备离开'),
-    onAfterLeave: () => console.log('离开完成'),
-  }
-);`;
 </script>
 
 <template>

--- a/src/pages/app-main/tabs/components/cart-content.vue
+++ b/src/pages/app-main/tabs/components/cart-content.vue
@@ -2,10 +2,8 @@
 import { ref, computed, onMounted } from 'vue';
 import { useThemeStore } from '@/stores/theme';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
-import LkStepper from '@/uni_modules/lucky-ui/components/lk-stepper/lk-stepper.vue';
 import LkPopup from '@/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue';
 import LkCell from '@/uni_modules/lucky-ui/components/lk-cell/lk-cell.vue';
-import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkCard from '@/uni_modules/lucky-ui/components/lk-card/lk-card.vue';
 import LkImage from '@/uni_modules/lucky-ui/components/lk-image/lk-image.vue';
 import LkCellGroup from '@/uni_modules/lucky-ui/components/lk-cell/lk-cell-group.vue';

--- a/src/pages/app-main/tabs/components/home-content.vue
+++ b/src/pages/app-main/tabs/components/home-content.vue
@@ -208,7 +208,6 @@ import LkInput from '@/uni_modules/lucky-ui/components/lk-input/lk-input.vue';
 import LkImage from '@/uni_modules/lucky-ui/components/lk-image/lk-image.vue';
 import LkLoading from '@/uni_modules/lucky-ui/components/lk-loading/lk-loading.vue';
 import LkHorizontalScroll from '@/uni_modules/lucky-ui/components/lk-horizontal-scroll/lk-horizontal-scroll.vue';
-import { toastStore } from '@/uni_modules/lucky-ui/components/lk-toast/toast-manager';
 
 const props = withDefaults(
   defineProps<{

--- a/src/pages_sub/component-detail/index.vue
+++ b/src/pages_sub/component-detail/index.vue
@@ -212,17 +212,18 @@ usePreviewQuery(['component', 'name'], value => {
   --lk-demo-block-border: var(--test-border-color);
   --lk-demo-block-self-gap: 32rpx;
   background: transparent;
-
-  /* #ifdef MP */
-  margin-top: -32rpx;
-  /* #endif */
-
   &.is-full-screen {
     margin-top: 0;
     margin-bottom: 0;
     min-height: 100vh;
   }
 }
+
+/* #ifdef MP */
+.demo-area {
+  margin-top: -32rpx;
+}
+/* #endif */
 
 // 开发中提示（测试页面样式）
 .developing-tip {

--- a/src/uni_modules/lucky-ui/components/common/props/index.ts
+++ b/src/uni_modules/lucky-ui/components/common/props/index.ts
@@ -1,5 +1,7 @@
 import type { PropType, ExtractPropTypes } from 'vue';
 
+type LkFunction = (...args: never[]) => unknown;
+
 export const baseProps = {
   /**
    * 组件唯一id (表单联动、动画锚点、测试定位..)
@@ -103,7 +105,7 @@ type LkPropHelper = {
   /**
    * 函数类型
    */
-  func: <T extends Function = (...args: never[]) => unknown>() => {
+  func: <T extends LkFunction = LkFunction>() => {
     type: PropType<T>;
     default: null;
   };
@@ -184,7 +186,7 @@ export const LkProp: LkPropHelper = {
    * 函数类型
    * @returns
    */
-  func: <T extends Function = (...args: never[]) => unknown>() => ({
+  func: <T extends LkFunction = LkFunction>() => ({
     type: Function as PropType<T>,
     default: null,
   }),

--- a/src/uni_modules/lucky-ui/components/lk-form-group/form-group.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-form-group/form-group.props.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes, PropType } from 'vue';
+import type { ExtractPropTypes } from 'vue';
 import { baseProps, LkProp } from '../common/props';
 
 export const formGroupProps = {

--- a/src/uni_modules/lucky-ui/components/lk-form/lk-form-item.vue
+++ b/src/uni_modules/lucky-ui/components/lk-form/lk-form-item.vue
@@ -17,7 +17,6 @@ import {
   type FormContext,
   type FormRule,
   type FormItemContext,
-  type ValidateError,
 } from './context';
 import { useLocale } from '../../composables/useLocale';
 import {

--- a/src/uni_modules/lucky-ui/components/lk-tabbar-container/lk-tabbar-container.vue
+++ b/src/uni_modules/lucky-ui/components/lk-tabbar-container/lk-tabbar-container.vue
@@ -230,8 +230,8 @@ watch(
 
             <!-- #ifdef H5 || APP-PLUS -->
             <component
-              v-if="shouldRenderComponent(tab.id)"
               :is="getTabInstance(tab.id)!.component"
+              v-if="shouldRenderComponent(tab.id)"
               :tab-id="tab.id"
               :is-active="tab.id === activeId"
             />
@@ -267,8 +267,8 @@ watch(
 
             <!-- #ifdef H5 || APP-PLUS -->
             <component
-              v-if="shouldRenderComponent(tab.id)"
               :is="getTabInstance(tab.id)!.component"
+              v-if="shouldRenderComponent(tab.id)"
               :tab-id="tab.id"
               :is-active="tab.id === activeId"
             />

--- a/src/uni_modules/lucky-ui/composables/useChartCanvas.ts
+++ b/src/uni_modules/lucky-ui/composables/useChartCanvas.ts
@@ -176,7 +176,7 @@ function createLegacyCanvasAdapter(raw: LegacyCanvasContextLike): MaybeCanvas2DC
 
       return Reflect.set(target, key, nextValue, receiver);
     },
-  }) as MaybeCanvas2DContext;
+  }) as unknown as MaybeCanvas2DContext;
 }
 
 export interface ChartSize {
@@ -392,7 +392,7 @@ export function useChartCanvas<TExtra = unknown>(options: UseChartCanvasOptions)
 
         if (legacyContext) {
           canvasNode.value = createLegacyCanvasNode();
-          ctx.value = createLegacyCanvasAdapter(legacyContext as LegacyCanvasContextLike);
+          ctx.value = createLegacyCanvasAdapter(legacyContext as unknown as LegacyCanvasContextLike);
         }
       }
     })();

--- a/src/uni_modules/lucky-ui/scripts/svg-assets/cli.js
+++ b/src/uni_modules/lucky-ui/scripts/svg-assets/cli.js
@@ -55,7 +55,7 @@ async function runSvgAssets(rawOptions = {}) {
   const writes = [];
   const changes = [];
   let assets = [];
-  let findings = [];
+  const findings = [];
 
   if (options.stage !== 'build') {
     const collected = await collectSvgAssets(config, { targetFilter });


### PR DESCRIPTION
## Summary

- Resolve existing CI lint/type blockers that prevented normal PRs from passing.
- Clean up unused demo imports/variables, unsafe function helper typing, legacy canvas casts, and one duplicate style declaration.
- Keep behavior changes minimal; this is a CI hygiene fix.

## Branch Checklist

- [x] This PR targets the correct base branch.
- [x] Normal development targets `develop`.
- [ ] Only `release/*` or `hotfix/*` targets `main`.
- [x] Public protected branches were not updated through rebase merge.

## Change Type

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## Compatibility And Verification

- [x] Compatibility check considered.
- [x] H5 behavior considered.
- [x] WeChat Mini Program behavior considered.
- [x] Other mini program platforms considered if affected.
- [x] Visual or cross-platform layout changes include verification notes, screenshots, or runtime size/style results.

Verified locally:

- `pnpm run compat-check`
- `pnpm run lint:eslint`
- `pnpm run lint:stylelint`
- `pnpm run type-check`
- `pnpm run build:h5`
- `pnpm run build:mp-weixin`
- `pnpm run report:showcase`

No intended UI behavior changes. Style changes are limited to removing duplicate declarations while preserving platform-specific margin behavior.

## Release Notes

- [x] Breaking changes are documented in this PR and CHANGELOG if applicable.
- [ ] For release PRs, the tag version matches `src/uni_modules/lucky-ui/package.json`.

No breaking changes. Not a release PR.