### PR TITLE
fix(release): align 1.0.1 publish metadata

### DIFF
--- a/docs/guide/uniapp-mp-weixin-release.md
+++ b/docs/guide/uniapp-mp-weixin-release.md
@@ -145,8 +145,8 @@ const project = new ci.Project({
 
 ci.upload({
   project,
-  version: '1.0.0',
-  desc: 'release: 1.0.0',
+  version: '1.0.1',
+  desc: 'release: 1.0.1',
   robot: 1,
 })
 ```

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "name": "",
   "appid": "",
   "description": "",
-  "versionName": "1.0.0",
-  "versionCode": "100",
+  "versionName": "1.0.1",
+  "versionCode": "101",
   "transformPx": false,
   /* 5+App特有相关 */
   "app-plus": {

--- a/src/uni_modules/lucky-ui/package.json
+++ b/src/uni_modules/lucky-ui/package.json
@@ -108,7 +108,7 @@
           "vue": {
             "vue2": "x",
             "vue3": {
-              "extVersion": "1.0.0",
+              "extVersion": "1.0.1",
               "minVersion": ""
             }
           },


### PR DESCRIPTION
## 总结

- 将 H5/App 版本号更新为 1.0.1，版本号为 101。
- 将 HBuilderX 插件市场元数据 `extVersion` 更新为 1.0.1。
- 将微信小程序发布文档示例更新为 1.0.1。
- 不修改或移动已有的 `v1.0.1` 标签。

## 分支检查清单

- [x] 此 PR 目标分支正确：`main`。
- [x] 普通开发目标分支为 `develop`。
- [ ] 只有 `release/*` 或 `hotfix/*` 分支可以合并到 `main`。
- [x] 未通过 rebase merge 更新受保护的公共分支。

> 注意：当前源分支名为 `fix/release-v1.0.1-publish-metadata`，按仓库规则合并到 `main` 前建议改为 `release/*` 或 `hotfix/*` 分支。

## 变更类型

- [x] Fix
- [x] Docs
- [x] Release
- [ ] Feature
- [ ] Chore
- [ ] Refactor
- [ ] Hotfix

## 兼容性与验证

- [x] 已考虑兼容性检查：本次仅修改版本元数据和文档示例。
- [x] 已考虑 H5 行为：H5 代码逻辑未变更，版本信息已更新。
- [x] 已考虑微信小程序行为：仅更新发布文档版本示例。
- [x] 未影响其他小程序平台。
- [x] 本次无视觉或跨平台布局变更，无需截图或运行时尺寸验证。

## 发布说明

- [x] 无破坏性变更，无需更新 CHANGELOG。
- [x] `src/uni_modules/lucky-ui/package.json` 版本为 `1.0.1`，与已有 `v1.0.1` 标签一致。