### PR TITLE
refactor(keyboard): 改用纯色 Popup 面板

### DIFF
--- a/docs/components/keyboard.md
+++ b/docs/components/keyboard.md
@@ -5,52 +5,42 @@ phone: keyboard
 
 # Keyboard 虚拟键盘
 
-用于数字、身份证、车牌号等受控输入场景。适合金额输入、验证码输入、自定义业务输入面板等移动端交互。
+用于数字、身份证、车牌号等受控输入场景。组件内部复用 `lk-popup`，默认呈现纯色面板、反差文字和无独立键帽的简约布局。
 
 ## 基础用法
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const value = ref('')
-const visible = ref(false)
+const value = ref('');
+const visible = ref(false);
 </script>
 
 <template>
   <lk-button @click="visible = true">打开数字键盘</lk-button>
-
-  <lk-keyboard
-    v-model:visible="visible"
-    v-model="value"
-    type="number"
-  />
+  <lk-keyboard v-model:visible="visible" v-model="value" />
 </template>
 ```
 
-## 带小数点与随机排列
+键盘默认显示遮罩，点击遮罩即可收起。标题栏和操作按钮默认不显示，因此基础形态只有键盘区域。
+
+## 小数点与随机排列
 
 ```vue
-<lk-keyboard
-  v-model:visible="visible"
-  v-model="value"
-  type="number"
-  :show-dot="true"
-  :random="true"
-/>
+<lk-keyboard v-model:visible="visible" v-model="value" :show-dot="true" :random="true" />
 ```
 
 ## 身份证与车牌号键盘
 
 ```vue
 <lk-keyboard v-model:visible="idVisible" v-model="idValue" type="idcard" :max-length="18" />
-
 <lk-keyboard v-model:visible="plateVisible" v-model="plateValue" type="plate" />
 ```
 
-`plate` 模式内置省份简称与字母数字切换逻辑，无需手动处理切面。
+`plate` 模式内置省份简称与字母数字切换逻辑。
 
-## 标题栏与确认按钮
+## 标题栏与确认操作
 
 ```vue
 <lk-keyboard
@@ -58,14 +48,14 @@ const visible = ref(false)
   v-model="value"
   title="输入金额"
   confirm-text="完成"
-  :show-close="true"
-  :show-confirm="true"
+  show-close
+  show-confirm
 />
 ```
 
 ## 自定义键盘布局
 
-当 `type="custom"` 时，可通过 `keys` 传入二维按键数组。
+当 `type="custom"` 时，通过 `keys` 传入二维按键数组。自定义布局与内置布局共用同一套纯色视觉，不提供旧式键帽皮肤入口。
 
 ```vue
 <script setup lang="ts">
@@ -79,181 +69,109 @@ const keys = [
     { text: '删除', type: 'delete' },
     { text: '确认', type: 'confirm', flex: 2 },
   ],
-]
+];
 </script>
 
 <template>
-  <lk-keyboard
-    v-model:visible="visible"
-    v-model="value"
-    type="custom"
-    :keys="keys"
-  />
+  <lk-keyboard v-model:visible="visible" v-model="value" type="custom" :keys="keys" />
 </template>
 ```
 
-## 内部结构定制
+## Popup 行为
 
-根节点继续使用 `customClass/customStyle`。如果需要定制更细的结构，可以使用 `overlayClass/overlayStyle`、`headerClass/headerStyle`、`bodyClass/bodyStyle`、`rowClass/rowStyle` 和 `keyClass/keyStyle`。自定义 `keys` 中的单个 `KeyboardKey` 也支持 `className/style`，用于突出确认键、快捷键或禁用态。
-
-```vue
-<script setup lang="ts">
-const keys = [
-  [
-    { text: 'A', value: 'A', className: 'key-accent' },
-    { text: 'B', value: 'B' },
-  ],
-  [
-    { text: 'VIP', value: 'VIP', flex: 2, style: { fontWeight: 700 } },
-    { text: '删除', type: 'delete' },
-  ],
-]
-</script>
-
-<template>
-  <lk-keyboard
-    v-model:visible="visible"
-    v-model="value"
-    type="custom"
-    :keys="keys"
-    header-class="payment-keyboard-header"
-    body-class="payment-keyboard-body"
-    key-class="payment-key"
-    :key-style="{ borderRadius: '16rpx' }"
-  />
-</template>
-```
-
-## 遮罩与关闭行为
+`lk-keyboard` 将弹层、遮罩、底部圆角、滚动锁定和安全区交给 `lk-popup` 处理。可以关闭遮罩，或阻止点击遮罩收起：
 
 ```vue
 <lk-keyboard
   v-model:visible="visible"
   v-model="value"
-  overlay
-  :close-on-overlay="true"
-  :blur="true"
+  show-close
+  :overlay="false"
+  :close-on-overlay="false"
 />
 ```
 
-## 键盘入口策略
+## 主题变量
 
-`lk-keyboard` 是唯一公开键盘入口，覆盖数字、身份证、车牌和自定义布局。未发布前已移除重复数字键盘入口，避免用户在两个能力重复的组件之间做选择。
+组件仅保留面板与文字两个视觉变量，避免键帽背景、边框、阴影和特殊键配色形成重复皮肤层。
 
-## 推荐示例
+| 变量                 | 说明                     | 默认值                   |
+| -------------------- | ------------------------ | ------------------------ |
+| `--lk-keyboard-bg`   | Popup 与键盘面板纯色背景 | `var(--lk-bg-container)` |
+| `--lk-keyboard-text` | 数字、操作文字与图标颜色 | `var(--lk-text-primary)` |
 
-### 1) 直接复用项目 Demo（推荐）
-
-```vue
-<script setup lang="ts">
-import KeyboardDemo from '@/components/demos/keyboard-demo.vue'
-</script>
-
-<template>
-  <KeyboardDemo />
-</template>
-```
-
-### 2) 在业务页中按需组合
+`customClass` 应用于键盘内容根节点，`customStyle` 应用于 Popup 面板。若要换成品牌色面板，可以通过 `customStyle` 同时设置上述两个变量，让 Popup、安全区和键盘内容保持同色，并确保文字对比度。
 
 ```vue
-<template>
-  <view class="page-demo">
-    <lk-keyboard />
-  </view>
-</template>
+<lk-keyboard
+  v-model:visible="visible"
+  v-model="value"
+  :custom-style="{
+    '--lk-keyboard-bg': '#111111',
+    '--lk-keyboard-text': '#ffffff',
+  }"
+/>
 ```
 
 ## API
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
-| customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
-| visible | 是否显示，支持 `v-model:visible` | `boolean` | `false` |
-| type | 键盘类型 | `number \| idcard \| plate \| custom` | `number` |
-| title | 标题文字 | `string` | `''` |
-| confirmText | 确认按钮文本 | `string` | `'完成'` |
-| showConfirm | 是否显示确认按钮 | `boolean` | `true` |
-| showDelete | 是否显示删除按钮 | `boolean` | `true` |
-| showDot | 数字键盘是否显示小数点 | `boolean` | `false` |
-| extraKey | 数字键盘左下角额外按键 | `string` | `''` |
-| random | 是否随机排列数字键 | `boolean` | `false` |
-| maxLength | 最大输入长度，`0` 表示不限制 | `number` | `0` |
-| modelValue | 当前输入值，支持 `v-model` | `string` | `''` |
-| overlay | 是否显示遮罩 | `boolean` | `false` |
-| closeOnOverlay | 点击遮罩是否关闭 | `boolean` | `true` |
-| blur | 是否启用毛玻璃效果 | `boolean` | `true` |
-| showClose | 是否显示关闭入口 | `boolean` | `true` |
-| zIndex | 层级 | `number` | `1000` |
-| safeAreaInsetBottom | 是否适配底部安全区 | `boolean` | `true` |
-| keys | 自定义键盘布局，仅 `custom` 模式使用 | `KeyboardKey[][]` | `[]` |
-| sound | 是否启用按键音效 | `boolean` | `false` |
-| vibrate | 是否启用触感反馈 | `boolean` | `true` |
-| overlayClass | 遮罩层自定义类名 | `string \| object \| array` | `''` |
-| overlayStyle | 遮罩层自定义样式 | `string \| object` | `''` |
-| headerClass | 标题栏自定义类名 | `string \| object \| array` | `''` |
-| headerStyle | 标题栏自定义样式 | `string \| object` | `''` |
-| bodyClass | 键盘区域自定义类名 | `string \| object \| array` | `''` |
-| bodyStyle | 键盘区域自定义样式 | `string \| object` | `''` |
-| rowClass | 按键行自定义类名 | `string \| object \| array` | `''` |
-| rowStyle | 按键行自定义样式 | `string \| object` | `''` |
-| keyClass | 全局按键自定义类名 | `string \| object \| array` | `''` |
-| keyStyle | 全局按键自定义样式 | `string \| object` | `''` |
+| 参数                | 说明                               | 类型                                  | 默认值   |
+| ------------------- | ---------------------------------- | ------------------------------------- | -------- |
+| customClass         | 键盘根节点自定义类名               | `string \| object \| array`           | `''`     |
+| customStyle         | Popup 面板自定义样式               | `string \| object`                    | `''`     |
+| visible             | 是否显示，支持 `v-model:visible`   | `boolean`                             | `false`  |
+| type                | 键盘类型                           | `number \| idcard \| plate \| custom` | `number` |
+| title               | 标题文字                           | `string`                              | `''`     |
+| confirmText         | 确认按钮文字，为空时使用国际化文案 | `string`                              | `''`     |
+| showConfirm         | 是否显示确认操作                   | `boolean`                             | `false`  |
+| showClose           | 是否显示收起操作                   | `boolean`                             | `false`  |
+| showDelete          | 数字键盘是否显示删除键             | `boolean`                             | `true`   |
+| showDot             | 数字键盘是否显示小数点             | `boolean`                             | `false`  |
+| extraKey            | 数字键盘左下角额外按键             | `string`                              | `''`     |
+| random              | 是否随机排列数字                   | `boolean`                             | `false`  |
+| maxLength           | 最大输入长度，`0` 表示不限制       | `number`                              | `0`      |
+| modelValue          | 当前输入值，支持 `v-model`         | `string`                              | `''`     |
+| overlay             | 是否显示 Popup 遮罩                | `boolean`                             | `true`   |
+| closeOnOverlay      | 点击遮罩是否收起                   | `boolean`                             | `true`   |
+| zIndex              | Popup 层级                         | `number`                              | `1000`   |
+| safeAreaInsetBottom | 是否适配底部安全区                 | `boolean`                             | `true`   |
+| keys                | 自定义布局，仅 `custom` 模式使用   | `KeyboardKey[][]`                     | `[]`     |
+| vibrate             | 是否启用触感反馈                   | `boolean`                             | `true`   |
 
 ### KeyboardKey
 
-| 字段 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| text | 按键显示文本 | `string` | — |
-| value | 点击后输出的值 | `string` | `undefined` |
-| flex | 按键宽度比例 | `number` | `undefined` |
-| type | 按键类型 | `default \| delete \| confirm \| extra \| empty` | `default` |
-| disabled | 是否禁用 | `boolean` | `undefined` |
-| className | 单个按键自定义类名 | `string \| object \| array` | `undefined` |
-| style | 单个按键自定义样式 | `string \| object` | `undefined` |
+| 字段     | 说明           | 类型                                             | 默认值      |
+| -------- | -------------- | ------------------------------------------------ | ----------- |
+| text     | 按键显示文字   | `string`                                         | —           |
+| value    | 点击后输出的值 | `string`                                         | `undefined` |
+| flex     | 按键宽度比例   | `number`                                         | `undefined` |
+| type     | 按键类型       | `default \| delete \| confirm \| extra \| empty` | `default`   |
+| disabled | 是否禁用       | `boolean`                                        | `undefined` |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:visible | 键盘显隐变化 | `(visible: boolean)` |
-| update:modelValue | 输入值变化 | `(value: string)` |
-| input | 输入普通字符时触发 | `(key: string)` |
-| delete | 点击删除键时触发 | `()` |
-| confirm | 点击确认时触发 | `(value: string)` |
-| close | 键盘关闭时触发 | `()` |
-| key-press | 任意按键点击时触发 | `(key: KeyboardKey)` |
+| 事件名            | 说明                   | 回调参数             |
+| ----------------- | ---------------------- | -------------------- |
+| update:visible    | 键盘显隐变化           | `(visible: boolean)` |
+| update:modelValue | 输入值变化             | `(value: string)`    |
+| input             | 输入普通字符时触发     | `(key: string)`      |
+| delete            | 点击删除键时触发       | `()`                 |
+| confirm           | 点击确认操作时触发     | `(value: string)`    |
+| close             | 键盘请求收起时触发     | `()`                 |
+| key-press         | 任意有效按键点击时触发 | `(key: KeyboardKey)` |
 
 ### Slots
 
-当前版本未提供插槽。
+当前版本不提供插槽。
 
 ## 使用建议
 
-::: warning
-`lk-keyboard` 本身只负责键盘输入，不会自动弹出系统输入框。推荐与受控展示区、验证码输入框、金额输入卡片等组件配合使用。
-:::
-
-::: tip
-如果是纯验证码或密码输入，可将 `lk-keyboard` 与 `lk-code-input`、`lk-input` 组合使用，由业务层统一管理输入值。
-:::
-
-## 兼容说明
-
-- 组件使用 fixed 底部浮层，存在安全区与软键盘遮挡差异；发布前需在 H5、App 与各小程序目标端确认底部间距。
-- `blur` 毛玻璃效果依赖平台对 CSS filter/backdrop-filter 的支持；性能敏感场景建议关闭 `blur`。
-- 车牌键盘和自定义键盘应由业务层限制输入格式，组件只负责按键输出。
-- `overlayClass/headerClass/bodyClass/rowClass/keyClass` 位于子组件内部；父组件 scoped 样式覆盖这些类时需使用 `:deep()`。
+- 键盘只负责受控输入，不会自动唤起系统输入框。
+- 验证码、密码和金额场景可与 `lk-code-input`、`lk-input` 或业务展示卡组合。
+- 自定义品牌色时同时设置面板与文字变量，并保持足够对比度。
 
 ## 发布验收
 
-`lk-keyboard` 已纳入 needs-hardening showcase 回归，发布前按下面边界验收：
-
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
-| 底部浮层 | 人工验收 | H5/App/小程序底部安全区、遮罩关闭和锁滚动无明显遮挡 |
-| 输入链路 | 人工验收 | 数字、身份证、车牌、自定义键盘的 `input/delete/confirm` 事件顺序一致 |
+发布前应在 H5、App 和目标小程序检查数字、身份证、车牌和自定义布局，并覆盖遮罩关闭、确认关闭、删除、暗色主题和底部安全区。

--- a/src/components/demos/keyboard-demo.vue
+++ b/src/components/demos/keyboard-demo.vue
@@ -17,17 +17,18 @@ const keyboardTitle = ref('');
 const keyboardShowDot = ref(false);
 const keyboardRandom = ref(false);
 const keyboardMaxLength = ref(0);
-const keyboardShowClose = ref(true);
+const keyboardShowClose = ref(false);
+const keyboardShowConfirm = ref(false);
 const keyboardKeys = ref<KeyboardKey[][]>([]);
 
 const customKeyboardKeys: KeyboardKey[][] = [
   [
-    { text: 'A', value: 'A', className: 'keyboard-demo-key--accent' },
+    { text: 'A', value: 'A' },
     { text: 'B', value: 'B' },
     { text: 'C', value: 'C' },
   ],
   [
-    { text: 'VIP', value: 'VIP', flex: 2, className: 'keyboard-demo-key--wide' },
+    { text: 'VIP', value: 'VIP', flex: 2 },
     { text: '', type: 'delete' },
   ],
 ];
@@ -38,6 +39,7 @@ interface KeyboardOptions {
   random?: boolean;
   maxLength?: number;
   showClose?: boolean;
+  showConfirm?: boolean;
   keys?: KeyboardKey[][];
 }
 
@@ -47,7 +49,8 @@ function showKeyboard(type: KeyboardType, options: KeyboardOptions = {}) {
   keyboardShowDot.value = options.showDot || false;
   keyboardRandom.value = options.random || false;
   keyboardMaxLength.value = options.maxLength || 0;
-  keyboardShowClose.value = options.showClose !== false;
+  keyboardShowClose.value = options.showClose || false;
+  keyboardShowConfirm.value = options.showConfirm || false;
   keyboardKeys.value = options.keys || [];
   keyboardVisible.value = true;
 }
@@ -110,16 +113,22 @@ function onClose() {
       </lk-space>
     </demo-block>
 
-    <demo-block title="带标题">
-      <view class="desc">可以显示标题栏和操作按钮。</view>
+    <demo-block title="标题与操作">
+      <view class="desc">默认只显示键盘；按需开启标题栏的收起与确认操作。</view>
       <lk-space wrap>
-        <lk-button size="sm" @click="showKeyboard('number', { title: '输入金额' })"
-          >带标题</lk-button
-        >
         <lk-button
           size="sm"
-          @click="showKeyboard('number', { title: '输入密码', showClose: false })"
-          >隐藏关闭</lk-button
+          @click="
+            showKeyboard('number', {
+              title: '输入金额',
+              showClose: true,
+              showConfirm: true,
+            })
+          "
+          >完整标题栏</lk-button
+        >
+        <lk-button size="sm" @click="showKeyboard('number', { title: '输入密码' })"
+          >仅标题</lk-button
         >
       </lk-space>
     </demo-block>
@@ -134,8 +143,8 @@ function onClose() {
       </lk-space>
     </demo-block>
 
-    <demo-block title="Custom structure style">
-      <view class="desc">Use header/body/row/key style entry points for internal structure and className/style on a single key.</view>
+    <demo-block title="自定义布局">
+      <view class="desc">自定义内容仍沿用统一的纯色面板与无键帽视觉。</view>
       <lk-space wrap>
         <lk-button
           size="sm"
@@ -148,7 +157,7 @@ function onClose() {
 
     <view class="tips">
       <lk-icon name="info-circle" size="28" color="var(--lk-color-primary)" />
-      <text>提示：键盘采用苹果风格设计，支持毛玻璃效果和触感反馈。</text>
+      <text>提示：键盘由 Popup 承载，采用纯色面板、反差文字和无卡片按键。</text>
     </view>
 
     <!-- 键盘组件 -->
@@ -161,14 +170,8 @@ function onClose() {
       :random="keyboardRandom"
       :max-length="keyboardMaxLength"
       :show-close="keyboardShowClose"
+      :show-confirm="keyboardShowConfirm"
       :keys="keyboardKeys"
-      overlay
-      overlay-class="keyboard-demo-overlay"
-      header-class="keyboard-demo-header"
-      body-class="keyboard-demo-body"
-      row-class="keyboard-demo-row"
-      key-class="keyboard-demo-key"
-      :key-style="{ '--keyboard-demo-key-radius': 'var(--lk-radius-lg)' }"
       @input="onInput"
       @delete="onDelete"
       @confirm="onConfirm"
@@ -183,7 +186,6 @@ function onClose() {
   > :not(:first-child) {
     margin-top: 32rpx;
   }
-  padding-bottom: 400rpx;
 }
 
 .input-display {
@@ -232,18 +234,5 @@ function onClose() {
   font-size: 24rpx;
   color: var(--lk-text-secondary);
   line-height: 1.6;
-}
-
-:deep(.keyboard-demo-key) {
-  border-radius: var(--keyboard-demo-key-radius, var(--lk-radius-md));
-}
-
-:deep(.keyboard-demo-key--accent) {
-  color: var(--lk-color-primary);
-  background: var(--lk-color-primary-light-9);
-}
-
-:deep(.keyboard-demo-key--wide) {
-  font-weight: 700;
 }
 </style>

--- a/src/components/showcase/showcase-cases.ts
+++ b/src/components/showcase/showcase-cases.ts
@@ -461,7 +461,7 @@ export const SHOWCASE_CASES: ShowcaseCase[] = [
     verifyStatus: 'verified',
     riskLevel: 'medium',
     visualEnabled: false,
-    riskNotes: ['fixed 底部浮层、毛玻璃与安全区需按 H5/App/小程序分别复核。'],
+    riskNotes: ['Popup 安全区、十列车牌布局与触感反馈需按 H5/App/小程序分别复核。'],
   },
   {
     slug: 'toast',

--- a/src/uni_modules/lucky-ui/CHANGELOG.md
+++ b/src/uni_modules/lucky-ui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- **Breaking:** Rebuilt `lk-keyboard` as a flat, solid-color panel hosted by `lk-popup`; removed the legacy blur, sound, internal class/style hook props, and per-key class/style fields.
+- Changed the keyboard defaults to a headerless layout with overlay enabled, while retaining explicit title, close, and confirm actions.
+
 ## 1.0.1（2026-07-12）
 - Fixed `lk-segmented` slider measurement when rendered inside modal.
 - Improved `lk-tooltip` popup motion and custom content rendering.

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.props.ts
@@ -16,9 +16,6 @@ export const KeyboardType = {
 } as const;
 
 export type KeyboardType = (typeof KeyboardType)[keyof typeof KeyboardType];
-export type KeyboardCustomClass = string | object | Array<string | object>;
-export type KeyboardCustomStyle = string | Record<string, unknown>;
-
 /**
  * 自定义按键配置
  */
@@ -33,10 +30,6 @@ export interface KeyboardKey {
   type?: 'default' | 'delete' | 'confirm' | 'extra' | 'empty';
   /** 是否禁用 */
   disabled?: boolean;
-  /** 单个按键自定义类名 */
-  className?: KeyboardCustomClass;
-  /** 单个按键自定义样式 */
-  style?: KeyboardCustomStyle;
 }
 
 export const keyboardProps = {
@@ -65,7 +58,7 @@ export const keyboardProps = {
   /**
    * 是否显示确认按钮
    */
-  showConfirm: LkProp.boolean(true),
+  showConfirm: LkProp.boolean(false),
 
   /**
    * 是否显示删除按钮
@@ -100,7 +93,7 @@ export const keyboardProps = {
   /**
    * 是否显示遮罩
    */
-  overlay: LkProp.boolean(false),
+  overlay: LkProp.boolean(true),
 
   /**
    * 点击遮罩关闭
@@ -108,14 +101,9 @@ export const keyboardProps = {
   closeOnOverlay: LkProp.boolean(true),
 
   /**
-   * 是否使用毛玻璃效果
-   */
-  blur: LkProp.boolean(true),
-
-  /**
    * 是否显示关闭按钮
    */
-  showClose: LkProp.boolean(true),
+  showClose: LkProp.boolean(false),
 
   /**
    * 层级
@@ -136,65 +124,9 @@ export const keyboardProps = {
   },
 
   /**
-   * 是否启用按键音效
-   */
-  sound: LkProp.boolean(false),
-
-  /**
    * 是否启用触感反馈
    */
   vibrate: LkProp.boolean(true),
-
-  /** 遮罩层自定义类名 */
-  overlayClass: {
-    type: [String, Object, Array] as PropType<KeyboardCustomClass>,
-    default: '',
-  },
-  /** 遮罩层自定义样式 */
-  overlayStyle: {
-    type: [String, Object] as PropType<KeyboardCustomStyle>,
-    default: '',
-  },
-  /** 标题栏自定义类名 */
-  headerClass: {
-    type: [String, Object, Array] as PropType<KeyboardCustomClass>,
-    default: '',
-  },
-  /** 标题栏自定义样式 */
-  headerStyle: {
-    type: [String, Object] as PropType<KeyboardCustomStyle>,
-    default: '',
-  },
-  /** 键盘区域自定义类名 */
-  bodyClass: {
-    type: [String, Object, Array] as PropType<KeyboardCustomClass>,
-    default: '',
-  },
-  /** 键盘区域自定义样式 */
-  bodyStyle: {
-    type: [String, Object] as PropType<KeyboardCustomStyle>,
-    default: '',
-  },
-  /** 按键行自定义类名 */
-  rowClass: {
-    type: [String, Object, Array] as PropType<KeyboardCustomClass>,
-    default: '',
-  },
-  /** 按键行自定义样式 */
-  rowStyle: {
-    type: [String, Object] as PropType<KeyboardCustomStyle>,
-    default: '',
-  },
-  /** 全局按键自定义类名 */
-  keyClass: {
-    type: [String, Object, Array] as PropType<KeyboardCustomClass>,
-    default: '',
-  },
-  /** 全局按键自定义样式 */
-  keyStyle: {
-    type: [String, Object] as PropType<KeyboardCustomStyle>,
-    default: '',
-  },
 } as const;
 
 export const keyboardEmits = {

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.utils.ts
@@ -1,4 +1,3 @@
-import type { StyleValue } from 'vue';
 import {
   KeyboardType,
   type KeyboardKey,
@@ -258,57 +257,4 @@ export function resolveKeyboardPressAction(options: {
   }
 
   return { kind: 'ignore' };
-}
-
-export function resolveKeyboardClass(options: {
-  type: string;
-  isVisible: boolean;
-  blur: boolean;
-  customClass?: unknown;
-}) {
-  return [
-    'lk-keyboard',
-    `lk-keyboard--${options.type}`,
-    {
-      'is-visible': options.isVisible,
-      'is-blur': options.blur,
-    },
-    options.customClass,
-  ];
-}
-
-export function resolveKeyboardStyle(options: {
-  zIndex: number;
-  safeAreaInsetBottom: boolean;
-  safeBottom: number;
-  customStyle?: StyleValue;
-}): StyleValue {
-  return [
-    {
-      zIndex: options.zIndex,
-      paddingBottom: options.safeAreaInsetBottom ? `${options.safeBottom}px` : '0',
-    },
-    options.customStyle || '',
-  ] as StyleValue;
-}
-
-export function resolveKeyboardKeyClass(key: KeyboardKey, customClass?: unknown) {
-  return [
-    'lk-keyboard__key',
-    {
-      'lk-keyboard__key--delete': key.type === 'delete',
-      'lk-keyboard__key--confirm': key.type === 'confirm',
-      'lk-keyboard__key--extra': key.type === 'extra',
-      'lk-keyboard__key--empty': key.type === 'empty',
-      'lk-keyboard__key--disabled': key.disabled,
-      'lk-keyboard__key--wide': (key.flex || 1) > 1,
-    },
-    customClass,
-    key.className,
-  ];
-}
-
-export function resolveKeyboardKeyStyle(key: KeyboardKey, customStyle?: StyleValue): StyleValue {
-  const baseStyle = key.flex && key.flex !== 1 ? { flex: key.flex } : {};
-  return [baseStyle, customStyle || '', key.style || ''] as StyleValue;
 }

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
@@ -1,254 +1,133 @@
 @use '../../theme/src/mixins' as *;
 
-// LkKeyboard - Apple Style Keyboard
-
 @include b(keyboard) {
-  // CSS Variables
-  --kb-bg: var(--lk-keyboard-bg);
-  --kb-key-bg: var(--lk-keyboard-key-bg);
-  --kb-key-bg-active: var(--lk-keyboard-key-bg-active);
-  --kb-key-text: var(--lk-keyboard-key-text);
-  --kb-key-shadow: var(--lk-keyboard-key-shadow);
-  --kb-key-border: var(--lk-keyboard-key-border);
-  --kb-special-bg: var(--lk-keyboard-special-bg);
-  --kb-special-text: var(--lk-keyboard-special-text);
-  --kb-accent: var(--lk-color-primary);
-  --kb-radius: var(--lk-radius-md);
-  --kb-key-height: var(--lk-control-height-md);
-  --kb-gap: var(--lk-spacing-sm);
-  --kb-padding: var(--lk-spacing-sm);
+  --kb-key-height: var(--lk-rpx-104);
 
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  transform: translateY(100%);
-  transition: transform 0.35s cubic-bezier(0.25, 1, 0.5, 1);
-  will-change: transform;
-  border-top-left-radius: var(--lk-radius-lg);
-  border-top-right-radius: var(--lk-radius-lg);
+  box-sizing: border-box;
+  width: 100%;
   overflow: hidden;
+  background: var(--lk-keyboard-bg);
+  color: var(--lk-keyboard-text);
 
-  @include when(visible) {
-    transform: translateY(0);
-  }
-
-  @include when(blur) {
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-  }
-
-  // 遮罩
-  @include e(overlay) {
-    position: fixed;
-    inset: 0;
-    background: var(--lk-keyboard-overlay-bg);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
-    z-index: 999;
-
-    @include when(visible) {
-      opacity: 1;
-      pointer-events: auto;
-    }
-  }
-
-  // 标题栏
   @include e(header) {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    height: calc(var(--lk-control-height-sm) + var(--lk-spacing-xs));
-    padding: 0 var(--lk-spacing-md);
-    background: var(--kb-bg);
-    border-bottom: var(--lk-rpx-1) solid var(--lk-keyboard-header-border);
-    box-shadow: inset 0 calc(var(--lk-rpx-1) * -1) 0 var(--lk-color-border-light);
+    min-height: var(--lk-rpx-88);
+    padding: var(--lk-spacing-xs) var(--lk-spacing-lg) 0;
   }
 
-  @include e(header-left) {
-    flex: 1;
+  @include e(header-side) {
     display: flex;
+    flex: 1;
     justify-content: flex-start;
+
+    @include m(end) {
+      justify-content: flex-end;
+    }
   }
 
-  @include e(header-right) {
-    flex: 1;
+  @include e(header-action) {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    min-height: var(--lk-rpx-64);
+    padding: 0 var(--lk-spacing-sm);
+    font-size: var(--lk-font-size-base);
+    font-weight: var(--lk-font-weight-semibold);
+    color: inherit;
+    cursor: pointer;
+    transition: opacity var(--lk-transition-fast);
+
+    &:active {
+      opacity: 0.56;
+    }
   }
 
   @include e(title) {
     flex: 2;
+    overflow: hidden;
+    font-size: var(--lk-font-size-base);
+    font-weight: var(--lk-font-weight-semibold);
+    color: inherit;
     text-align: center;
-    font-size: var(--lk-font-size-base);
-    font-weight: 500;
-    color: var(--kb-key-text);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
-  @include e(close) {
-    padding: var(--lk-spacing-xs) var(--lk-spacing-md);
-  }
-
-  @include e(close-text) {
-    font-size: var(--lk-font-size-base);
-    color: var(--kb-key-text);
-    opacity: 0.6;
-  }
-
-  @include e(done) {
-    padding: var(--lk-spacing-xs) var(--lk-spacing-md);
-  }
-
-  @include e(done-text) {
-    font-size: var(--lk-font-size-base);
-    color: var(--kb-accent);
-    font-weight: 600;
-  }
-
-  // 拖拽指示条
-  @include e(indicator) {
-    display: flex;
-    justify-content: center;
-    padding: var(--lk-spacing-sm) 0 var(--lk-spacing-xs);
-    background: var(--kb-bg);
-  }
-
-  @include e(indicator-bar) {
-    width: calc(var(--lk-control-height-xs) + var(--lk-spacing-lg));
-    height: var(--lk-spacing-xs);
-    background: var(--lk-keyboard-indicator-bg);
-    border-radius: var(--lk-radius-xs);
-  }
-
-  // 键盘主体
   @include e(body) {
-    background: var(--kb-bg);
-    padding: var(--kb-padding);
-    padding-top: var(--lk-spacing-xs);
-    border-top: var(--lk-rpx-1) solid var(--lk-keyboard-header-border);
+    box-sizing: border-box;
+    width: 100%;
+    padding: var(--lk-spacing-md) var(--lk-spacing-lg) var(--lk-spacing-lg);
   }
 
-  // 键盘行
   @include e(row) {
     display: flex;
-    margin-bottom: var(--kb-gap);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    & > view:not(:first-child) {
-      margin-left: var(--kb-gap);
-    }
+    width: 100%;
   }
 
-  // 按键
   @include e(key) {
-    flex: 1;
-    height: var(--kb-key-height);
     display: flex;
+    flex: 1;
     align-items: center;
     justify-content: center;
-    background: var(--kb-key-bg);
-    border-radius: var(--kb-radius);
-    border: var(--lk-rpx-1) solid var(--kb-key-border);
-    box-shadow: none;
+    min-width: 0;
+    height: var(--kb-key-height);
+    color: inherit;
+    cursor: pointer;
+    user-select: none;
     transition:
-      background-color var(--lk-transition-fast),
-      transform var(--lk-transition-fast),
-      box-shadow var(--lk-transition-fast);
+      opacity var(--lk-transition-fast),
+      transform var(--lk-transition-fast);
 
     &:active {
-      background: var(--kb-key-bg-active);
-      transform: translateY(var(--lk-rpx-2)) scale(0.985);
+      opacity: 0.52;
+      transform: scale(0.9);
     }
 
-    // 删除键
-    @include m(delete) {
-      background: var(--kb-special-bg);
-      color: var(--kb-special-text);
-
-      &:active {
-        background: var(--kb-key-bg-active);
-      }
-    }
-
-    // 确认键
-    @include m(confirm) {
-      background: var(--kb-accent);
-      color: var(--lk-color-white);
-      border-color: transparent;
-
-      &:active {
-        opacity: 0.9;
-      }
-    }
-
-    // 额外按键
-    @include m(extra) {
-      background: var(--kb-special-bg);
-      color: var(--kb-special-text);
-      font-size: var(--lk-font-size-sm);
-
-      &:active {
-        background: var(--kb-key-bg-active);
-      }
-    }
-
-    // 空按键
     @include m(empty) {
-      background: transparent;
-      box-shadow: none;
       pointer-events: none;
     }
 
-    // 禁用
     @include m(disabled) {
-      opacity: 0.4;
+      opacity: 0.28;
       pointer-events: none;
     }
 
-    // 宽按键
-    @include m(wide) {
-      flex: 1.5;
+    @include m(extra) {
+      .lk-keyboard__key-text {
+        font-size: var(--lk-font-size-base);
+      }
     }
   }
 
-  // 按键文字
   @include e(key-text) {
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', sans-serif;
     font-size: var(--lk-font-size-xl);
-    font-weight: var(--lk-font-weight-semibold);
-    color: var(--kb-key-text);
+    font-weight: var(--lk-font-weight-medium);
     line-height: 1;
-    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', sans-serif;
+    color: inherit;
   }
 
-  // 车牌键盘特殊样式
   @include m(plate) {
-    .lk-keyboard__key {
-      --kb-key-height: var(--lk-rpx-72);
-      --kb-radius: var(--lk-radius-sm);
+    --kb-key-height: var(--lk-rpx-80);
+
+    .lk-keyboard__body {
+      padding-right: var(--lk-spacing-sm);
+      padding-left: var(--lk-spacing-sm);
     }
 
     .lk-keyboard__key-text {
       font-size: var(--lk-font-size-lg);
     }
 
-    .lk-keyboard__row {
-      justify-content: center;
-    }
-
     .lk-keyboard__key {
-      flex: 0 0 auto;
-      width: calc((100% - var(--kb-gap) * 9) / 10);
-      min-width: var(--lk-control-height-xs);
+      flex: 0 0 10%;
+      width: 10%;
     }
 
     .lk-keyboard__key--extra,
     .lk-keyboard__key--delete {
-      width: calc((100% - var(--kb-gap)) / 2);
       flex: 1;
+      width: auto;
     }
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
-import type { StyleValue } from 'vue';
+import { computed, ref } from 'vue';
 import { keyboardProps, keyboardEmits, type KeyboardKey } from './keyboard.props';
 import {
-  resolveKeyboardClass,
-  resolveKeyboardKeyClass,
-  resolveKeyboardKeyStyle,
   resolveKeyboardLayout,
   resolveKeyboardPressAction,
-  resolveKeyboardStyle,
   type KeyboardPlateMode,
 } from './keyboard.utils';
 import LkIcon from '../lk-icon/lk-icon.vue';
+import LkPopup from '../lk-popup/lk-popup.vue';
 import { useLocale } from '../../composables/useLocale';
 
 defineOptions({ name: 'LkKeyboard' });
@@ -20,20 +16,8 @@ const props = defineProps(keyboardProps);
 const emit = defineEmits(keyboardEmits);
 const { t } = useLocale('keyboard');
 
-// 内部显示状态
-const isVisible = ref(props.visible);
-
-watch(
-  () => props.visible,
-  val => {
-    isVisible.value = val;
-  }
-);
-
-// 车牌模式：省份 or 字母数字
 const plateMode = ref<KeyboardPlateMode>('province');
 
-// 当前键盘布局
 const currentLayout = computed((): KeyboardKey[][] =>
   resolveKeyboardLayout({
     type: props.type,
@@ -48,16 +32,48 @@ const currentLayout = computed((): KeyboardKey[][] =>
   })
 );
 
-// 触感反馈
-function triggerHaptic() {
-  if (props.vibrate) {
-    // #ifdef APP-PLUS || MP-WEIXIN
-    uni.vibrateShort({ type: 'light' });
-    // #endif
+const resolvedConfirmText = computed(() => props.confirmText || t('confirm'));
+const popupStyle = computed<string | Record<string, unknown>>(() => {
+  if (typeof props.customStyle === 'string') {
+    return `--lk-popup-surface-bg: var(--lk-keyboard-bg); border: 0; box-shadow: none; ${props.customStyle}`;
   }
+
+  return {
+    '--lk-popup-surface-bg': 'var(--lk-keyboard-bg)',
+    border: 0,
+    boxShadow: 'none',
+    ...props.customStyle,
+  };
+});
+
+function triggerHaptic() {
+  if (!props.vibrate) return;
+
+  // #ifdef APP-PLUS || MP-WEIXIN
+  uni.vibrateShort({ type: 'light' });
+  // #endif
 }
 
-// 按键点击
+function closeKeyboard() {
+  emit('update:visible', false);
+  emit('close');
+}
+
+function onPopupModelChange(visible: boolean) {
+  if (visible) {
+    emit('update:visible', true);
+    return;
+  }
+
+  closeKeyboard();
+}
+
+function onConfirm() {
+  triggerHaptic();
+  emit('confirm', props.modelValue);
+  closeKeyboard();
+}
+
 function onKeyPress(key: KeyboardKey) {
   const action = resolveKeyboardPressAction({
     key,
@@ -71,7 +87,6 @@ function onKeyPress(key: KeyboardKey) {
   triggerHaptic();
   emit('key-press', key);
 
-  // 删除
   if (action.kind === 'delete') {
     emit('delete');
     if (props.modelValue.length > 0) {
@@ -80,158 +95,85 @@ function onKeyPress(key: KeyboardKey) {
     return;
   }
 
-  // 确认
   if (action.kind === 'confirm') {
     emit('confirm', props.modelValue);
     closeKeyboard();
     return;
   }
 
-  // 车牌切换
   if (action.kind === 'switch') {
     plateMode.value = action.nextPlateMode;
     return;
   }
 
-  // 普通输入
-  if (action.kind === 'input') {
-    emit('input', action.input);
-    emit('update:modelValue', action.nextValue);
-  }
+  emit('input', action.input);
+  emit('update:modelValue', action.nextValue);
 }
-
-// 确认按钮
-function onConfirm() {
-  triggerHaptic();
-  emit('confirm', props.modelValue);
-  closeKeyboard();
-}
-
-// 关闭键盘
-function closeKeyboard() {
-  isVisible.value = false;
-  emit('update:visible', false);
-  emit('close');
-}
-
-// 遮罩点击
-function onOverlayClick() {
-  if (props.closeOnOverlay) {
-    closeKeyboard();
-  }
-}
-
-// 安全区域高度
-const safeBottom = uni.getSystemInfoSync().safeAreaInsets?.bottom || 0;
-
-const resolvedConfirmText = computed(() => props.confirmText || t('confirm'));
-
-// 样式计算
-const keyboardClass = computed(() =>
-  resolveKeyboardClass({
-    type: props.type,
-    isVisible: isVisible.value,
-    blur: props.blur,
-    customClass: props.customClass,
-  })
-);
-
-const keyboardStyle = computed(() =>
-  resolveKeyboardStyle({
-    zIndex: props.zIndex,
-    safeAreaInsetBottom: props.safeAreaInsetBottom,
-    safeBottom,
-    customStyle: props.customStyle as StyleValue,
-  })
-);
-
-// 按键样式
-const overlayClass = computed(() => [
-  'lk-keyboard__overlay',
-  { 'is-visible': isVisible.value },
-  props.overlayClass,
-]);
-const overlayStyle = computed<StyleValue>(() => [
-  { zIndex: props.zIndex - 1 },
-  props.overlayStyle as StyleValue,
-]);
-const headerClass = computed(() => ['lk-keyboard__header', props.headerClass]);
-const headerStyle = computed<StyleValue>(() => props.headerStyle as StyleValue);
-const bodyClass = computed(() => ['lk-keyboard__body', props.bodyClass]);
-const bodyStyle = computed<StyleValue>(() => props.bodyStyle as StyleValue);
-const rowClass = computed(() => ['lk-keyboard__row', props.rowClass]);
-const rowStyle = computed<StyleValue>(() => props.rowStyle as StyleValue);
 
 function getKeyClass(key: KeyboardKey) {
-  return resolveKeyboardKeyClass(key, props.keyClass);
+  return [
+    'lk-keyboard__key',
+    {
+      'lk-keyboard__key--delete': key.type === 'delete',
+      'lk-keyboard__key--extra': key.type === 'extra',
+      'lk-keyboard__key--empty': key.type === 'empty',
+      'lk-keyboard__key--disabled': key.disabled,
+    },
+  ];
 }
 
-function getKeyStyle(key: KeyboardKey) {
-  return resolveKeyboardKeyStyle(key, props.keyStyle as StyleValue);
+function getKeyStyle(key: KeyboardKey): Record<string, number> {
+  return key.flex && key.flex !== 1 ? { flex: key.flex } : {};
 }
 </script>
 
 <template>
-  <!-- 遮罩 -->
-  <view
-    v-if="overlay"
-    :class="overlayClass"
-    :style="overlayStyle"
-    @tap="onOverlayClick"
-  />
+  <lk-popup
+    :model-value="visible"
+    position="bottom"
+    round
+    :overlay="overlay"
+    :close-on-overlay="closeOnOverlay"
+    :safe-area="safeAreaInsetBottom"
+    :z-index="zIndex"
+    :custom-style="popupStyle"
+    @update:model-value="onPopupModelChange"
+  >
+    <view :id="id" class="lk-keyboard" :class="[`lk-keyboard--${type}`, customClass]">
+      <view v-if="title || showClose || showConfirm" class="lk-keyboard__header">
+        <view class="lk-keyboard__header-side">
+          <view v-if="showClose" class="lk-keyboard__header-action" @tap="closeKeyboard">
+            <text>{{ t('hide') }}</text>
+          </view>
+        </view>
 
-  <!-- 键盘主体 -->
-  <view :class="keyboardClass" :style="keyboardStyle">
-    <!-- 标题栏 -->
-    <view v-if="title || showClose || showConfirm" :class="headerClass" :style="headerStyle">
-      <view class="lk-keyboard__header-left">
-        <view v-if="showClose" class="lk-keyboard__close" @tap="closeKeyboard">
-          <text class="lk-keyboard__close-text">{{ t('hide') }}</text>
+        <text class="lk-keyboard__title">{{ title }}</text>
+
+        <view class="lk-keyboard__header-side lk-keyboard__header-side--end">
+          <view v-if="showConfirm" class="lk-keyboard__header-action" @tap="onConfirm">
+            <text>{{ resolvedConfirmText }}</text>
+          </view>
         </view>
       </view>
-      <view class="lk-keyboard__title">
-        <text v-if="title">{{ title }}</text>
-      </view>
-      <view class="lk-keyboard__header-right">
-        <view v-if="showConfirm" class="lk-keyboard__done" @tap="onConfirm">
-          <text class="lk-keyboard__done-text">{{ resolvedConfirmText }}</text>
-        </view>
-      </view>
-    </view>
 
-    <!-- 拖拽指示条 -->
-    <view class="lk-keyboard__indicator">
-      <view class="lk-keyboard__indicator-bar" />
-    </view>
-
-    <!-- 键盘区域 -->
-    <view :class="bodyClass" :style="bodyStyle">
-      <view
-        v-for="(row, rowIndex) in currentLayout"
-        :key="rowIndex"
-        :class="rowClass"
-        :style="rowStyle"
-      >
-        <view
-          v-for="(key, keyIndex) in row"
-          :key="keyIndex"
-          :class="getKeyClass(key)"
-          :style="getKeyStyle(key)"
-          @tap="onKeyPress(key)"
-        >
-          <template v-if="key.type === 'delete'">
-            <LkIcon name="arrow-left" :size="40" />
-          </template>
-          <template v-else-if="key.type === 'empty'">
-            <!-- 空按键 -->
-          </template>
-          <template v-else>
-            <text class="lk-keyboard__key-text">{{ key.text }}</text>
-          </template>
+      <view class="lk-keyboard__body">
+        <view v-for="(row, rowIndex) in currentLayout" :key="rowIndex" class="lk-keyboard__row">
+          <view
+            v-for="(key, keyIndex) in row"
+            :key="keyIndex"
+            :class="getKeyClass(key)"
+            :style="getKeyStyle(key)"
+            @tap="onKeyPress(key)"
+          >
+            <lk-icon v-if="key.type === 'delete'" name="eraser" :size="40" />
+            <text v-else-if="key.type !== 'empty'" class="lk-keyboard__key-text">
+              {{ key.text }}
+            </text>
+          </view>
         </view>
       </view>
     </view>
-  </view>
+  </lk-popup>
 </template>
 
 <style lang="scss">

--- a/src/uni_modules/lucky-ui/theme/src/component-vars.scss
+++ b/src/uni_modules/lucky-ui/theme/src/component-vars.scss
@@ -260,17 +260,8 @@ page,
 
   --lk-stepper-bg: var(--lk-fill-1);
 
-  --lk-keyboard-bg: var(--lk-bg-elevated);
-  --lk-keyboard-key-bg: var(--lk-bg-container);
-  --lk-keyboard-key-bg-active: var(--lk-fill-1);
-  --lk-keyboard-key-text: var(--lk-text-primary);
-  --lk-keyboard-key-shadow: var(--lk-shadow-sm);
-  --lk-keyboard-key-border: var(--lk-color-border-light);
-  --lk-keyboard-special-bg: var(--lk-fill-2);
-  --lk-keyboard-special-text: var(--lk-text-secondary);
-  --lk-keyboard-overlay-bg: rgba(0, 0, 0, 0.3);
-  --lk-keyboard-header-border: var(--lk-color-border-light);
-  --lk-keyboard-indicator-bg: var(--lk-color-border);
+  --lk-keyboard-bg: var(--lk-bg-container);
+  --lk-keyboard-text: var(--lk-text-primary);
 
   --lk-preload-debugger-bg: rgba(0, 0, 0, 0.9);
   --lk-preload-debugger-text: var(--lk-color-white);
@@ -392,16 +383,7 @@ page,
   --lk-stepper-bg: var(--lk-fill-1);
 
   --lk-keyboard-bg: var(--lk-bg-container);
-  --lk-keyboard-key-bg: var(--lk-fill-1);
-  --lk-keyboard-key-bg-active: var(--lk-fill-2);
-  --lk-keyboard-key-text: var(--lk-text-primary);
-  --lk-keyboard-key-shadow: var(--lk-shadow-sm);
-  --lk-keyboard-key-border: var(--lk-color-border-light);
-  --lk-keyboard-special-bg: var(--lk-fill-2);
-  --lk-keyboard-special-text: var(--lk-text-secondary);
-  --lk-keyboard-overlay-bg: rgba(0, 0, 0, 0.45);
-  --lk-keyboard-header-border: var(--lk-color-border-light);
-  --lk-keyboard-indicator-bg: var(--lk-color-border);
+  --lk-keyboard-text: var(--lk-text-primary);
 
   --lk-preload-debugger-bg: rgba(0, 0, 0, 0.9);
   --lk-preload-debugger-text: var(--lk-color-white);

--- a/tests/unit/lk-keyboard.spec.ts
+++ b/tests/unit/lk-keyboard.spec.ts
@@ -1,5 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { KeyboardType, type KeyboardKey } from '../../src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.props';
+import {
+  keyboardProps,
+  KeyboardType,
+  type KeyboardKey,
+} from '../../src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.props';
 import {
   buildIdCardKeyboardLayout,
   buildNumberKeyboardLayout,
@@ -8,12 +14,8 @@ import {
   canKeyboardInput,
   generateKeyboardNumberKeys,
   getNextKeyboardPlateMode,
-  resolveKeyboardClass,
-  resolveKeyboardKeyClass,
-  resolveKeyboardKeyStyle,
   resolveKeyboardLayout,
   resolveKeyboardPressAction,
-  resolveKeyboardStyle,
 } from '../../src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.utils';
 
 describe('lk-keyboard input and layout rules', () => {
@@ -39,7 +41,15 @@ describe('lk-keyboard input and layout rules', () => {
 
   it('supports deterministic number shuffling for random keyboard mode', () => {
     expect(generateKeyboardNumberKeys({ random: true, randomFn: () => 0 })).toEqual([
-      '2', '3', '4', '5', '6', '7', '8', '9', '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '1',
     ]);
   });
 
@@ -69,21 +79,25 @@ describe('lk-keyboard input and layout rules', () => {
   it('resolves current layout by keyboard type', () => {
     const customKeys: KeyboardKey[][] = [[{ text: 'OK', value: 'ok', type: 'confirm' }]];
 
-    expect(resolveKeyboardLayout({
-      type: KeyboardType.Custom,
-      keys: customKeys,
-      plateMode: 'province',
-      abcText: 'ABC',
-      provinceText: '省份',
-    })).toBe(customKeys);
+    expect(
+      resolveKeyboardLayout({
+        type: KeyboardType.Custom,
+        keys: customKeys,
+        plateMode: 'province',
+        abcText: 'ABC',
+        provinceText: '省份',
+      })
+    ).toBe(customKeys);
 
-    expect(resolveKeyboardLayout({
-      type: KeyboardType.Plate,
-      keys: [],
-      plateMode: 'alphanum',
-      abcText: 'ABC',
-      provinceText: '省份',
-    })[0][0]).toEqual({ text: 'A', value: 'A' });
+    expect(
+      resolveKeyboardLayout({
+        type: KeyboardType.Plate,
+        keys: [],
+        plateMode: 'alphanum',
+        abcText: 'ABC',
+        provinceText: '省份',
+      })[0][0]
+    ).toEqual({ text: 'A', value: 'A' });
   });
 
   it('resolves key press actions without emitting disabled or overflowing input', () => {
@@ -91,96 +105,91 @@ describe('lk-keyboard input and layout rules', () => {
     expect(canKeyboardInput('123', 3)).toBe(false);
     expect(getNextKeyboardPlateMode('province')).toBe('alphanum');
 
-    expect(resolveKeyboardPressAction({
-      key: { text: '1', value: '1', disabled: true },
-      modelValue: '',
-      maxLength: 0,
-      plateMode: 'province',
-    })).toEqual({ kind: 'ignore' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: '1', value: '1', disabled: true },
+        modelValue: '',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'ignore' });
 
-    expect(resolveKeyboardPressAction({
-      key: { text: '1', value: '1' },
-      modelValue: '12',
-      maxLength: 2,
-      plateMode: 'province',
-    })).toEqual({ kind: 'ignore' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: '1', value: '1' },
+        modelValue: '12',
+        maxLength: 2,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'ignore' });
 
-    expect(resolveKeyboardPressAction({
-      key: { text: '1', value: '1' },
-      modelValue: '12',
-      maxLength: 3,
-      plateMode: 'province',
-    })).toEqual({ kind: 'input', input: '1', nextValue: '121' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: '1', value: '1' },
+        modelValue: '12',
+        maxLength: 3,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'input', input: '1', nextValue: '121' });
 
-    expect(resolveKeyboardPressAction({
-      key: { text: '', type: 'delete' },
-      modelValue: '123',
-      maxLength: 0,
-      plateMode: 'province',
-    })).toEqual({ kind: 'delete', nextValue: '12' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: '', type: 'delete' },
+        modelValue: '123',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'delete', nextValue: '12' });
 
-    expect(resolveKeyboardPressAction({
-      key: { text: 'ABC', value: '__switch__', type: 'extra' },
-      modelValue: '',
-      maxLength: 0,
-      plateMode: 'province',
-    })).toEqual({ kind: 'switch', nextPlateMode: 'alphanum' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: 'ABC', value: '__switch__', type: 'extra' },
+        modelValue: '',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'switch', nextPlateMode: 'alphanum' });
 
-    expect(resolveKeyboardPressAction({
-      key: { text: 'OK', type: 'confirm' },
-      modelValue: '123',
-      maxLength: 0,
-      plateMode: 'province',
-    })).toEqual({ kind: 'confirm' });
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: 'OK', type: 'confirm' },
+        modelValue: '123',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'confirm' });
   });
 
-  it('builds root and key styles', () => {
-    expect(resolveKeyboardClass({
-      type: 'number',
-      isVisible: true,
-      blur: false,
-      customClass: 'custom-keyboard',
-    })).toEqual([
-      'lk-keyboard',
-      'lk-keyboard--number',
-      { 'is-visible': true, 'is-blur': false },
-      'custom-keyboard',
-    ]);
+  it('uses Popup for a flat, card-free key surface', () => {
+    const component = readFileSync(
+      join(process.cwd(), 'src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue'),
+      'utf8'
+    );
+    const styles = readFileSync(
+      join(process.cwd(), 'src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss'),
+      'utf8'
+    );
+    const keyBlockStart = styles.indexOf('@include e(key)');
+    const keyBlockEnd = styles.indexOf('@include e(key-text)', keyBlockStart);
+    const keyBlock = styles.slice(keyBlockStart, keyBlockEnd);
 
-    expect(resolveKeyboardStyle({
-      zIndex: 100,
-      safeAreaInsetBottom: true,
-      safeBottom: 12,
-      customStyle: { backgroundColor: '#fff' },
-    })).toEqual([{ zIndex: 100, paddingBottom: '12px' }, { backgroundColor: '#fff' }]);
+    expect(component).toContain("import LkPopup from '../lk-popup/lk-popup.vue'");
+    expect(component).toContain('<lk-popup');
+    expect(component).toContain('position="bottom"');
+    expect(component).not.toContain('lk-keyboard__overlay');
+    expect(component).not.toContain('getSystemInfoSync');
+    expect(component).toContain("'--lk-popup-surface-bg': 'var(--lk-keyboard-bg)'");
+    expect(keyBlockStart).toBeGreaterThan(-1);
+    expect(keyBlockEnd).toBeGreaterThan(keyBlockStart);
+    expect(keyBlock).not.toContain('background:');
+    expect(keyBlock).not.toContain('border:');
+    expect(keyBlock).not.toContain('box-shadow:');
+    expect(styles).toContain('flex: 0 0 10%');
+  });
 
-    expect(resolveKeyboardKeyClass({
-      text: 'OK',
-      type: 'confirm',
-      flex: 2,
-      className: 'key-confirm',
-    }, 'custom-key')).toEqual([
-      'lk-keyboard__key',
-      {
-        'lk-keyboard__key--delete': false,
-        'lk-keyboard__key--confirm': true,
-        'lk-keyboard__key--extra': false,
-        'lk-keyboard__key--empty': false,
-        'lk-keyboard__key--disabled': undefined,
-        'lk-keyboard__key--wide': true,
-      },
-      'custom-key',
-      'key-confirm',
-    ]);
-    expect(resolveKeyboardKeyStyle({
-      text: 'OK',
-      flex: 2,
-      style: { color: '#fff' },
-    }, { fontWeight: 600 })).toEqual([
-      { flex: 2 },
-      { fontWeight: 600 },
-      { color: '#fff' },
-    ]);
-    expect(resolveKeyboardKeyStyle({ text: 'OK', flex: 1 })).toEqual([{}, '', '']);
+  it('defaults to the minimal Popup presentation', () => {
+    expect(keyboardProps.overlay.default).toBe(true);
+    expect(keyboardProps.showClose.default).toBe(false);
+    expect(keyboardProps.showConfirm.default).toBe(false);
   });
 });


### PR DESCRIPTION
## 变更
- Keyboard 改由 `LkPopup` 统一处理遮罩、动画、圆角和安全区
- 替换为纯色面板、反差文字、透明无键帽布局，并使用线性橡皮删除图标
- 删除自绘 fixed/overlay、毛玻璃、假拖拽指示条和细粒度旧样式入口
- 同步主题变量、Demo、展示台说明、文档、CHANGELOG 与回归测试

## Breaking Change
- `overlay` 默认改为 `true`
- `showClose`、`showConfirm` 默认改为 `false`
- 移除 `blur`、`sound`、结构 class/style 与单键 class/style 属性
- `customStyle` 现在应用于 Popup 面板

## 验证
- `pnpm run test:unit`：77 个文件、429 项通过
- `pnpm run type-check`
- 相关 ESLint / Stylelint
- `pnpm run build:h5`
- `pnpm run build:mp-weixin`
- `pnpm run docs:build`
- H5 移动端亮/暗主题视觉与输入、删除、遮罩关闭、车牌十列布局实测