### PR TITLE
fix(theme): 补齐主题切换样式入口

### DIFF
--- a/src/uni_modules/lucky-ui/theme/src/index.scss
+++ b/src/uni_modules/lucky-ui/theme/src/index.scss
@@ -2,6 +2,7 @@
 @use './base/global';
 @use './base/typography';
 @use './base/animations';
+@use './base/theme-transition';
 @use './base/ripple';
 
 @use './component-vars';

--- a/tests/unit/theme-base-styles.spec.ts
+++ b/tests/unit/theme-base-styles.spec.ts
@@ -23,6 +23,16 @@ function colorDeclarationsForSelector(css: string, selector: string): string[] {
   return values;
 }
 
+function selectorsInTheme(css: string): string[] {
+  const selectors = new Set<string>();
+
+  postcss.parse(css).walkRules(rule => {
+    rule.selectors.forEach(selector => selectors.add(selector.trim()));
+  });
+
+  return [...selectors];
+}
+
 describe('theme base styles', () => {
   it('defines the default text color on page without overriding descendant inheritance', () => {
     const css = compileThemeCss();
@@ -30,5 +40,13 @@ describe('theme base styles', () => {
     expect(colorDeclarationsForSelector(css, 'page')).toContain('var(--lk-text-primary)');
     expect(colorDeclarationsForSelector(css, 'view')).toEqual([]);
     expect(colorDeclarationsForSelector(css, 'text')).toEqual([]);
+  });
+
+  it('includes cross-platform theme transition rules in the public entry', () => {
+    const selectors = selectorsInTheme(compileThemeCss());
+
+    expect(selectors).toContain('.lk-theme-transition');
+    expect(selectors).toContain('.lk-theme-switching *');
+    expect(selectors).toContain('.lk-theme-switching view');
   });
 });


### PR DESCRIPTION
## 变更内容

- 在公共主题入口加载 base/theme-transition
- 确保主题过渡与切换期间动画保护进入标准发布产物
- 扩展主题基础回归测试，覆盖 H5 通配后代与小程序标签枚举规则

## 验证结果

- 主题基础测试：2/2 通过
- 兼容检查：0 错误，60 条既有警告
- 类型检查：通过
- ESLint：通过
- Stylelint：0 错误，13 条既有警告
- H5 生产构建：通过
- 微信小程序生产构建：通过
- 微信小程序渲染测试：通过
- 双端产物检查：H5 使用通配后代保护，微信小程序使用兼容标签枚举

## 基线说明

全量单测中本次回归测试全部通过，共 407 个用例通过；仓库仍保留 6 个既有失败用例与 1 个既有 SVG CommonJS/ESM 加载失败，本次未扩大范围处理。

关联 #33