### PR TITLE
fix(segmented): correct slider measurement in modal

### DIFF
--- a/docs/.vitepress/theme/constants/preview.ts
+++ b/docs/.vitepress/theme/constants/preview.ts
@@ -1,2 +1,11 @@
-/** H5 组件预览站点（文档 iframe 实时预览统一入口） */
-export const H5_PREVIEW_BASE_URL = 'https://preview.lucky-ui.cn'
+const DEFAULT_DEV_PREVIEW_URL = 'http://localhost:5188'
+const DEFAULT_PROD_PREVIEW_URL = 'https://preview.lucky-ui.cn'
+
+function normalizePreviewUrl(url: string) {
+  return url.replace(/\/+$/, '')
+}
+
+export const H5_PREVIEW_BASE_URL = normalizePreviewUrl(
+  import.meta.env.VITE_LUCKY_UI_H5_PREVIEW_URL ||
+    (import.meta.env.DEV ? DEFAULT_DEV_PREVIEW_URL : DEFAULT_PROD_PREVIEW_URL)
+)

--- a/docs/components/segmented.md
+++ b/docs/components/segmented.md
@@ -71,6 +71,29 @@ const options = [
 />
 ```
 
+## 横向滚动选项
+
+当选项总宽度超过容器时，组件会在自身内部横向滚动，并保持滑块与当前选项对齐。
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const active = ref('week')
+const options = [
+  { label: '今日热榜', value: 'today' },
+  { label: '本周精选内容', value: 'week' },
+  { label: '设计趋势观察', value: 'design' },
+  { label: '工程效率', value: 'engineering' },
+  { label: '跨端兼容', value: 'compat' },
+]
+</script>
+
+<template>
+  <lk-segmented v-model="active" :options="options" />
+</template>
+```
+
 ## 自定义高度
 
 ```vue
@@ -178,5 +201,5 @@ import SegmentedDemo from '@/components/demos/segmented-demo.vue'
 ## 使用建议
 
 ::: tip
-`lk-segmented` 适合少量平级选项切换。如果选项很多、需要横向滚动或二级导航，建议改用自定义导航或 `lk-horizontal-scroll` 承载选项。
+`lk-segmented` 适合少量平级选项切换。选项略超出容器时可直接使用内置横向滚动；如果选项很多、存在二级导航或需要复杂卡片内容，建议改用自定义导航或 `lk-horizontal-scroll` 承载选项。
 :::

--- a/src/components/demos/modal-demo.vue
+++ b/src/components/demos/modal-demo.vue
@@ -2,7 +2,10 @@
 import { computed, ref } from 'vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
-import type { TransitionConfig } from '@/uni_modules/lucky-ui/composables/useTransition';
+import type {
+  TransitionConfig,
+  TransitionName,
+} from '@/uni_modules/lucky-ui/composables/useTransition';
 import type { SegmentedOption } from '@/uni_modules/lucky-ui/components/lk-segmented/segmented.props';
 
 const visible1 = ref(false);
@@ -20,16 +23,21 @@ const visibleFooterText = ref(false);
 const visibleSingleBtn = ref(false);
 
 // 动态参数
-const dynamicType = ref<TransitionConfig['name']>('zoom-in');
+const dynamicType = ref<TransitionName>('zoom-in');
 const dynamicDuration = ref(400);
 const dynamicEasing = ref('ease-out');
 const modalEasing = computed(() => dynamicEasing.value as TransitionConfig['easing']);
+const animationOptions: SegmentedOption[] = [
+  { label: 'zoom-in', value: 'zoom-in' },
+  { label: 'slide-up', value: 'slide-up' },
+  { label: 'fade-up', value: 'fade-up' },
+  { label: 'bounce-in', value: 'bounce-in' },
+];
 const easingOptions: SegmentedOption[] = [
   { label: 'ease', value: 'ease' },
   { label: 'ease-out', value: 'ease-out' },
   { label: 'ease-in', value: 'ease-in' },
   { label: 'ease-in-out', value: 'ease-in-out' },
-  { label: 'ease-out-back', value: 'ease-out-back' },
 ];
 
 const handleConfirm = () => {
@@ -128,16 +136,19 @@ const handleConfirm = () => {
               >当前动画: {{ dynamicType }} 时长: {{ dynamicDuration }}ms 缓动:
               {{ dynamicEasing }}</text
             >
-            <lk-space wrap :gap="12">
-              <lk-button size="sm" @click="dynamicType = 'zoom-in'">zoom-in</lk-button>
-              <lk-button size="sm" @click="dynamicType = 'slide-up'">slide-up</lk-button>
-              <lk-button size="sm" @click="dynamicType = 'fade-up'">fade-up</lk-button>
-              <lk-button size="sm" @click="dynamicType = 'bounce-in'">bounce-in</lk-button>
-            </lk-space>
+            <lk-segmented
+              v-model="dynamicType"
+              :options="animationOptions"
+              size="sm"
+              class="dynamic-option-segmented"
+            />
             <lk-slider v-model="dynamicDuration" :min="100" :max="1000" :step="100" />
-            <scroll-view scroll-x class="segmented-scroll">
-              <lk-segmented v-model="dynamicEasing" :options="easingOptions" />
-            </scroll-view>
+            <lk-segmented
+              v-model="dynamicEasing"
+              :options="easingOptions"
+              size="sm"
+              class="dynamic-easing-segmented"
+            />
           </view>
         </lk-modal>
       </lk-space>
@@ -193,9 +204,9 @@ const handleConfirm = () => {
   }
 }
 
-.segmented-scroll {
+.dynamic-option-segmented,
+.dynamic-easing-segmented {
   width: 100%;
-  white-space: nowrap;
 }
 
 .dynamic-modal-content {

--- a/src/components/demos/segmented-demo.vue
+++ b/src/components/demos/segmented-demo.vue
@@ -12,6 +12,7 @@ const v5 = ref('a');
 const v6 = ref('daily');
 const v7 = ref('nearby');
 const v8 = ref('daily');
+const scrollVal = ref('week');
 
 const hVal = ref('weekly');
 const slotVal = ref('1');
@@ -41,6 +42,13 @@ const disabledOptions = [
   { label: '启用 A', value: 'a' },
   { label: '禁用 B', value: 'b', disabled: true },
   { label: '启用 C', value: 'c' },
+];
+const scrollOptions = [
+  { label: '今日热榜', value: 'today' },
+  { label: '本周精选内容', value: 'week' },
+  { label: '设计趋势观察', value: 'design' },
+  { label: '工程效率', value: 'engineering' },
+  { label: '跨端兼容', value: 'compat' },
 ];
 </script>
 
@@ -101,6 +109,11 @@ const disabledOptions = [
         inset="6rpx"
         radius="999px"
       />
+    </demo-block>
+
+    <demo-block title="横向滚动选项">
+      <view class="sub-title">选项超过容器宽度时，滑块会跟随滚动后的点击位置</view>
+      <lk-segmented v-model="scrollVal" :options="scrollOptions" />
     </demo-block>
 
     <!-- 主题变量覆写 --------------------------------------------------->

--- a/src/uni_modules/lucky-ui/components/lk-segmented/lk-segmented.scss
+++ b/src/uni_modules/lucky-ui/components/lk-segmented/lk-segmented.scss
@@ -122,10 +122,3 @@
   }
 }
 
-/* 当被 scroll-view 包裹时，取消最大宽度限制以允许横向滚动 */
-uni-scroll-view,
-scroll-view {
-  .lk-segmented {
-    max-width: none;
-  }
-}

--- a/src/uni_modules/lucky-ui/components/lk-segmented/lk-segmented.vue
+++ b/src/uni_modules/lucky-ui/components/lk-segmented/lk-segmented.vue
@@ -6,6 +6,8 @@ import {
   resolveSegmentedRootStyle,
   resolveSegmentedSelection,
   resolveSegmentedSliderStyle,
+  type SegmentRect,
+  type SegmentWrapRect,
 } from './segmented.utils';
 
 defineOptions({ name: 'LkSegmented' });
@@ -44,50 +46,105 @@ function select(opt: SegmentedOption, event?: unknown) {
   }
   if (result.reselected) {
     emit('reselect', { value: opt.value, option: opt, event });
+    scheduleSliderUpdate();
     return;
   }
   active.value = result.value;
   emit('update:modelValue', result.value);
   emit('select', { value: result.value, option: opt, oldValue: result.oldValue });
   emit('change', result.value, opt, result.oldValue);
-  setTimeout(updateSlider, 50);
+  scheduleSliderUpdate();
 }
 
 watch(
   () => props.modelValue,
   v => {
     active.value = v;
-    updateSlider();
+    scheduleSliderUpdate();
   }
 );
 watch(
-  [() => props.options, () => props.size, () => props.block, () => props.inset, () => props.gutter],
-  () => nextTick(updateSlider),
+  [
+    () => props.options,
+    () => props.size,
+    () => props.block,
+    () => props.inset,
+    () => props.gutter,
+    () => props.animated,
+    () => props.duration,
+    () => props.easing,
+    () => props.radius,
+    () => props.height,
+    () => props.customStyle,
+  ],
+  scheduleSliderUpdate,
   { deep: true }
 );
 
+function scheduleSliderUpdate() {
+  nextTick(updateSlider);
+}
+
+function applySliderMetrics(wrap: SegmentWrapRect, items: SegmentRect[]) {
+  sliderStyle.value = resolveSegmentedSliderStyle({
+    wrap,
+    items,
+    options: props.options,
+    activeValue: active.value,
+    animated: props.animated,
+    duration: props.duration,
+    easing: props.easing,
+  });
+}
+
+function getRootElement(): HTMLElement | null {
+  if (typeof HTMLElement === 'undefined') return null;
+  const raw = rootRef.value ? (rootRef.value.$el || rootRef.value) : null;
+  return raw instanceof HTMLElement ? raw : null;
+}
+
+function updateH5Slider() {
+  const root = getRootElement();
+  if (!root) return false;
+
+  const items = Array.from(root.children)
+    .filter(
+      (el): el is HTMLElement =>
+        el instanceof HTMLElement && el.classList.contains('lk-segmented__item')
+    )
+    .map(item => ({
+      left: item.offsetLeft,
+      width: item.offsetWidth,
+    }));
+
+  if (!items.length) return false;
+
+  applySliderMetrics({ left: 0 }, items);
+  return true;
+}
+
 function updateSlider() {
-  const q = uni.createSelectorQuery().in(inst);
-  q.select('.lk-segmented').boundingClientRect();
+  if (updateH5Slider()) return;
+  if (!inst?.proxy) return;
+
+  const q = uni.createSelectorQuery().in(inst.proxy);
+  q.select('.lk-segmented').fields({
+    rect: true,
+    size: true,
+    scrollOffset: true,
+  }, () => {});
   q.selectAll('.lk-segmented__item').boundingClientRect();
   q.exec(res => {
     const wrap = res?.[0];
     const items = res?.[1];
-    if (!wrap || !items?.length) return;
+    if (!wrap || typeof wrap.left !== 'number' || !items?.length) return;
 
-    sliderStyle.value = resolveSegmentedSliderStyle({
-      wrap,
-      items,
-      options: props.options,
-      activeValue: active.value,
-      animated: props.animated,
-      duration: props.duration,
-      easing: props.easing,
-    });
+    applySliderMetrics(wrap, items);
   });
 }
 
 onMounted(() => {
+  scheduleSliderUpdate();
   setTimeout(updateSlider, 50);
   // #ifdef H5
   if (typeof ResizeObserver !== 'undefined') {

--- a/src/uni_modules/lucky-ui/components/lk-segmented/segmented.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-segmented/segmented.utils.ts
@@ -19,8 +19,13 @@ export interface SegmentRect {
   width: number;
 }
 
+export interface SegmentWrapRect {
+  left: number;
+  scrollLeft?: number;
+}
+
 export interface ResolveSegmentedSliderOptions {
-  wrap: Pick<SegmentRect, 'left'>;
+  wrap: SegmentWrapRect;
   items: SegmentRect[];
   options: SegmentedOption[];
   activeValue: SegmentedValue;
@@ -66,7 +71,8 @@ export function resolveSegmentedSliderStyle(
     return { opacity: '0' };
   }
 
-  const offset = activeItem.left - options.wrap.left;
+  const scrollLeft = options.wrap.scrollLeft ?? 0;
+  const offset = activeItem.left - options.wrap.left + scrollLeft;
   return {
     width: `${activeItem.width}px`,
     transform: `translateX(${offset}px)`,

--- a/tests/unit/lk-segmented.spec.ts
+++ b/tests/unit/lk-segmented.spec.ts
@@ -71,6 +71,25 @@ describe('lk-segmented interaction rules', () => {
     });
   });
 
+  it('keeps slider offset aligned after the segmented wrapper scrolls horizontally', () => {
+    expect(resolveSegmentedSliderStyle({
+      wrap: { left: 100, scrollLeft: 128 },
+      items: [
+        { left: 104, width: 80 },
+        { left: 188, width: 96 },
+      ],
+      options: options.slice(0, 2),
+      activeValue: 'weekly',
+      animated: true,
+      duration: 260,
+      easing: 'ease-out',
+    })).toMatchObject({
+      width: '96px',
+      transform: 'translateX(216px)',
+      opacity: '1',
+    });
+  });
+
   it('hides the slider when the active value is absent or rect is missing', () => {
     expect(resolveSegmentedSliderStyle({
       wrap: { left: 100 },
@@ -103,6 +122,18 @@ describe('lk-segmented interaction rules', () => {
       duration: 260,
       easing: 'ease-out',
     }).transition).toBe('none');
+  });
+
+  it('uses the latest animation options when rebuilding slider style', () => {
+    expect(resolveSegmentedSliderStyle({
+      wrap: { left: 0 },
+      items: [{ left: 0, width: 120 }],
+      options: [options[0]],
+      activeValue: 'daily',
+      animated: true,
+      duration: 480,
+      easing: 'linear',
+    }).transition).toBe('width 480ms linear, transform 480ms linear, opacity 180ms ease');
   });
 
   it('builds root CSS variables while preserving custom style', () => {


### PR DESCRIPTION
## 摘要

- 修复 `lk-segmented` 在 `lk-modal` 首次入场动画期间滑块测量不准的问题。
- H5 端改用 `offsetLeft / offsetWidth` 计算滑块位置，避免父级 `transform: scale()` 影响首次渲染。
- 调整 Modal 动态参数 demo，移除外层 `scroll-view`，让动画类型和缓动参数使用更稳定的分段器示例。
- 补充分段器横向滚动示例、文档说明和单元测试。
- 调整 docs 开发环境预览地址：本地开发默认指向 `http://localhost:5188`，生产仍使用线上预览地址。

## 分支检查

- [x] 此 PR 指向正确的 base 分支。
- [x] 常规开发目标分支为 `develop`。
- [x] 只有 `release/*` 或 `hotfix/*` 分支才指向 `main`。
- [x] 未通过 rebase merge 更新公共受保护分支。

## 变更类型

- [ ] Feature
- [x] Fix
- [x] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## 兼容性与验证

- [x] 已考虑兼容性影响。
- [x] 已考虑 H5 行为。
- [x] 已考虑微信小程序行为。
- [x] 如受影响，已考虑其他小程序平台。
- [x] 视觉或跨端布局变更已包含验证说明、截图或运行态尺寸/样式结果。

验证说明：

- 已执行 `pnpm run type-check`，通过。
- H5 路由验证：`http://localhost:5188/#/pages_sub/component-detail/index?component=modal`
- 运行态抓取结果：修复前 `ease-out` active 宽 `58.92px`，slider 宽 `48.72px`，left 差 `-7.26px`；修复后 active 宽 `58.92px`，slider 宽 `59px`，left 差 `0.06px`。
- 该修复不变更 `lk-segmented` 的 props、事件或公开 API，属于非破坏性 bug fix。

## 发布说明

- [x] 本 PR 无破坏性变更，无需在 CHANGELOG 中按 breaking change 记录。
- [ ] 本 PR 不是 release PR，不涉及 `src/uni_modules/lucky-ui/package.json` 版本标签匹配。