### PR TITLE
fix(theme): 统一浮层组件层级

### DIFF
--- a/docs/components/curtain.md
+++ b/docs/components/curtain.md
@@ -108,7 +108,7 @@ import CurtainDemo from '@/components/demos/curtain-demo.vue'
 
 | 参数 | 说明 | 类型 | 默认值 |
 |------|------|------|--------|
-| zIndex | 层级 | `number` | `10090` |
+| zIndex | 层级 | `number` | `1500` |
 | modelValue | 是否显示，支持 `v-model` | `boolean` | `false` |
 | imageUrl | 幕帘图片地址 | `string` | `''` |
 | imageMode | 图片裁剪模式 | `CurtainImageMode` | `widthFix` |

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -164,6 +164,7 @@ function close() {
 |------|------|------|--------|
 | customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
 | customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
+| zIndex | 全局 Toast 宿主层级 | `number` | `2000` |
 
 ### Events
 

--- a/src/uni_modules/lucky-ui/components/lk-curtain/curtain.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-curtain/curtain.props.ts
@@ -54,7 +54,7 @@ export const curtainProps = {
   /**
    * 层级 (覆盖 baseProps 默认值)
    */
-  zIndex: LkProp.number(10090),
+  zIndex: LkProp.number(1500),
   /**
    * 是否显示幕帘
    */

--- a/src/uni_modules/lucky-ui/components/lk-dropdown/lk-dropdown.scss
+++ b/src/uni_modules/lucky-ui/components/lk-dropdown/lk-dropdown.scss
@@ -50,7 +50,6 @@
       0 var(--lk-rpx-20) var(--lk-rpx-48) rgba(15, 23, 42, 0.14)
     );
     padding: var(--lk-dropdown-menu-padding, var(--lk-spacing-xs));
-    z-index: 2400;
     pointer-events: auto;
     -webkit-tap-highlight-color: transparent;
   }

--- a/src/uni_modules/lucky-ui/components/lk-toast/lk-toast-manager.vue
+++ b/src/uni_modules/lucky-ui/components/lk-toast/lk-toast-manager.vue
@@ -1,15 +1,19 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { StyleValue } from 'vue';
-import { baseProps } from '../common/props';
 import { toastStore } from './toast-manager';
+import { toastManagerProps } from './toast.props';
+import { resolveToastManagerStyle } from './toast.utils';
 import LkToastItem from './lk-toast-item.vue';
 
 defineOptions({ name: 'LkToastManager' });
 
-const props = defineProps(baseProps);
+const props = defineProps(toastManagerProps);
 const managerClass = computed(() => ['lk-toast-manager', props.customClass]);
-const managerStyle = computed<StyleValue>(() => props.customStyle as StyleValue);
+const managerStyle = computed<StyleValue>(() => resolveToastManagerStyle({
+  customStyle: props.customStyle as StyleValue,
+  zIndex: props.zIndex,
+}));
 </script>
 
 <template>

--- a/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.scss
+++ b/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.scss
@@ -4,7 +4,7 @@
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 4000;
+  z-index: var(--lk-z-index-toast);
   pointer-events: none;
 
   @include m(center) {
@@ -114,7 +114,7 @@
   right: 0;
   bottom: 0;
   pointer-events: none;
-  z-index: 4500;
+  z-index: var(--lk-z-index-toast);
 }
 
 @include b(toast-mgr) {

--- a/src/uni_modules/lucky-ui/components/lk-toast/toast.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-toast/toast.props.ts
@@ -60,6 +60,15 @@ export const toastProps = {
 
 export type ToastProps = ExtractPropTypes<typeof toastProps>;
 
+export const toastManagerProps = {
+  ...baseProps,
+
+  /** 全局 Toast 宿主层级 */
+  zIndex: LkProp.number(2000),
+} as const;
+
+export type ToastManagerProps = ExtractPropTypes<typeof toastManagerProps>;
+
 export const toastEmits = {
   'update:modelValue': (_val: boolean) => true,
   open: () => true,

--- a/src/uni_modules/lucky-ui/components/lk-toast/toast.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-toast/toast.utils.ts
@@ -53,6 +53,13 @@ export function resolveToastRootStyle(zIndex: number): StyleValue {
   return { zIndex: zIndex + 1 };
 }
 
+export function resolveToastManagerStyle(options: {
+  customStyle: StyleValue;
+  zIndex: number;
+}): StyleValue {
+  return [options.customStyle, { zIndex: options.zIndex }];
+}
+
 export function resolveToastManagerItemClass(position: ToastPosition) {
   return [`pos-${position}`];
 }

--- a/src/uni_modules/lucky-ui/components/lk-tooltip/lk-tooltip.scss
+++ b/src/uni_modules/lucky-ui/components/lk-tooltip/lk-tooltip.scss
@@ -14,7 +14,6 @@
 
   @include e(pop) {
     position: absolute;
-    z-index: 2000;
     pointer-events: auto;
 
     /* 默认 top */

--- a/tests/unit/component-style-selectors.spec.ts
+++ b/tests/unit/component-style-selectors.spec.ts
@@ -40,4 +40,18 @@ describe('component style selectors', () => {
       css.indexOf('.lk-popup--bottom.is-round .lk-popup__panel')
     );
   });
+
+  it('keeps overlay component layers aligned with props and public tokens', () => {
+    const dropdownMenu = selectorBlock(compileStyle('dropdown'), '.lk-dropdown__menu');
+    const tooltipPop = selectorBlock(compileStyle('tooltip'), '.lk-tooltip__pop');
+    const toastCss = compileStyle('toast');
+    const toastRoot = selectorBlock(toastCss, '.lk-toast');
+    const toastManager = selectorBlock(toastCss, '.lk-toast-manager');
+
+    expect(dropdownMenu).not.toContain('z-index:');
+    expect(tooltipPop).not.toContain('z-index:');
+    expect(toastRoot).toContain('z-index: var(--lk-z-index-toast)');
+    expect(toastManager).toContain('z-index: var(--lk-z-index-toast)');
+    expect(toastCss).not.toMatch(/z-index:\s*(?:4000|4500)/);
+  });
 });

--- a/tests/unit/lk-curtain.spec.ts
+++ b/tests/unit/lk-curtain.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { curtainProps } from '../../src/uni_modules/lucky-ui/components/lk-curtain/curtain.props';
 import {
   ensureCurtainNegativeOffset,
   isCurtainHttpLink,
@@ -15,6 +16,10 @@ import {
 } from '../../src/uni_modules/lucky-ui/components/lk-curtain/curtain.utils';
 
 describe('lk-curtain layout and link rules', () => {
+  it('uses the public modal layer by default', () => {
+    expect(curtainProps.zIndex.default).toBe(1500);
+  });
+
   it('normalizes width, height and copy text fallback', () => {
     expect(resolveCurtainWidth(600)).toBe('600rpx');
     expect(resolveCurtainHeight('80vh')).toBe('80vh');

--- a/tests/unit/lk-toast.spec.ts
+++ b/tests/unit/lk-toast.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { toastManagerProps } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.props';
 import {
   createToastItem,
   resolveToastManagerItemClass,
+  resolveToastManagerStyle,
   resolveToastManagerTransition,
   resolveToastOverlayClass,
   resolveToastOverlayStyle,
@@ -12,6 +14,19 @@ import {
 } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.utils';
 
 describe('lk-toast display and manager rules', () => {
+  it('uses the public toast layer for the global manager', () => {
+    const customStyle = { top: '24rpx', zIndex: 3000 };
+
+    expect(toastManagerProps.zIndex.default).toBe(2000);
+    expect(resolveToastManagerStyle({
+      customStyle,
+      zIndex: 2100,
+    })).toEqual([
+      customStyle,
+      { zIndex: 2100 },
+    ]);
+  });
+
   it('resolves controlled toast transition by position', () => {
     expect(resolveToastTransition({
       transition: 'slide-up',


### PR DESCRIPTION
## 变更内容

- 移除 Dropdown、Tooltip 中覆盖组件 zIndex 属性的旧 SCSS 硬编码
- 将 Toast 与 ToastManager 对齐公共 Toast 层级令牌，并为管理器补充 zIndex 属性
- 将 Curtain 默认层级从 10090 调整到公共 Modal 层级 1500
- 补充样式、默认属性和 ToastManager 样式合并回归测试
- 同步 Curtain、Toast 组件文档

## 验证结果

- 目标单测：13 项全部通过
- TypeScript 类型检查：通过
- ESLint：通过
- Stylelint：0 错误，保留仓库既有 13 条警告
- 兼容检查：0 错误，保留仓库既有 60 条警告
- H5 构建：通过
- 微信小程序构建：通过
- 微信小程序渲染测试：通过
- H5 / 微信小程序产物：旧层级值已清除，Toast 公共令牌与 Curtain 1500 已生效

## 已知基线

全量单测为 410 项通过，仍有 develop 既有的 6 项失败及 1 个 SVG 资源套件错误；本次未新增失败。

关联 #35