### PR TITLE
Chore/sync main to develop v1.0.1

### DIFF
--- a/docs/guide/uniapp-mp-weixin-release.md
+++ b/docs/guide/uniapp-mp-weixin-release.md
@@ -145,8 +145,8 @@ const project = new ci.Project({
 
 ci.upload({
   project,
-  version: '1.0.0',
-  desc: 'release: 1.0.0',
+  version: '1.0.1',
+  desc: 'release: 1.0.1',
   robot: 1,
 })
 ```

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "name": "",
   "appid": "",
   "description": "",
-  "versionName": "1.0.0",
-  "versionCode": "100",
+  "versionName": "1.0.1",
+  "versionCode": "101",
   "transformPx": false,
   /* 5+App特有相关 */
   "app-plus": {

--- a/src/uni_modules/lucky-ui/package.json
+++ b/src/uni_modules/lucky-ui/package.json
@@ -108,7 +108,7 @@
           "vue": {
             "vue2": "x",
             "vue3": {
-              "extVersion": "1.0.0",
+              "extVersion": "1.0.1",
               "minVersion": ""
             }
           },


### PR DESCRIPTION
## 总结

- 将 `main` 中已合并的 1.0.1 发布元数据修正同步到 `develop`。
- 同步 H5/App 版本号 `1.0.1 / 101`。
- 同步微信小程序发布文档中的 1.0.1 示例。
- 未修改已有的 `v1.0.1` 标签。

## 分支检查清单

- [x] 此 PR 目标分支正确：`develop`。
- [x] 普通开发目标分支为 `develop`。
- [x] 只有 `release/*` 或 `hotfix/*` 分支可以合并到 `main`。
- [x] 未通过 rebase merge 更新受保护的公共分支。

## 变更类型

- [ ] Feature
- [ ] Fix
- [ ] Docs
- [x] Chore
- [ ] Refactor
- [x] Release
- [ ] Hotfix

## 兼容性与验证

- [x] 已考虑兼容性检查：本次为版本元数据和文档同步。
- [x] 已考虑 H5 行为：H5 业务逻辑未变更。
- [x] 已考虑微信小程序行为：仅同步发布文档版本示例。
- [x] 未影响其他小程序平台。
- [x] 无视觉或跨平台布局变更，无需截图或运行时尺寸验证。

## 发布说明

- [x] 无破坏性变更，无需更新 CHANGELOG。
- [x] `src/uni_modules/lucky-ui/package.json` 版本为 `1.0.1`，与已有 `v1.0.1` 标签一致。