### PR TITLE
fix(package): restore utf-8 in lucky-ui package.json

### DIFF
--- a/src/uni_modules/lucky-ui/package.json
+++ b/src/uni_modules/lucky-ui/package.json
@@ -85,13 +85,13 @@
       "qq": ""
     },
     "declaration": {
-      "ads": "æ—?,
-      "data": "æ’ä»¶ä¸é‡‡é›†ä»»ä½•æ•°æ?,
-      "permissions": "æ—?
+      "ads": "æ— ",
+      "data": "æ’ä»¶ä¸é‡‡é›†ä»»ä½•æ•°æ®",
+      "permissions": "æ— "
     },
     "npmurl": "https://www.npmjs.com/package/uni-lucky-ui",
-    "darkmode": "âˆ?,
-    "i18n": "âˆ?,
+    "darkmode": "âˆš",
+    "i18n": "âˆš",
     "widescreen": "x"
   },
   "uni_modules": {
@@ -113,26 +113,26 @@
             }
           },
           "web": {
-            "safari": "âˆ?,
-            "chrome": "âˆ?
+            "safari": "âˆš",
+            "chrome": "âˆš"
           },
           "app": {
-            "vue": "âˆ?,
+            "vue": "âˆš",
             "nvue": "x",
-            "android": "âˆ?,
-            "ios": "âˆ?,
+            "android": "âˆš",
+            "ios": "âˆš",
             "harmony": "-"
           },
           "mp": {
-            "weixin": "âˆ?,
-            "alipay": "âˆ?,
-            "toutiao": "âˆ?,
-            "baidu": "âˆ?,
-            "kuaishou": "âˆ?,
-            "jd": "âˆ?,
+            "weixin": "âˆš",
+            "alipay": "âˆš",
+            "toutiao": "âˆš",
+            "baidu": "âˆš",
+            "kuaishou": "âˆš",
+            "jd": "âˆš",
             "harmony": "-",
-            "qq": "âˆ?,
-            "lark": "âˆ?,
+            "qq": "âˆš",
+            "lark": "âˆš",
             "xhs": "-"
           },
           "quickapp": {


### PR DESCRIPTION
## Summary

- 修复 `#25` 合入后 `src/uni_modules/lucky-ui/package.json` 的 UTF-8 编码损坏（中文声明与 `√` 平台标记被破坏）
- 基于正确编码内容恢复文件，并保留 DCloud `extVersion` 为 `1.0.1`
- 无运行时逻辑变更，仅为发布元数据修复

## Branch Checklist

- [x] 本 PR 的目标分支正确
- [x] 日常开发合入目标为 `develop`
- [x] 仅 `release/*` 或 `hotfix/*` 合入 `main`
- [x] 未通过 rebase merge 更新受保护的公共分支

## Change Type

- [ ] Feature
- [x] Fix
- [ ] Docs
- [ ] Chore
- [ ] Refactor
- [ ] Release
- [ ] Hotfix

## Compatibility And Verification

- [x] 已考虑兼容性检查
- [x] 已考虑 H5 行为
- [x] 已考虑微信小程序行为
- [ ] 若有影响，已考虑其他小程序平台
- [ ] 视觉或跨端布局变更已附验证说明、截图或运行态尺寸/样式结果

说明：仅修复 `package.json` 文本编码与 `extVersion` 元数据，不影响组件运行时行为。

## Release Notes

- [x] 若有破坏性变更，已在本 PR 与 CHANGELOG 中说明（本次无破坏性变更）
- [ ] 若为 release PR，标签版本与 `src/uni_modules/lucky-ui/package.json` 一致（本次非 release PR）