### PR TITLE
fix(pull-refresh): 修复微信小程序下拉指示层位置异常

### DIFF
--- a/src/uni_modules/lucky-ui/components/lk-pull-refresh/lk-pull-refresh.scss
+++ b/src/uni_modules/lucky-ui/components/lk-pull-refresh/lk-pull-refresh.scss
@@ -12,16 +12,14 @@
   }
 
   @include e(indicator) {
-    position: absolute;
-    top: var(--lk-rpx-12);
-    left: 0;
-    right: 0;
-    z-index: 2;
+    width: 100%;
     display: flex;
+    align-items: center;
     justify-content: center;
+    box-sizing: border-box;
     pointer-events: none;
     opacity: 0;
-    transform-origin: top center;
+    transform-origin: center;
     transition:
       opacity var(--lk-transition-fast),
       transform var(--lk-transition-fast);

--- a/src/uni_modules/lucky-ui/components/lk-pull-refresh/lk-pull-refresh.vue
+++ b/src/uni_modules/lucky-ui/components/lk-pull-refresh/lk-pull-refresh.vue
@@ -85,6 +85,7 @@ const indicatorStyle = computed(() =>
   resolvePullRefreshIndicatorStyle({
     visible: isIndicatorVisible.value,
     progress: progress.value,
+    threshold: props.threshold,
   })
 );
 
@@ -214,45 +215,6 @@ defineExpose({
 
 <template>
   <view :id="props.id" :class="classes" :style="mergedStyle">
-    <view class="lk-pull-refresh__indicator" :style="indicatorStyle">
-      <slot
-        v-if="isIndicatorVisible"
-        name="indicator"
-        :status="status"
-        :pulling-distance="pullingDistance"
-        :refreshing="status === PullRefreshStatus.Refreshing"
-        :progress="progress"
-      >
-        <view class="lk-pull-refresh__indicator-inner">
-          <view class="lk-pull-refresh__main">
-            <slot
-              name="icon"
-              :status="status"
-              :pulling-distance="pullingDistance"
-              :refreshing="status === PullRefreshStatus.Refreshing"
-              :progress="progress"
-            />
-            <slot
-              name="text"
-              :status="status"
-              :pulling-distance="pullingDistance"
-              :refreshing="status === PullRefreshStatus.Refreshing"
-              :progress="progress"
-            >
-              <lk-loading
-                v-if="status !== PullRefreshStatus.Success"
-                variant="text"
-                :text="indicatorText"
-              />
-              <text v-else class="lk-pull-refresh__text">
-                {{ indicatorText }}
-              </text>
-            </slot>
-          </view>
-        </view>
-      </slot>
-    </view>
-
     <scroll-view
       class="lk-pull-refresh__scroll"
       scroll-y
@@ -270,6 +232,47 @@ defineExpose({
       @scrolltolower="onScrollToLower"
     >
       <slot />
+
+      <!-- UniApp scroll-view requires the native slot attribute for custom refresher content. -->
+      <!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -->
+      <view slot="refresher" class="lk-pull-refresh__indicator" :style="indicatorStyle">
+        <slot
+          v-if="isIndicatorVisible"
+          name="indicator"
+          :status="status"
+          :pulling-distance="pullingDistance"
+          :refreshing="status === PullRefreshStatus.Refreshing"
+          :progress="progress"
+        >
+          <view class="lk-pull-refresh__indicator-inner">
+            <view class="lk-pull-refresh__main">
+              <slot
+                name="icon"
+                :status="status"
+                :pulling-distance="pullingDistance"
+                :refreshing="status === PullRefreshStatus.Refreshing"
+                :progress="progress"
+              />
+              <slot
+                name="text"
+                :status="status"
+                :pulling-distance="pullingDistance"
+                :refreshing="status === PullRefreshStatus.Refreshing"
+                :progress="progress"
+              >
+                <lk-loading
+                  v-if="status !== PullRefreshStatus.Success"
+                  variant="text"
+                  :text="indicatorText"
+                />
+                <text v-else class="lk-pull-refresh__text">
+                  {{ indicatorText }}
+                </text>
+              </slot>
+            </view>
+          </view>
+        </slot>
+      </view>
     </scroll-view>
   </view>
 </template>

--- a/src/uni_modules/lucky-ui/components/lk-pull-refresh/pull-refresh.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-pull-refresh/pull-refresh.utils.ts
@@ -90,8 +90,13 @@ export function resolvePullRefreshProgress(options: {
   return Math.min(1, options.pullingDistance / Math.max(1, options.threshold));
 }
 
-export function resolvePullRefreshIndicatorStyle(options: { visible: boolean; progress: number }) {
+export function resolvePullRefreshIndicatorStyle(options: {
+  visible: boolean;
+  progress: number;
+  threshold: number;
+}) {
   return {
+    height: `${Math.max(0, options.threshold)}px`,
     opacity: options.visible ? 1 : 0,
     transform: `translate3d(0, ${Math.min(18, options.progress * 18)}rpx, 0)`,
   };

--- a/tests/unit/component-style-selectors.spec.ts
+++ b/tests/unit/component-style-selectors.spec.ts
@@ -75,4 +75,13 @@ describe('component style selectors', () => {
     expect(root).toContain('column-gap: var(--lk-space-col-gap)');
     expect(root).not.toContain('margin:');
   });
+
+  it('keeps the pull refresh indicator in native slot flow', () => {
+    const indicator = selectorBlock(compileStyle('pull-refresh'), '.lk-pull-refresh__indicator');
+
+    expect(indicator).toContain('width: 100%');
+    expect(indicator).toContain('align-items: center');
+    expect(indicator).not.toContain('position: absolute');
+    expect(indicator).not.toContain('z-index:');
+  });
 });

--- a/tests/unit/lk-pull-refresh.spec.ts
+++ b/tests/unit/lk-pull-refresh.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { PullRefreshStatus } from '../../src/uni_modules/lucky-ui/components/lk-pull-refresh/pull-refresh.props';
 import {
@@ -18,6 +20,28 @@ import {
 } from '../../src/uni_modules/lucky-ui/components/lk-pull-refresh/pull-refresh.utils';
 
 describe('lk-pull-refresh state and indicator rules', () => {
+  it('places the custom indicator in the native refresher slot after content', () => {
+    const source = readFileSync(join(
+      process.cwd(),
+      'src/uni_modules/lucky-ui/components/lk-pull-refresh/lk-pull-refresh.vue'
+    ), 'utf8');
+    const scrollStart = source.indexOf('<scroll-view');
+    const scrollEnd = source.indexOf('</scroll-view>', scrollStart);
+    const scrollMarkup = source.slice(scrollStart, scrollEnd);
+
+    expect(scrollStart).toBeGreaterThan(-1);
+    expect(scrollEnd).toBeGreaterThan(scrollStart);
+    expect(scrollMarkup.indexOf('<slot />')).toBeLessThan(
+      scrollMarkup.indexOf('slot="refresher"')
+    );
+    expect(scrollMarkup).toContain(
+      '<view slot="refresher" class="lk-pull-refresh__indicator"'
+    );
+    expect(source.slice(source.indexOf('<template>'), scrollStart)).not.toContain(
+      'lk-pull-refresh__indicator'
+    );
+  });
+
   it('resolves initial status from model value', () => {
     expect(resolvePullRefreshInitialStatus(true)).toBe(PullRefreshStatus.Refreshing);
     expect(resolvePullRefreshInitialStatus(false)).toBe(PullRefreshStatus.Idle);
@@ -98,7 +122,9 @@ describe('lk-pull-refresh state and indicator rules', () => {
     expect(resolvePullRefreshIndicatorStyle({
       visible: true,
       progress: 2,
+      threshold: 80,
     })).toEqual({
+      height: '80px',
       opacity: 1,
       transform: 'translate3d(0, 18rpx, 0)',
     });


### PR DESCRIPTION
## 变更

- 将自定义下拉指示内容移入 `scroll-view` 原生 `slot=refresher`
- 指示层高度与 `refresher-threshold` 保持一致
- 移除外部绝对定位和人为 `z-index`，改为原生刷新层内普通流布局
- 补充模板结构、样式选择器和指示层高度回归测试

## 原因

微信小程序的自定义下拉刷新内容由 `scroll-view` 的原生 refresher 层管理。此前指示层作为外部绝对定位兄弟节点渲染，与原生刷新层不在同一坐标系，导致下拉时显示位置和层级异常。

## 验证

- `pnpm run test:unit`：77 个测试文件、428 个用例通过
- `pnpm run type-check`：通过
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：0 错误
- `pnpm run compat-check`：0 错误
- `pnpm run assets:svg:check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过
- `pnpm run test:mp`：通过
- `pnpm run dev:mp-weixin`：微信开发者工具真实运行通过
- Peekit 运行态：容器宽 320px；刷新态指示层宽 320px、高 80px、`position: static`、`z-index: auto`；指示内容中心与容器中心均为 195px

关联 #39