### PR TITLE
fix(theme): 对齐运行时品牌色阶算法

### DIFF
--- a/src/uni_modules/lucky-ui/theme/src/brand-color.ts
+++ b/src/uni_modules/lucky-ui/theme/src/brand-color.ts
@@ -29,7 +29,8 @@ export function generateShade(baseColor: string, level: number): string {
     const ratio = ((600 - level) / 500) * 0.85;
     return `rgb(${Math.round(r + (255 - r) * ratio)}, ${Math.round(g + (255 - g) * ratio)}, ${Math.round(b + (255 - b) * ratio)})`;
   } else {
-    const ratio = ((level - 600) / 300) * 0.6;
+    // 与 tokens/_colors.scss 保持一致：1000 色阶混合 70% 黑色。
+    const ratio = ((level - 600) / 400) * 0.7;
     return `rgb(${Math.round(r * (1 - ratio))}, ${Math.round(g * (1 - ratio))}, ${Math.round(b * (1 - ratio))})`;
   }
 }

--- a/src/uni_modules/lucky-ui/theme/src/theme-store.ts
+++ b/src/uni_modules/lucky-ui/theme/src/theme-store.ts
@@ -3,6 +3,7 @@
  * 提供主题切换、品牌色变量与小程序系统 UI 同步。
  */
 import { ref, computed, readonly } from 'vue';
+import { DEFAULT_BRAND_COLOR, generateBrandVars } from './brand-color';
 
 export type Theme = 'light' | 'dark';
 
@@ -11,7 +12,6 @@ export const DEFAULT_THEME: Theme = 'dark';
 
 const THEME_STORAGE_KEY = 'lk-theme';
 const BRAND_COLOR_STORAGE_KEY = 'lk-brand-color';
-const DEFAULT_BRAND_COLOR = '#6965db';
 const SYSTEM_UI_THEME = {
   light: {
     backgroundColor: '#f4f5f9',
@@ -48,53 +48,6 @@ const _theme = ref<Theme>(readStoredTheme());
 const _isSwitching = ref(false);
 const _brandColor = ref<string>(readStoredBrandColor());
 let switchingTimer: ReturnType<typeof setTimeout> | null = null;
-
-/**
- * HEX 转 RGB
- */
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const match = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return match
-    ? { r: parseInt(match[1], 16), g: parseInt(match[2], 16), b: parseInt(match[3], 16) }
-    : null;
-}
-
-/**
- * 生成色阶
- */
-function generateShade(baseColor: string, level: number): string {
-  const rgb = hexToRgb(baseColor);
-  if (!rgb) return baseColor;
-
-  const { r, g, b } = rgb;
-  if (level === 600) return baseColor;
-
-  if (level < 600) {
-    const ratio = ((600 - level) / 500) * 0.85;
-    return `rgb(${Math.round(r + (255 - r) * ratio)}, ${Math.round(g + (255 - g) * ratio)}, ${Math.round(b + (255 - b) * ratio)})`;
-  } else {
-    const ratio = ((level - 600) / 300) * 0.6;
-    return `rgb(${Math.round(r * (1 - ratio))}, ${Math.round(g * (1 - ratio))}, ${Math.round(b * (1 - ratio))})`;
-  }
-}
-
-/**
- * 生成品牌色 CSS 变量
- */
-function generateBrandVars(color: string): Record<string, string> {
-  const vars: Record<string, string> = {};
-  const rgb = hexToRgb(color);
-  const levels = [100, 200, 300, 400, 500, 600, 700, 800, 900];
-
-  levels.forEach(level => {
-    vars[`--lk-brand-${level}`] = generateShade(color, level);
-  });
-
-  if (rgb) {
-    vars['--lk-brand-rgb'] = `${rgb.r}, ${rgb.g}, ${rgb.b}`;
-  }
-  return vars;
-}
 
 /**
  * 序列化 CSS 变量为内联样式

--- a/tests/unit/theme-brand-color.spec.ts
+++ b/tests/unit/theme-brand-color.spec.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import * as sass from 'sass';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_BRAND_COLOR,
+  generateBrandVars,
+  generateShade,
+} from '../../src/uni_modules/lucky-ui/theme/src/brand-color';
+import { themeStore } from '../../src/uni_modules/lucky-ui/theme/src/theme-store';
+import {
+  cssColorToRgb,
+  generateBrandShade,
+} from '../../src/uni_modules/lucky-ui/utils/chart-colors';
+
+const BRAND_LEVELS = [100, 200, 300, 400, 500, 600, 700, 800, 900] as const;
+const THEME_SOURCE_DIR = path.join(process.cwd(), 'src/uni_modules/lucky-ui/theme/src');
+
+function extractBrandVars(serialized: string): Record<string, string> {
+  return Object.fromEntries(
+    [...serialized.matchAll(/(--lk-brand-(?:\d+|rgb)):\s*([^;}]+)/g)].map(match => [
+      match[1],
+      match[2].trim(),
+    ])
+  );
+}
+
+function compileScssPalette(baseColor: string): Record<string, string> {
+  const declarations = BRAND_LEVELS.map(
+    level => `  --lk-brand-${level}: #{colors.$color-brand-${level}};`
+  ).join('\n');
+  const source = `
+@use 'tokens/colors' as colors with ($color-brand-base: ${baseColor});
+
+:root {
+${declarations}
+}
+`;
+  const result = sass.compileString(source, { loadPaths: [THEME_SOURCE_DIR] });
+  return extractBrandVars(result.css);
+}
+
+function normalizeColor(color: string): [number, number, number] {
+  const rgb = cssColorToRgb(color);
+  if (!rgb) throw new Error(`Unable to parse color: ${color}`);
+  return [Math.round(rgb.r), Math.round(rgb.g), Math.round(rgb.b)];
+}
+
+function expectRuntimePaletteToMatchScss(baseColor: string): void {
+  const scssPalette = compileScssPalette(baseColor);
+  const runtimePalette = generateBrandVars(baseColor);
+
+  BRAND_LEVELS.forEach(level => {
+    const name = `--lk-brand-${level}`;
+    const expected = normalizeColor(scssPalette[name]);
+
+    expect(normalizeColor(runtimePalette[name])).toEqual(expected);
+    expect(normalizeColor(generateShade(baseColor, level))).toEqual(expected);
+    expect(normalizeColor(generateBrandShade(baseColor, level))).toEqual(expected);
+  });
+}
+
+describe('theme brand color palette', () => {
+  it('keeps every runtime generator aligned with the canonical SCSS palette', () => {
+    expectRuntimePaletteToMatchScss(DEFAULT_BRAND_COLOR);
+    expectRuntimePaletteToMatchScss('#336699');
+  });
+
+  it('uses the canonical dark-shade curve for levels 700 through 900', () => {
+    expect(BRAND_LEVELS.slice(6).map(level => generateShade(DEFAULT_BRAND_COLOR, level))).toEqual([
+      'rgb(87, 83, 181)',
+      'rgb(68, 66, 142)',
+      'rgb(50, 48, 104)',
+    ]);
+  });
+
+  it('serializes the shared generator through the global theme store', () => {
+    const customColor = '#336699';
+    vi.stubGlobal('uni', { setStorageSync: vi.fn() });
+    themeStore.setBrandColor(customColor);
+
+    try {
+      expect(extractBrandVars(themeStore.brandStyleVars)).toEqual(generateBrandVars(customColor));
+    } finally {
+      themeStore.setBrandColor(DEFAULT_BRAND_COLOR);
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## 变更摘要

- 统一 TypeScript 运行时与 SCSS 令牌的品牌色深色阶算法，消除 700–900 色阶偏差。
- 让全局主题仓库复用唯一的品牌色变量生成器，移除重复实现。
- 新增回归测试，对比默认色、自定义色、主题仓库与图表色阶的一致性。

## 分支检查

- [x] 本 PR 目标分支正确。
- [x] 常规开发目标为 `develop`。
- [x] 未直接更新受保护的 `main` 或 `develop`。

## 变更类型

- [ ] 功能
- [x] 修复
- [ ] 文档
- [ ] 杂项
- [ ] 重构
- [ ] 发布
- [ ] 热修复

## 兼容性与验证

- [x] 已执行兼容性检查：0 个错误；60 个既有警告。
- [x] 已验证 H5 生产构建。
- [x] 已验证微信小程序生产构建及开发模式启动。
- [x] 已评估其他小程序平台：未引入平台专用逻辑。
- [x] 已核对运行时色阶结果：默认品牌色 700/800/900 分别为 `rgb(87, 83, 181)`、`rgb(68, 66, 142)`、`rgb(50, 48, 104)`。

已通过：

- `pnpm exec vitest run tests/unit/theme-brand-color.spec.ts`（3/3）
- `pnpm run compat-check`
- `pnpm run lint:eslint`
- `pnpm run lint:stylelint`（0 个错误；13 个既有警告）
- `pnpm run type-check`
- `pnpm run build:h5`
- `pnpm run build:mp-weixin`
- 变更文件 Prettier 检查与 `git diff --check`

补充：完整单测已运行；当前基线仍有 7 个既有失败及 1 个 SVG 测试套件加载失败，均位于本 PR 未修改的文件，本次新增回归测试全部通过。

## 发布说明

- [x] 无破坏性变更。
- [x] 不涉及版本号或发布标签。