### PR TITLE
docs: improve phone preview layout

### DIFF
--- a/docs/.vitepress/theme/components/PhonePreview.vue
+++ b/docs/.vitepress/theme/components/PhonePreview.vue
@@ -128,17 +128,44 @@ watch(frameUrl, (newUrl) => {
 <style scoped>
 .phone-preview-panel {
   position: fixed;
-  right: 24px;
-  top: calc(var(--vp-nav-height) + 16px);
-  width: 300px;
+  right: 28px;
+  top: calc(var(--vp-nav-height) + 12px);
+  width: 376px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   z-index: 10;
 }
 
-/* 在小屏幕上隐藏预览面板 */
-@media (max-width: 1380px) {
+/* 分段缩放预览面板：窄桌面保留预览，再窄时隐藏以保证正文可读 */
+@media (max-width: 1599px) and (min-width: 1381px) {
+  .phone-preview-panel {
+    right: 20px;
+    top: calc(var(--vp-nav-height) + 8px);
+    width: 336px;
+    gap: 6px;
+  }
+}
+
+@media (max-height: 820px) and (min-width: 1381px) {
+  .phone-preview-panel {
+    right: 20px;
+    top: calc(var(--vp-nav-height) + 8px);
+    width: 336px;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 1380px) and (min-width: 1181px) {
+  .phone-preview-panel {
+    right: 12px;
+    top: calc(var(--vp-nav-height) + 8px);
+    width: 304px;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 1180px) {
   .phone-preview-panel {
     display: none;
   }
@@ -190,8 +217,8 @@ watch(frameUrl, (newUrl) => {
 }
 
 .phone-shell {
-  width: 248px;
-  height: 520px;
+  width: 320px;
+  height: 672px;
   background: var(--vp-c-bg-soft);
   border: 2px solid var(--vp-c-border);
   border-radius: 36px;
@@ -203,6 +230,30 @@ watch(frameUrl, (newUrl) => {
     0 8px 32px rgba(0, 0, 0, 0.12),
     0 2px 8px rgba(0, 0, 0, 0.08);
   position: relative;
+}
+
+@media (max-height: 820px) and (min-width: 1381px) {
+  .phone-shell {
+    width: 288px;
+    height: 604px;
+    border-radius: 32px;
+  }
+}
+
+@media (max-width: 1599px) and (min-width: 1381px) {
+  .phone-shell {
+    width: 288px;
+    height: 604px;
+    border-radius: 32px;
+  }
+}
+
+@media (max-width: 1380px) and (min-width: 1181px) {
+  .phone-shell {
+    width: 260px;
+    height: 548px;
+    border-radius: 30px;
+  }
 }
 
 .phone-shell::before {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -31,14 +31,32 @@
 
 /* ── 有手机预览时，压缩主内容宽度让出右侧空间 ── */
 html.has-phone-preview .VPDoc {
-  padding-right: 340px;
+  padding-right: 430px;
 }
 
 html.has-phone-preview .VPDoc .aside {
   display: none;
 }
 
+@media (max-width: 1599px) and (min-width: 1381px) {
+  html.has-phone-preview .VPDoc {
+    padding-right: 384px;
+  }
+}
+
 @media (max-width: 1380px) {
+  html.has-phone-preview .VPDoc {
+    padding-right: 324px;
+  }
+}
+
+@media (max-height: 820px) and (min-width: 1381px) {
+  html.has-phone-preview .VPDoc {
+    padding-right: 384px;
+  }
+}
+
+@media (max-width: 1180px) {
   html.has-phone-preview .VPDoc {
     padding-right: 0;
   }


### PR DESCRIPTION
## Summary

- Optimize the docs right-side phone preview layout.
- Increase preview size on wide desktop screens.
- Add responsive preview scaling for narrower desktop widths before hiding it below 1180px.

## Branch Checklist

- [x] This PR targets the correct base branch.
- [x] Normal development targets `develop`.
- [ ] Only `release/*` or `hotfix/*` targets `main`.
- [x] Public protected branches were not updated through rebase merge.

## Change Type

- [ ] Feature
- [ ] Fix
- [x] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## Compatibility And Verification

- [x] Compatibility check considered.
- [x] H5 behavior considered.
- [x] WeChat Mini Program behavior considered.
- [x] Other mini program platforms considered if affected.
- [x] Visual or cross-platform layout changes include verification notes, screenshots, or runtime size/style results.

Verification notes:

- Checked docs preview layout locally at `http://localhost:4188/components/button.html`.
- Verified preview remains visible and scaled at 1600px, 1440px, 1366px, and 1280px widths.
- Verified preview hides below 1180px so the document content remains readable.
- This change only affects the VitePress docs site layout. It does not change lucky-ui runtime components.

## Release Notes

- [x] Breaking changes are documented in this PR and CHANGELOG if applicable.
- [ ] For release PRs, the tag version matches `src/uni_modules/lucky-ui/package.json`.

No breaking changes. Not a release PR.