### PR TITLE
fix(theme): 恢复文本颜色继承

### DIFF
--- a/src/uni_modules/lucky-ui/theme/src/base/_reset.scss
+++ b/src/uni_modules/lucky-ui/theme/src/base/_reset.scss
@@ -15,11 +15,6 @@ swiper-item {
   box-sizing: border-box;
 }
 
-view,
-text {
-  color: var(--lk-text-primary);
-}
-
 ul,
 ol {
   list-style: none;

--- a/tests/unit/theme-base-styles.spec.ts
+++ b/tests/unit/theme-base-styles.spec.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import postcss from 'postcss';
+import * as sass from 'sass';
+import { describe, expect, it } from 'vitest';
+
+const THEME_ENTRY = path.join(process.cwd(), 'src/uni_modules/lucky-ui/theme/src/index.scss');
+
+function compileThemeCss(): string {
+  return sass.compile(THEME_ENTRY, { style: 'expanded' }).css;
+}
+
+function colorDeclarationsForSelector(css: string, selector: string): string[] {
+  const values: string[] = [];
+
+  postcss.parse(css).walkRules(rule => {
+    if (!rule.selectors.map(item => item.trim()).includes(selector)) return;
+
+    rule.walkDecls('color', declaration => {
+      values.push(declaration.value);
+    });
+  });
+
+  return values;
+}
+
+describe('theme base styles', () => {
+  it('defines the default text color on page without overriding descendant inheritance', () => {
+    const css = compileThemeCss();
+
+    expect(colorDeclarationsForSelector(css, 'page')).toContain('var(--lk-text-primary)');
+    expect(colorDeclarationsForSelector(css, 'view')).toEqual([]);
+    expect(colorDeclarationsForSelector(css, 'text')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 变更内容

- 移除全局重置样式对 view、text 的默认文字色覆盖
- 保留页面根节点的 --lk-text-primary 默认色
- 新增基础主题回归测试，约束子节点继续使用正常颜色继承

## 验证结果

- 主题及 Button、Tag、NoticeBar 相关测试：20/20 通过
- 新增回归测试：通过
- 兼容检查：0 错误，60 条既有警告
- 类型检查：通过
- ESLint：通过
- Stylelint：0 错误，13 条既有警告
- H5 生产构建：通过
- 微信小程序生产构建：通过
- 微信小程序渲染测试：通过
- 双端产物检查：默认文字色仅保留在页面根节点

## 基线说明

全量单测中本次新增测试通过；仓库仍保留 6 个既有失败用例与 1 个既有 SVG CommonJS/ESM 加载失败，本次未扩大范围处理。

关联 #31