### PR TITLE
fix(docs): 交互式调试实时预览改用生产 H5 地址

### DIFF
--- a/docs/.vitepress/theme/components/PhonePreview.vue
+++ b/docs/.vitepress/theme/components/PhonePreview.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { H5_PREVIEW_BASE_URL } from '../constants/preview'
 
 const props = defineProps<{
   src: string      // e.g. "button"  — component name, or full path like "/pages/component-detail/index?component=button"
   title?: string
 }>()
 
-// H5 preview site base URL.
-const BASE_URL = 'https://preview.lucky-ui.cn'
-
 const frameUrl = computed(() => {
-  if (!props.src) return `${BASE_URL}/#/pages_sub/component-detail/index`
+  if (!props.src) return `${H5_PREVIEW_BASE_URL}/#/pages_sub/component-detail/index`
   // 若 src 不含斜杠，视为组件名，拼接 component-detail 路由
   if (!props.src.includes('/')) {
-    return `${BASE_URL}/#/pages_sub/component-detail/index?component=${encodeURIComponent(props.src)}`
+    return `${H5_PREVIEW_BASE_URL}/#/pages_sub/component-detail/index?component=${encodeURIComponent(props.src)}`
   }
   // 否则视为完整路径
-  return `${BASE_URL}/#${props.src}`
+  return `${H5_PREVIEW_BASE_URL}/#${props.src}`
 })
 
 const loaded = ref(false)

--- a/docs/.vitepress/theme/components/PropsPlayground.vue
+++ b/docs/.vitepress/theme/components/PropsPlayground.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { H5_PREVIEW_BASE_URL } from '../constants/preview'
 
 /**
  * PropsPlayground — 文档调试模式组件
@@ -26,8 +27,6 @@ const props = defineProps<{
   tagPrefix?: string
 }>()
 
-const BASE_URL = 'http://localhost:5173'
-
 // ── 状态管理 ──
 const currentValues = ref<Record<string, unknown>>({})
 const slotText = ref(props.slotContent ?? '')
@@ -48,7 +47,7 @@ initValues()
 
 // iframe URL
 const frameUrl = computed(() => {
-  return `${BASE_URL}/#/pages_sub/playground/index?component=${encodeURIComponent(props.component)}`
+  return `${H5_PREVIEW_BASE_URL}/#/pages_sub/playground/index?component=${encodeURIComponent(props.component)}`
 })
 
 // ── 生成代码 ──

--- a/docs/.vitepress/theme/constants/preview.ts
+++ b/docs/.vitepress/theme/constants/preview.ts
@@ -1,0 +1,2 @@
+/** H5 组件预览站点（文档 iframe 实时预览统一入口） */
+export const H5_PREVIEW_BASE_URL = 'https://preview.lucky-ui.cn'


### PR DESCRIPTION
## Summary

- 修复文档「交互式调试」实时预览仍指向 `localhost:5173` 的问题
- 统一改为生产 H5 预览地址 `https://preview.lucky-ui.cn`
- 抽取 `H5_PREVIEW_BASE_URL`，`PropsPlayground` 与 `PhonePreview` 共用

## Branch Checklist

- [x] 目标分支为 `develop`
- [x] 未对受保护分支做 rebase merge

## Change Type

- [ ] Feature
- [x] Fix
- [x] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## Compatibility And Verification

- [x] 仅改动 VitePress 文档预览地址，未改组件库源码
- [ ] H5 业务代码
- [ ] 微信小程序
- [ ] 其他小程序平台
- [x] 已验证：展开「调试模式 → 实时预览」，iframe 指向 `preview.lucky-ui.cn`

## Release Notes

- [x] 无破坏性变更，无需更新 CHANGELOG
- [ ] 发布 PR 需核对 `package.json` 版本号