### PR TITLE
docs: fix homepage npm package name

### DIFF
--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -59,13 +59,13 @@ const features = [
   },
 ]
 
-const codeSnippet = `import { LkButton, LkToast } from 'lucky-ui'
+const codeSnippet = `import { LkButton, LkToast } from 'uni-lucky-ui'
 
 // 全局引入
-import LuckyUI from 'lucky-ui'
+import LuckyUI from 'uni-lucky-ui'
 app.use(LuckyUI)`
 
-const installCmd = 'pnpm add lucky-ui'
+const installCmd = 'pnpm add uni-lucky-ui'
 </script>
 
 <template>
@@ -270,7 +270,7 @@ const installCmd = 'pnpm add lucky-ui'
             <div class="lk-step__num">01</div>
             <div class="lk-step__body">
               <div class="lk-step__title">安装</div>
-              <div class="lk-step__code"><span class="lk-step__prompt">$</span> pnpm add lucky-ui</div>
+              <div class="lk-step__code"><span class="lk-step__prompt">$</span> pnpm add uni-lucky-ui</div>
             </div>
           </div>
           <div class="lk-step">
@@ -278,7 +278,7 @@ const installCmd = 'pnpm add lucky-ui'
             <div class="lk-step__body">
               <div class="lk-step__title">注册</div>
               <div class="lk-step__code">
-                <span class="lk-step__import">import</span> LuckyUI <span class="lk-step__import">from</span> <span class="lk-step__str">'lucky-ui'</span><br>
+                <span class="lk-step__import">import</span> LuckyUI <span class="lk-step__import">from</span> <span class="lk-step__str">'uni-lucky-ui'</span><br>
                 app.<span class="lk-step__fn">use</span>(LuckyUI)
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Fix homepage npm package examples to use `uni-lucky-ui`.
- Align the hero install command and quick-start import snippet with the published npm package name.
- The old `lucky-ui` name is only the local `uni_modules` directory/plugin name, not the npm package name.

## Branch Checklist

- [x] This PR targets the correct base branch.
- [x] Normal development targets `develop`.
- [ ] Only `release/*` or `hotfix/*` targets `main`.
- [x] Public protected branches were not updated through rebase merge.

## Change Type

- [ ] Feature
- [ ] Fix
- [x] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## Compatibility And Verification

- [x] Compatibility check considered.
- [x] H5 behavior considered.
- [x] WeChat Mini Program behavior considered.
- [x] Other mini program platforms considered if affected.
- [x] Visual or cross-platform layout changes include verification notes, screenshots, or runtime size/style results.

Verification:
- Ran `pnpm run docs:build`.
- Verified generated homepage contains `pnpm add uni-lucky-ui`.
- Verified generated homepage no longer contains `pnpm add lucky-ui`.
- Deployed docs to `https://lucky-ui.cn/` and verified the live homepage.

## Release Notes

- [x] Breaking changes are documented in this PR and CHANGELOG if applicable.
- [ ] For release PRs, the tag version matches `src/uni_modules/lucky-ui/package.json`.

No breaking changes. Not a release PR.