### PR TITLE
feat(audit): 添加跨端确定性演练场壳层

### DIFF
--- a/src/components/audit/audit-fixture.ts
+++ b/src/components/audit/audit-fixture.ts
@@ -1,0 +1,439 @@
+export const AUDIT_COMPONENT_SLUGS = [
+  'action-sheet',
+  'anchor',
+  'avatar',
+  'backtop',
+  'badge',
+  'button',
+  'calendar',
+  'calendar-picker',
+  'card',
+  'carousel',
+  'cell',
+  'chart-area',
+  'chart-bar',
+  'chart-line',
+  'chart-pie',
+  'chart-radar-lite',
+  'chart-ring',
+  'chart-sparkline',
+  'chart-stat-card',
+  'checkbox',
+  'choice',
+  'collapse',
+  'countdown',
+  'curtain',
+  'divider',
+  'dropdown',
+  'empty',
+  'fab',
+  'form',
+  'form-group',
+  'grid',
+  'horizontal-scroll',
+  'icon',
+  'image',
+  'input',
+  'keyboard',
+  'loading',
+  'meta-row',
+  'modal',
+  'navbar',
+  'notice-bar',
+  'number-roller',
+  'overlay',
+  'page',
+  'picker',
+  'popup',
+  'preload-debugger',
+  'progress',
+  'pull-refresh',
+  'radio',
+  'rate',
+  'root',
+  'segmented',
+  'select-list',
+  'skeleton',
+  'slider',
+  'space',
+  'stepper',
+  'sticky',
+  'switch',
+  'tab',
+  'tabbar',
+  'tabbar-container',
+  'tag',
+  'textarea',
+  'timeline',
+  'toast',
+  'tooltip',
+  'upload',
+  'verify-code',
+  'virtual-list',
+  'waterfall',
+  'watermark',
+] as const;
+
+export type AuditComponentSlug = (typeof AUDIT_COMPONENT_SLUGS)[number];
+export type AuditTheme = 'light' | 'dark';
+export type AuditMotion = 'full' | 'css-tokens-reduced';
+export type AuditProfile = 'render-baseline';
+export type AuditScenario = 'none';
+export type AuditComponentKind = 'public' | 'internal-debug';
+export type AuditInteractionCapability = 'none';
+export type AuditMotionCoverage = 'css-tokens-only';
+
+export const AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS = [
+  'anchor',
+  'avatar',
+  'card',
+  'curtain',
+  'empty',
+  'image',
+  'preload-debugger',
+  'skeleton',
+  'timeline',
+  'upload',
+  'waterfall',
+] as const satisfies readonly AuditComponentSlug[];
+
+export interface AuditFixtureQuery {
+  component?: string;
+  profile?: string;
+  scenario?: string;
+  theme?: string;
+  brand?: string;
+  locale?: string;
+  motion?: string;
+  clock?: string;
+  seed?: string;
+  viewport?: string;
+}
+
+export interface AuditFixtureConfig {
+  component: AuditComponentSlug;
+  componentKind: AuditComponentKind;
+  previewSlug: string;
+  profile: AuditProfile;
+  scenario: AuditScenario;
+  interactionCapability: AuditInteractionCapability;
+  theme: AuditTheme;
+  brand: string;
+  locale: string;
+  motion: AuditMotion;
+  motionCoverage: AuditMotionCoverage;
+  clock: string;
+  clockMs: number;
+  seed: number;
+  viewport: string;
+  viewportWidth: number;
+  viewportHeight: number;
+  viewportMetric: 'uni-window-css-px';
+  resourcePolicy: 'known-direct-remote-deny';
+  resourceEnforcement: 'direct-demo-literal-scan';
+}
+
+export interface AuditFixtureParseResult {
+  config: AuditFixtureConfig;
+  errors: string[];
+  fingerprint: string;
+}
+
+export interface AuditStorageAdapter {
+  listKeys: () => string[];
+  get: (key: string) => unknown;
+  set: (key: string, value: unknown) => void;
+  remove: (key: string) => void;
+}
+
+interface AuditStorageSnapshot {
+  key: string;
+  exists: boolean;
+  value: unknown;
+}
+
+const COMPONENT_SET = new Set<string>(AUDIT_COMPONENT_SLUGS);
+const REMOTE_RESOURCE_COMPONENT_SET = new Set<string>(AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS);
+const SUPPORTED_LOCALES = ['zh-Hans', 'zh-Hant', 'en', 'ja', 'ko', 'fr', 'es', 'pt-BR'] as const;
+const LOCALE_MAP = new Map(SUPPORTED_LOCALES.map(locale => [locale.toLowerCase(), locale]));
+const DEFAULT_CLOCK = '2026-08-13T00:00:00.000Z';
+const DEFAULT_VIEWPORT = '390x844';
+const BRAND_PATTERN = /^#[0-9a-f]{6}$/i;
+const VIEWPORT_PATTERN = /^(\d{3,4})x(\d{3,4})$/;
+const CANONICAL_UTC_CLOCK_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function normalizeComponent(value: string | undefined): string {
+  return (value || 'button').trim().toLowerCase().replace(/^lk-/, '');
+}
+
+function normalizeEnum<T extends string>(
+  value: string | undefined,
+  fallback: T,
+  values: readonly T[],
+  field: string,
+  errors: string[]
+): T {
+  const normalized = (value || fallback).trim().toLowerCase() as T;
+  if (values.includes(normalized)) return normalized;
+  errors.push(`${field}=${value || ''} 不在允许范围内`);
+  return fallback;
+}
+
+function getPreviewSlug(component: AuditComponentSlug): string {
+  return component === 'preload-debugger' ? 'preload' : component;
+}
+
+function getComponentKind(component: AuditComponentSlug): AuditComponentKind {
+  return component === 'preload-debugger' ? 'internal-debug' : 'public';
+}
+
+export function stableAuditConfigJson(config: AuditFixtureConfig): string {
+  return JSON.stringify({
+    component: config.component,
+    componentKind: config.componentKind,
+    previewSlug: config.previewSlug,
+    profile: config.profile,
+    scenario: config.scenario,
+    interactionCapability: config.interactionCapability,
+    theme: config.theme,
+    brand: config.brand,
+    locale: config.locale,
+    motion: config.motion,
+    motionCoverage: config.motionCoverage,
+    clock: config.clock,
+    seed: config.seed,
+    viewport: config.viewport,
+    viewportMetric: config.viewportMetric,
+    resourcePolicy: config.resourcePolicy,
+    resourceEnforcement: config.resourceEnforcement,
+  });
+}
+
+export function fingerprintAuditConfig(config: AuditFixtureConfig): string {
+  const input = stableAuditConfigJson(config);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function parseAuditFixtureQuery(query: AuditFixtureQuery = {}): AuditFixtureParseResult {
+  const errors: string[] = [];
+  const normalizedComponent = normalizeComponent(query.component);
+  const component = COMPONENT_SET.has(normalizedComponent)
+    ? (normalizedComponent as AuditComponentSlug)
+    : 'button';
+  if (!COMPONENT_SET.has(normalizedComponent)) {
+    errors.push(`component=${query.component || ''} 不是 73 个已审计组件目录之一`);
+  }
+
+  const profileCandidate = (query.profile || 'render-baseline').trim().toLowerCase();
+  const profileValid = profileCandidate === 'render-baseline';
+  if (!profileValid) {
+    errors.push(`profile=${query.profile || ''} 尚未注册`);
+  }
+
+  const scenarioCandidate = (query.scenario || 'none').trim().toLowerCase();
+  const scenarioValid = scenarioCandidate === 'none';
+  if (!scenarioValid) {
+    errors.push(`scenario=${query.scenario || ''} 尚未注册组件级适配器`);
+  }
+
+  if (REMOTE_RESOURCE_COMPONENT_SET.has(component)) {
+    errors.push(`component=${component} 的现有 demo 含已知直接远程 URL，演练场拒绝渲染`);
+  }
+
+  const theme = normalizeEnum(query.theme, 'light', ['light', 'dark'], 'theme', errors);
+  const motion = normalizeEnum(
+    query.motion,
+    'css-tokens-reduced',
+    ['full', 'css-tokens-reduced'],
+    'motion',
+    errors
+  );
+
+  const brandCandidate = (query.brand || '#6965db').trim().toLowerCase();
+  const brand = BRAND_PATTERN.test(brandCandidate) ? brandCandidate : '#6965db';
+  if (!BRAND_PATTERN.test(brandCandidate)) {
+    errors.push(`brand=${query.brand || ''} 必须是六位 HEX 颜色`);
+  }
+
+  const localeCandidate = (query.locale || 'zh-Hans').trim();
+  const locale = LOCALE_MAP.get(localeCandidate.toLowerCase()) || 'zh-Hans';
+  if (!LOCALE_MAP.has(localeCandidate.toLowerCase())) {
+    errors.push(`locale=${query.locale || ''} 不受支持`);
+  }
+
+  const clockCandidate = (query.clock || DEFAULT_CLOCK).trim();
+  const clockCandidateMs = CANONICAL_UTC_CLOCK_PATTERN.test(clockCandidate)
+    ? Date.parse(clockCandidate)
+    : Number.NaN;
+  const clockValid =
+    Number.isFinite(clockCandidateMs) &&
+    new Date(clockCandidateMs).toISOString() === clockCandidate;
+  const clockMs = clockValid ? clockCandidateMs : Date.parse(DEFAULT_CLOCK);
+  const clock = new Date(clockMs).toISOString();
+  if (!clockValid) {
+    errors.push(`clock=${query.clock || ''} 必须是带毫秒的 UTC ISO 时间`);
+  }
+
+  const seedCandidate =
+    query.seed === undefined || query.seed.trim() === '' ? Number.NaN : Number(query.seed);
+  const seed =
+    Number.isInteger(seedCandidate) && seedCandidate >= 0 && seedCandidate <= 0xffffffff
+      ? seedCandidate
+      : 20260813;
+  if (query.seed !== undefined && seed !== seedCandidate) {
+    errors.push(`seed=${query.seed || ''} 必须是 0..4294967295 的整数`);
+  }
+
+  const viewportCandidate = (query.viewport || DEFAULT_VIEWPORT).trim().toLowerCase();
+  const viewportMatch = VIEWPORT_PATTERN.exec(viewportCandidate);
+  let viewportWidth = 390;
+  let viewportHeight = 844;
+  if (viewportMatch) {
+    viewportWidth = Number(viewportMatch[1]);
+    viewportHeight = Number(viewportMatch[2]);
+  }
+  const viewportValid = Boolean(
+    viewportMatch &&
+      viewportWidth >= 240 &&
+      viewportWidth <= 2048 &&
+      viewportHeight >= 320 &&
+      viewportHeight <= 4096
+  );
+  if (!viewportValid) {
+    errors.push(`viewport=${query.viewport || ''} 必须是合理的 宽x高 CSS px`);
+    viewportWidth = 390;
+    viewportHeight = 844;
+  }
+  const viewport = `${viewportWidth}x${viewportHeight}`;
+
+  const config: AuditFixtureConfig = {
+    component,
+    componentKind: getComponentKind(component),
+    previewSlug: getPreviewSlug(component),
+    profile: 'render-baseline',
+    scenario: 'none',
+    interactionCapability: 'none',
+    theme,
+    brand,
+    locale,
+    motion,
+    motionCoverage: 'css-tokens-only',
+    clock,
+    clockMs,
+    seed,
+    viewport,
+    viewportWidth,
+    viewportHeight,
+    viewportMetric: 'uni-window-css-px',
+    resourcePolicy: 'known-direct-remote-deny',
+    resourceEnforcement: 'direct-demo-literal-scan',
+  };
+
+  return {
+    config,
+    errors,
+    fingerprint: fingerprintAuditConfig(config),
+  };
+}
+
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function installAuditDeterminism(
+  config: AuditFixtureConfig,
+  monotonicNow?: () => number
+): () => void {
+  const OriginalDate = globalThis.Date;
+  const originalRandom = Math.random;
+  const seededRandom = createSeededRandom(config.seed);
+  const readMonotonic =
+    monotonicNow ||
+    (typeof globalThis.performance?.now === 'function'
+      ? () => globalThis.performance.now()
+      : () => OriginalDate.now());
+  const readFiniteMonotonic = () => {
+    const value = readMonotonic();
+    if (!Number.isFinite(value)) throw new Error(`audit-clock:non-finite:${String(value)}`);
+    return value;
+  };
+  const monotonicStart = readFiniteMonotonic();
+  let lastElapsed = 0;
+  const currentClockMs = () => {
+    const candidate = Math.max(0, readFiniteMonotonic() - monotonicStart);
+    lastElapsed = Math.max(lastElapsed, candidate);
+    return config.clockMs + Math.floor(lastElapsed);
+  };
+  const FixedDate = function AuditDate(this: Date, ...args: unknown[]) {
+    if (!new.target) return new OriginalDate(currentClockMs()).toString();
+    return Reflect.construct(OriginalDate, args.length ? args : [currentClockMs()], new.target);
+  } as unknown as DateConstructor;
+
+  Object.setPrototypeOf(FixedDate, OriginalDate);
+  Object.setPrototypeOf(FixedDate.prototype, OriginalDate.prototype);
+  FixedDate.now = currentClockMs;
+  FixedDate.parse = OriginalDate.parse;
+  FixedDate.UTC = OriginalDate.UTC;
+
+  globalThis.Date = FixedDate;
+  Math.random = seededRandom;
+
+  return () => {
+    if (globalThis.Date === FixedDate) globalThis.Date = OriginalDate;
+    if (Math.random === seededRandom) Math.random = originalRandom;
+  };
+}
+
+export function applyTemporaryStorageOverlay(
+  storage: AuditStorageAdapter,
+  values: Readonly<Record<string, unknown>>,
+  apply: () => void
+): void {
+  const keys = Object.keys(values);
+  const existingKeys = new Set(storage.listKeys());
+  const snapshots: AuditStorageSnapshot[] = keys.map(key => ({
+    key,
+    exists: existingKeys.has(key),
+    value: existingKeys.has(key) ? storage.get(key) : undefined,
+  }));
+  let applyFailed = false;
+  let applyError: unknown;
+
+  try {
+    for (const key of keys) storage.set(key, values[key]);
+    apply();
+  } catch (error) {
+    applyFailed = true;
+    applyError = error;
+  }
+
+  const restoreErrors: string[] = [];
+  for (const snapshot of [...snapshots].reverse()) {
+    try {
+      if (snapshot.exists) storage.set(snapshot.key, snapshot.value);
+      else storage.remove(snapshot.key);
+    } catch (error) {
+      restoreErrors.push(`${snapshot.key}:${String(error)}`);
+    }
+  }
+
+  if (applyFailed || restoreErrors.length > 0) {
+    const parts = [
+      ...(applyFailed ? [`apply:${String(applyError)}`] : []),
+      ...restoreErrors.map(error => `restore:${error}`),
+    ];
+    throw new Error(`storage-overlay:${parts.join('|')}`);
+  }
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,16 @@
 /// <reference types="vite/client" />
 
+declare const __LUCKY_UI_BUILD_IDENTITY__: Readonly<{
+  commit: string;
+  branch: string;
+  dirty: boolean;
+  sourceDigest: string;
+  version: string;
+  buildMode: 'static-build' | 'dev-server';
+  provenance: 'git-worktree' | 'unverified';
+  valid: boolean;
+}>;
+
 declare module '*.vue' {
   import { DefineComponent } from 'vue';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/pages.json
+++ b/src/pages.json
@@ -35,6 +35,13 @@
           }
         },
         {
+          "path": "audit-fixture/index",
+          "style": {
+            "navigationBarTitleText": "Audit Fixture",
+            "navigationStyle": "custom"
+          }
+        },
+        {
           "path": "i18n-preview/index",
           "style": {
             "navigationBarTitleText": "i18n Preview",

--- a/src/pages_sub/audit-fixture/index.vue
+++ b/src/pages_sub/audit-fixture/index.vue
@@ -1,0 +1,580 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, ref } from 'vue';
+import { onLoad, onUnload } from '@dcloudio/uni-app';
+import PreviewDemoRenderer from '@/components/preview/PreviewDemoRenderer.vue';
+import {
+  applyTemporaryStorageOverlay,
+  installAuditDeterminism,
+  parseAuditFixtureQuery,
+  stableAuditConfigJson,
+  type AuditFixtureParseResult,
+  type AuditFixtureQuery,
+  type AuditStorageAdapter,
+} from '@/components/audit/audit-fixture';
+import { Locale } from '@/uni_modules/lucky-ui/locale';
+import { themeStore } from '@/uni_modules/lucky-ui/theme/src/theme-store';
+
+interface AuditEvent {
+  sequence: number;
+  name: string;
+  detail?: string;
+}
+
+type WindowResizeUni = typeof uni & {
+  onWindowResize?: (callback: () => void) => void;
+  offWindowResize?: (callback: () => void) => void;
+};
+
+type RuntimeErrorUni = typeof uni & {
+  onError?: (callback: (error: string) => void) => void;
+  offError?: (callback: (error: string) => void) => void;
+  onUnhandledRejection?: (callback: (result: { reason: unknown }) => void) => void;
+  offUnhandledRejection?: (callback: (result: { reason: unknown }) => void) => void;
+};
+
+const THEME_STORAGE_KEY = 'lk-theme';
+const BRAND_STORAGE_KEY = 'lk-brand-color';
+const buildIdentity = __LUCKY_UI_BUILD_IDENTITY__;
+const parseResult = ref<AuditFixtureParseResult | null>(null);
+const initialized = ref(false);
+const shellReady = ref(false);
+const evidenceReady = ref(false);
+const environmentValid = ref(false);
+const runtimeErrors = ref<string[]>([]);
+const auditEvents = ref<AuditEvent[]>([]);
+const actualViewport = ref('pending');
+const viewportMatches = ref(false);
+const platform = ref('unknown');
+const runtimeErrorCapture = ref<'pending' | 'h5-global' | 'mp-global' | 'unsupported'>('pending');
+let restoreDeterminism: (() => void) | null = null;
+let restoreEnvironment: (() => void) | null = null;
+let restoreRuntimeCapture: (() => void) | null = null;
+let restoreResizeCapture: (() => void) | null = null;
+let eventSequence = 0;
+let disposed = false;
+let lifecycleGeneration = 0;
+
+const config = computed(() => parseResult.value?.config);
+const configJson = computed(() => (config.value ? stableAuditConfigJson(config.value) : '{}'));
+const validationErrors = computed(() => {
+  const errors = [...(parseResult.value?.errors || []), ...runtimeErrors.value];
+  if (!buildIdentity.valid) {
+    errors.push('build-identity:必须来自干净、可验证 Git 工作树的一次全新静态构建');
+  }
+  if (actualViewport.value !== 'pending' && !viewportMatches.value) {
+    errors.push(
+      `viewport-mismatch:expected=${config.value?.viewport || 'unknown'},actual=${actualViewport.value}`
+    );
+  }
+  return [...new Set(errors)];
+});
+const errorsJson = computed(() => JSON.stringify(validationErrors.value));
+const eventsJson = computed(() => JSON.stringify(auditEvents.value));
+const fixtureValid = computed(
+  () =>
+    initialized.value &&
+    environmentValid.value &&
+    buildIdentity.valid &&
+    viewportMatches.value &&
+    validationErrors.value.length === 0
+);
+const canRenderPreview = computed(() => fixtureValid.value);
+const stateJson = computed(() =>
+  JSON.stringify({
+    initialized: initialized.value,
+    shellReady: shellReady.value,
+    evidenceReady: evidenceReady.value,
+    fixtureValid: fixtureValid.value,
+    evidenceScope: 'fixture-shell',
+    componentStatus: 'pending-adapter',
+    interactionCapability: config.value?.interactionCapability || 'none',
+    build: buildIdentity,
+    platform: platform.value,
+    actualViewport: actualViewport.value,
+    viewportMatches: viewportMatches.value,
+    viewportMetric: config.value?.viewportMetric || 'uni-window-css-px',
+    runtimeErrorCapture: runtimeErrorCapture.value,
+    nativeSystemUiScope: 'external-runtime-required',
+  })
+);
+const revisionLabel = computed(
+  () =>
+    `${buildIdentity.commit.slice(0, 12)}${buildIdentity.dirty ? '+dirty' : ''} / ${buildIdentity.sourceDigest.slice(0, 12)}`
+);
+const fixtureStyle = computed(() => {
+  const brandVars = themeStore.brandStyleVars;
+  const motionVars =
+    config.value?.motion === 'css-tokens-reduced'
+      ? '--lk-transition-fast:0s linear;--lk-transition-base:0s linear;--lk-transition-slow:0s linear;--lk-transition-duration:0s;'
+      : '';
+  return `${brandVars};${motionVars}`;
+});
+
+const storageAdapter: AuditStorageAdapter = {
+  listKeys() {
+    const info = uni.getStorageInfoSync();
+    if (!info || !Array.isArray(info.keys)) throw new Error('storage-info-without-keys');
+    return [...info.keys];
+  },
+  get: key => uni.getStorageSync(key),
+  set: (key, value) => uni.setStorageSync(key, value),
+  remove: key => uni.removeStorageSync(key),
+};
+
+function restoreOriginalEnvironment(previousLocale: string): void {
+  const errors: string[] = [];
+  try {
+    Locale.use(previousLocale);
+  } catch (error) {
+    errors.push(`locale:${String(error)}`);
+  }
+  try {
+    themeStore.init();
+  } catch (error) {
+    errors.push(`theme:${String(error)}`);
+  }
+  if (errors.length > 0) throw new Error(errors.join('|'));
+}
+
+function applyAuditEnvironment(result: AuditFixtureParseResult): () => void {
+  const previousLocale = Locale.locale;
+  try {
+    applyTemporaryStorageOverlay(
+      storageAdapter,
+      {
+        [THEME_STORAGE_KEY]: result.config.theme,
+        [BRAND_STORAGE_KEY]: result.config.brand,
+      },
+      () => {
+        themeStore.init();
+        Locale.use(result.config.locale);
+        if (themeStore.theme !== result.config.theme) {
+          throw new Error(
+            `theme-postcondition:expected=${result.config.theme},actual=${themeStore.theme}`
+          );
+        }
+        if (themeStore.brandColor.toLowerCase() !== result.config.brand.toLowerCase()) {
+          throw new Error(
+            `brand-postcondition:expected=${result.config.brand},actual=${themeStore.brandColor}`
+          );
+        }
+        if (Locale.locale !== result.config.locale) {
+          throw new Error(
+            `locale-postcondition:expected=${result.config.locale},actual=${Locale.locale}`
+          );
+        }
+      }
+    );
+  } catch (error) {
+    try {
+      restoreOriginalEnvironment(previousLocale);
+    } catch (rollbackError) {
+      throw new Error(`environment:${String(error)}|rollback:${String(rollbackError)}`);
+    }
+    throw error;
+  }
+  return () => restoreOriginalEnvironment(previousLocale);
+}
+
+function formatConsoleValue(value: unknown): string {
+  if (value instanceof Error) return value.stack || `${value.name}: ${value.message}`;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function installRuntimeCapture(): () => void {
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  let active = true;
+  const capturedError = (...args: unknown[]) => {
+    if (active) runtimeErrors.value.push(`console-error:${args.map(formatConsoleValue).join(' ')}`);
+    Reflect.apply(originalError, console, args);
+  };
+  const capturedWarn = (...args: unknown[]) => {
+    if (active) runtimeErrors.value.push(`console-warn:${args.map(formatConsoleValue).join(' ')}`);
+    Reflect.apply(originalWarn, console, args);
+  };
+
+  // #ifdef H5
+  let windowListenersInstalled = false;
+  const handleWindowError = (event: ErrorEvent) => {
+    if (!active) return;
+    const target = event.target as (EventTarget & { src?: string; href?: string }) | null;
+    runtimeErrors.value.push(
+      `window-error:${event.message || target?.src || target?.href || 'resource-error'}`
+    );
+  };
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    if (active) runtimeErrors.value.push(`unhandled-rejection:${formatConsoleValue(event.reason)}`);
+  };
+  // #endif
+
+  // #ifdef MP-WEIXIN
+  const runtimeUni = uni as RuntimeErrorUni;
+  let appErrorInstalled = false;
+  let rejectionInstalled = false;
+  const handleAppError = (error: string) => {
+    if (active) runtimeErrors.value.push(`mp-app-error:${error}`);
+  };
+  const handleAppUnhandledRejection = (result: { reason: unknown }) => {
+    if (active) {
+      runtimeErrors.value.push(`mp-unhandled-rejection:${formatConsoleValue(result.reason)}`);
+    }
+  };
+  // #endif
+
+  const restore = () => {
+    active = false;
+    const restoreErrors: string[] = [];
+    if (console.error === capturedError) console.error = originalError;
+    if (console.warn === capturedWarn) console.warn = originalWarn;
+    // #ifdef H5
+    if (windowListenersInstalled) {
+      try {
+        window.removeEventListener('error', handleWindowError, true);
+        window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      } catch (error) {
+        restoreErrors.push(`window:${String(error)}`);
+      }
+    }
+    // #endif
+    // #ifdef MP-WEIXIN
+    if (appErrorInstalled) {
+      try {
+        runtimeUni.offError?.(handleAppError);
+      } catch (error) {
+        restoreErrors.push(`mp-error:${String(error)}`);
+      }
+    }
+    if (rejectionInstalled) {
+      try {
+        runtimeUni.offUnhandledRejection?.(handleAppUnhandledRejection);
+      } catch (error) {
+        restoreErrors.push(`mp-rejection:${String(error)}`);
+      }
+    }
+    // #endif
+    if (restoreErrors.length > 0) throw new Error(restoreErrors.join('|'));
+  };
+
+  try {
+    console.error = capturedError;
+    console.warn = capturedWarn;
+    // #ifdef H5
+    window.addEventListener('error', handleWindowError, true);
+    windowListenersInstalled = true;
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    runtimeErrorCapture.value = 'h5-global';
+    // #endif
+    // #ifdef MP-WEIXIN
+    if (
+      typeof runtimeUni.onError !== 'function' ||
+      typeof runtimeUni.offError !== 'function' ||
+      typeof runtimeUni.onUnhandledRejection !== 'function' ||
+      typeof runtimeUni.offUnhandledRejection !== 'function'
+    ) {
+      throw new Error('mp-global-error-api-incomplete');
+    }
+    runtimeUni.onError(handleAppError);
+    appErrorInstalled = true;
+    runtimeUni.onUnhandledRejection(handleAppUnhandledRejection);
+    rejectionInstalled = true;
+    runtimeErrorCapture.value = 'mp-global';
+    // #endif
+    if (!['h5-global', 'mp-global'].includes(runtimeErrorCapture.value)) {
+      runtimeErrorCapture.value = 'unsupported';
+      throw new Error('platform-global-error-capture-unsupported');
+    }
+  } catch (error) {
+    runtimeErrorCapture.value = 'unsupported';
+    try {
+      restore();
+    } catch (rollbackError) {
+      throw new Error(`runtime-capture:${String(error)}|rollback:${String(rollbackError)}`);
+    }
+    throw error;
+  }
+
+  return restore;
+}
+
+function installResizeCapture(): () => void {
+  const resizeUni = uni as WindowResizeUni;
+  if (
+    typeof resizeUni.onWindowResize !== 'function' ||
+    typeof resizeUni.offWindowResize !== 'function'
+  ) {
+    return () => {};
+  }
+  let active = true;
+  const handleResize = () => {
+    if (active) readViewport();
+  };
+  resizeUni.onWindowResize(handleResize);
+  return () => {
+    active = false;
+    resizeUni.offWindowResize?.(handleResize);
+  };
+}
+
+function recordEvent(name: string, detail?: string) {
+  eventSequence += 1;
+  auditEvents.value.push({ sequence: eventSequence, name, detail });
+}
+
+function restoreOwnedEnvironment() {
+  try {
+    restoreDeterminism?.();
+  } catch (error) {
+    runtimeErrors.value.push(`restore-determinism:${String(error)}`);
+  }
+  restoreDeterminism = null;
+  try {
+    restoreEnvironment?.();
+  } catch (error) {
+    runtimeErrors.value.push(`restore-environment:${String(error)}`);
+  }
+  restoreEnvironment = null;
+}
+
+function initialize(query: AuditFixtureQuery) {
+  if (initialized.value) return;
+  const result = parseAuditFixtureQuery(query);
+  parseResult.value = result;
+  runtimeErrors.value = [];
+  auditEvents.value = [];
+  eventSequence = 0;
+  disposed = false;
+  runtimeErrorCapture.value = 'pending';
+  try {
+    restoreRuntimeCapture = installRuntimeCapture();
+  } catch (error) {
+    runtimeErrors.value.push(`runtime-capture:${String(error)}`);
+    environmentValid.value = false;
+    initialized.value = true;
+    return;
+  }
+
+  if (result.errors.length === 0 && buildIdentity.valid) {
+    try {
+      restoreEnvironment = applyAuditEnvironment(result);
+      restoreDeterminism = installAuditDeterminism(result.config);
+      environmentValid.value = true;
+    } catch (error) {
+      runtimeErrors.value.push(`initialize:${String(error)}`);
+      environmentValid.value = false;
+      restoreOwnedEnvironment();
+    }
+  } else {
+    environmentValid.value = false;
+  }
+  initialized.value = true;
+}
+
+function readViewport() {
+  try {
+    const info =
+      typeof uni.getWindowInfo === 'function' ? uni.getWindowInfo() : uni.getSystemInfoSync();
+    const width = Math.round(info.windowWidth);
+    const height = Math.round(info.windowHeight);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) throw new Error('non-finite-window');
+    actualViewport.value = `${width}x${height}`;
+    viewportMatches.value =
+      width === config.value?.viewportWidth && height === config.value?.viewportHeight;
+  } catch (error) {
+    runtimeErrors.value.push(`viewport:${String(error)}`);
+    actualViewport.value = 'unavailable';
+    viewportMatches.value = false;
+  }
+}
+
+function cleanup() {
+  if (disposed) return;
+  disposed = true;
+  lifecycleGeneration += 1;
+  shellReady.value = false;
+  evidenceReady.value = false;
+  environmentValid.value = false;
+  try {
+    restoreResizeCapture?.();
+  } catch (error) {
+    runtimeErrors.value.push(`restore-resize:${String(error)}`);
+  }
+  restoreResizeCapture = null;
+  restoreOwnedEnvironment();
+  try {
+    restoreRuntimeCapture?.();
+  } catch (error) {
+    runtimeErrors.value.push(`restore-runtime-capture:${String(error)}`);
+  }
+  restoreRuntimeCapture = null;
+  initialized.value = false;
+}
+
+onErrorCaptured((error, _instance, info) => {
+  runtimeErrors.value.push(`vue-descendant:${info}:${formatConsoleValue(error)}`);
+});
+
+onLoad((query?: AuditFixtureQuery) => {
+  initialize(query || {});
+});
+
+onMounted(async () => {
+  if (!initialized.value) initialize({});
+  const generation = ++lifecycleGeneration;
+  // #ifdef H5
+  platform.value = 'h5';
+  // #endif
+  // #ifdef MP-WEIXIN
+  platform.value = 'mp-weixin';
+  // #endif
+  readViewport();
+  restoreResizeCapture = installResizeCapture();
+  await nextTick();
+  if (disposed || generation !== lifecycleGeneration || !initialized.value) return;
+  shellReady.value = true;
+  recordEvent('shell-ready', parseResult.value?.fingerprint);
+});
+
+onUnload(cleanup);
+onBeforeUnmount(cleanup);
+</script>
+
+<template>
+  <view
+    v-if="initialized && config"
+    id="audit-fixture-root"
+    class="audit-fixture"
+    :class="[themeStore.themeClass, `audit-fixture--motion-${config.motion}`]"
+    :style="fixtureStyle"
+    :data-audit-shell-ready="String(shellReady)"
+    :data-audit-evidence-ready="String(evidenceReady)"
+    :data-audit-fixture-valid="String(fixtureValid)"
+    :data-audit-error-count="String(validationErrors.length)"
+    data-audit-evidence-scope="fixture-shell"
+    data-audit-component-status="pending-adapter"
+    :data-audit-component="config.component"
+    :data-audit-component-kind="config.componentKind"
+    :data-audit-profile="config.profile"
+    :data-audit-scenario="config.scenario"
+    :data-audit-interaction-capability="config.interactionCapability"
+    :data-audit-motion-coverage="config.motionCoverage"
+    :data-audit-resource-policy="config.resourcePolicy"
+    :data-audit-resource-enforcement="config.resourceEnforcement"
+    :data-audit-fingerprint="parseResult?.fingerprint"
+    :data-audit-commit="buildIdentity.commit"
+    :data-audit-branch="buildIdentity.branch"
+    :data-audit-dirty="String(buildIdentity.dirty)"
+    :data-audit-source-digest="buildIdentity.sourceDigest"
+    :data-audit-version="buildIdentity.version"
+    :data-audit-build-mode="buildIdentity.buildMode"
+    :data-audit-provenance="buildIdentity.provenance"
+    :data-audit-platform="platform"
+    :data-audit-viewport="actualViewport"
+    :data-audit-viewport-metric="config.viewportMetric"
+    :data-audit-viewport-match="String(viewportMatches)"
+    :data-audit-runtime-error-capture="runtimeErrorCapture"
+    data-audit-native-system-ui-scope="external-runtime-required"
+  >
+    <view class="audit-fixture__header">
+      <text class="audit-fixture__title">{{ config.component }} / {{ config.profile }}</text>
+      <text class="audit-fixture__revision">{{ revisionLabel }}</text>
+    </view>
+
+    <view
+      class="audit-fixture__stage"
+      :data-audit-preview-slug="config.previewSlug"
+      :data-audit-preview-mounted="String(canRenderPreview)"
+    >
+      <preview-demo-renderer v-if="canRenderPreview" :slug="config.previewSlug" />
+      <view v-else class="audit-fixture__invalid">
+        <text>当前只允许确定性的壳层基线；配置、资源或环境不满足门槛时禁止生成组件证据。</text>
+      </view>
+    </view>
+
+    <view class="audit-fixture__diagnostics">
+      <text class="audit-fixture__config">{{ configJson }}</text>
+      <text class="audit-fixture__state">{{ stateJson }}</text>
+      <text class="audit-fixture__events">{{ eventsJson }}</text>
+      <text class="audit-fixture__errors">{{ errorsJson }}</text>
+    </view>
+  </view>
+</template>
+
+<style scoped lang="scss">
+.audit-fixture {
+  width: 100%;
+  min-height: 100vh;
+  box-sizing: border-box;
+  color: var(--lk-text-primary);
+  background: var(--lk-bg-page);
+}
+
+.audit-fixture__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72rpx;
+  padding: 16rpx 24rpx;
+  box-sizing: border-box;
+  color: var(--lk-text-secondary);
+  background: var(--lk-bg-card);
+  border-bottom: 1rpx solid var(--lk-border-color);
+}
+
+.audit-fixture__title,
+.audit-fixture__revision {
+  font-family: monospace;
+  font-size: 20rpx;
+  line-height: 1.4;
+}
+
+.audit-fixture__stage {
+  width: 100%;
+  min-height: 480rpx;
+  padding: 24rpx;
+  box-sizing: border-box;
+}
+
+.audit-fixture__invalid {
+  padding: 32rpx;
+  color: var(--lk-color-danger);
+  background: var(--lk-bg-card);
+  border: 1rpx solid var(--lk-color-danger);
+  border-radius: 16rpx;
+}
+
+.audit-fixture__diagnostics {
+  display: flex;
+  flex-direction: column;
+  padding: 20rpx 24rpx 40rpx;
+  background: var(--lk-bg-card);
+  border-top: 1rpx solid var(--lk-border-color);
+}
+
+.audit-fixture__config,
+.audit-fixture__state,
+.audit-fixture__events,
+.audit-fixture__errors {
+  display: block;
+  overflow-wrap: anywhere;
+  color: var(--lk-text-secondary);
+  font-family: monospace;
+  font-size: 18rpx;
+  line-height: 1.5;
+}
+
+.audit-fixture__state,
+.audit-fixture__events,
+.audit-fixture__errors {
+  margin-top: 8rpx;
+}
+
+.audit-fixture__errors {
+  color: var(--lk-color-danger);
+}
+</style>

--- a/src/pages_sub/audit-fixture/index.vue
+++ b/src/pages_sub/audit-fixture/index.vue
@@ -3,16 +3,14 @@ import { computed, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, ref } 
 import { onLoad, onUnload } from '@dcloudio/uni-app';
 import PreviewDemoRenderer from '@/components/preview/PreviewDemoRenderer.vue';
 import {
-  applyTemporaryStorageOverlay,
   installAuditDeterminism,
   parseAuditFixtureQuery,
   stableAuditConfigJson,
   type AuditFixtureParseResult,
   type AuditFixtureQuery,
-  type AuditStorageAdapter,
 } from '@/components/audit/audit-fixture';
 import { Locale } from '@/uni_modules/lucky-ui/locale';
-import { themeStore } from '@/uni_modules/lucky-ui/theme/src/theme-store';
+import { generateBrandVars } from '@/uni_modules/lucky-ui/theme/src/brand-color';
 
 interface AuditEvent {
   sequence: number;
@@ -32,8 +30,6 @@ type RuntimeErrorUni = typeof uni & {
   offUnhandledRejection?: (callback: (result: { reason: unknown }) => void) => void;
 };
 
-const THEME_STORAGE_KEY = 'lk-theme';
-const BRAND_STORAGE_KEY = 'lk-brand-color';
 const buildIdentity = __LUCKY_UI_BUILD_IDENTITY__;
 const parseResult = ref<AuditFixtureParseResult | null>(null);
 const initialized = ref(false);
@@ -94,7 +90,9 @@ const stateJson = computed(() =>
     viewportMatches: viewportMatches.value,
     viewportMetric: config.value?.viewportMetric || 'uni-window-css-px',
     runtimeErrorCapture: runtimeErrorCapture.value,
-    nativeSystemUiScope: 'external-runtime-required',
+    themeScope: 'fixture-root',
+    brandScope: 'fixture-root',
+    nativeSystemUiScope: 'not-controlled',
   })
 );
 const revisionLabel = computed(
@@ -102,7 +100,9 @@ const revisionLabel = computed(
     `${buildIdentity.commit.slice(0, 12)}${buildIdentity.dirty ? '+dirty' : ''} / ${buildIdentity.sourceDigest.slice(0, 12)}`
 );
 const fixtureStyle = computed(() => {
-  const brandVars = themeStore.brandStyleVars;
+  const brandVars = Object.entries(generateBrandVars(config.value?.brand || '#6965db'))
+    .map(([key, value]) => `${key}:${value}`)
+    .join(';');
   const motionVars =
     config.value?.motion === 'css-tokens-reduced'
       ? '--lk-transition-fast:0s linear;--lk-transition-base:0s linear;--lk-transition-slow:0s linear;--lk-transition-duration:0s;'
@@ -110,70 +110,24 @@ const fixtureStyle = computed(() => {
   return `${brandVars};${motionVars}`;
 });
 
-const storageAdapter: AuditStorageAdapter = {
-  listKeys() {
-    const info = uni.getStorageInfoSync();
-    if (!info || !Array.isArray(info.keys)) throw new Error('storage-info-without-keys');
-    return [...info.keys];
-  },
-  get: key => uni.getStorageSync(key),
-  set: (key, value) => uni.setStorageSync(key, value),
-  remove: key => uni.removeStorageSync(key),
-};
-
-function restoreOriginalEnvironment(previousLocale: string): void {
-  const errors: string[] = [];
-  try {
-    Locale.use(previousLocale);
-  } catch (error) {
-    errors.push(`locale:${String(error)}`);
-  }
-  try {
-    themeStore.init();
-  } catch (error) {
-    errors.push(`theme:${String(error)}`);
-  }
-  if (errors.length > 0) throw new Error(errors.join('|'));
-}
-
 function applyAuditEnvironment(result: AuditFixtureParseResult): () => void {
   const previousLocale = Locale.locale;
   try {
-    applyTemporaryStorageOverlay(
-      storageAdapter,
-      {
-        [THEME_STORAGE_KEY]: result.config.theme,
-        [BRAND_STORAGE_KEY]: result.config.brand,
-      },
-      () => {
-        themeStore.init();
-        Locale.use(result.config.locale);
-        if (themeStore.theme !== result.config.theme) {
-          throw new Error(
-            `theme-postcondition:expected=${result.config.theme},actual=${themeStore.theme}`
-          );
-        }
-        if (themeStore.brandColor.toLowerCase() !== result.config.brand.toLowerCase()) {
-          throw new Error(
-            `brand-postcondition:expected=${result.config.brand},actual=${themeStore.brandColor}`
-          );
-        }
-        if (Locale.locale !== result.config.locale) {
-          throw new Error(
-            `locale-postcondition:expected=${result.config.locale},actual=${Locale.locale}`
-          );
-        }
-      }
-    );
+    Locale.use(result.config.locale);
+    if (Locale.locale !== result.config.locale) {
+      throw new Error(
+        `locale-postcondition:expected=${result.config.locale},actual=${Locale.locale}`
+      );
+    }
   } catch (error) {
     try {
-      restoreOriginalEnvironment(previousLocale);
+      Locale.use(previousLocale);
     } catch (rollbackError) {
       throw new Error(`environment:${String(error)}|rollback:${String(rollbackError)}`);
     }
     throw error;
   }
-  return () => restoreOriginalEnvironment(previousLocale);
+  return () => Locale.use(previousLocale);
 }
 
 function formatConsoleValue(value: unknown): string {
@@ -449,7 +403,7 @@ onBeforeUnmount(cleanup);
     v-if="initialized && config"
     id="audit-fixture-root"
     class="audit-fixture"
-    :class="[themeStore.themeClass, `audit-fixture--motion-${config.motion}`]"
+    :class="[`lk-theme-${config.theme}`, `audit-fixture--motion-${config.motion}`]"
     :style="fixtureStyle"
     :data-audit-shell-ready="String(shellReady)"
     :data-audit-evidence-ready="String(evidenceReady)"
@@ -478,7 +432,9 @@ onBeforeUnmount(cleanup);
     :data-audit-viewport-metric="config.viewportMetric"
     :data-audit-viewport-match="String(viewportMatches)"
     :data-audit-runtime-error-capture="runtimeErrorCapture"
-    data-audit-native-system-ui-scope="external-runtime-required"
+    data-audit-theme-scope="fixture-root"
+    data-audit-brand-scope="fixture-root"
+    data-audit-native-system-ui-scope="not-controlled"
   >
     <view class="audit-fixture__header">
       <text class="audit-fixture__title">{{ config.component }} / {{ config.profile }}</text>

--- a/tests/unit/audit-fixture.spec.ts
+++ b/tests/unit/audit-fixture.spec.ts
@@ -213,6 +213,10 @@ describe('audit fixture contract', () => {
     expect(source).toContain('data-audit-component-status="pending-adapter"');
     expect(source).toContain(':data-audit-build-mode="buildIdentity.buildMode"');
     expect(source).toContain(':data-audit-provenance="buildIdentity.provenance"');
+    expect(source).toContain('data-audit-theme-scope="fixture-root"');
+    expect(source).toContain('data-audit-brand-scope="fixture-root"');
+    expect(source).not.toContain('themeStore');
+    expect(source).not.toContain('applyTemporaryStorageOverlay');
   });
 
   it('does not overwrite a newer global owner during cleanup', () => {

--- a/tests/unit/audit-fixture.spec.ts
+++ b/tests/unit/audit-fixture.spec.ts
@@ -1,0 +1,311 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PREVIEW_DEMO_SLUGS } from '../../src/components/preview/preview-demo-registry';
+import {
+  AUDIT_COMPONENT_SLUGS,
+  AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS,
+  applyTemporaryStorageOverlay,
+  createSeededRandom,
+  fingerprintAuditConfig,
+  installAuditDeterminism,
+  parseAuditFixtureQuery,
+  stableAuditConfigJson,
+  type AuditStorageAdapter,
+} from '../../src/components/audit/audit-fixture';
+
+const COMPONENT_ROOT = fileURLToPath(
+  new URL('../../src/uni_modules/lucky-ui/components/', import.meta.url)
+);
+const DEMO_ROOT = fileURLToPath(new URL('../../src/components/demos/', import.meta.url));
+const RENDERER_PATH = fileURLToPath(
+  new URL('../../src/components/preview/PreviewDemoRenderer.vue', import.meta.url)
+);
+const FIXTURE_PAGE_PATH = fileURLToPath(
+  new URL('../../src/pages_sub/audit-fixture/index.vue', import.meta.url)
+);
+
+describe('audit fixture contract', () => {
+  it('covers exactly the 73 audited lk-* component directories', () => {
+    const componentDirectories = readdirSync(COMPONENT_ROOT, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() && entry.name.startsWith('lk-'))
+      .map(entry => entry.name.replace(/^lk-/, ''))
+      .sort();
+
+    expect([...AUDIT_COMPONENT_SLUGS].sort()).toEqual(componentDirectories);
+    expect(AUDIT_COMPONENT_SLUGS).toHaveLength(73);
+    expect(new Set(AUDIT_COMPONENT_SLUGS).size).toBe(73);
+    expect(AUDIT_COMPONENT_SLUGS).not.toContain('chart-lite');
+    expect(AUDIT_COMPONENT_SLUGS).not.toContain('transition');
+    expect(parseAuditFixtureQuery({ component: 'preload-debugger' }).config.componentKind).toBe(
+      'internal-debug'
+    );
+  });
+
+  it('keeps the preview registry and renderer branches in exact agreement', () => {
+    const rendererSource = readFileSync(RENDERER_PATH, 'utf8');
+    const rendererSlugs = [...rendererSource.matchAll(/activeSlug === ['"]([^'"]+)['"]/g)].map(
+      match => match[1]
+    );
+    expect(rendererSlugs).toEqual([...PREVIEW_DEMO_SLUGS]);
+    expect(new Set(rendererSlugs).size).toBe(rendererSlugs.length);
+  });
+
+  it('maps every audited component to a concrete preview renderer', () => {
+    const previewSlugs = new Set<string>(PREVIEW_DEMO_SLUGS);
+    for (const component of AUDIT_COMPONENT_SLUGS) {
+      const result = parseAuditFixtureQuery({ component });
+      expect(previewSlugs.has(result.config.previewSlug)).toBe(true);
+    }
+  });
+
+  it('fails closed for every demo that still references a remote resource', () => {
+    const detected = AUDIT_COMPONENT_SLUGS.filter(component => {
+      const previewSlug = component === 'preload-debugger' ? 'preload' : component;
+      const source = readFileSync(`${DEMO_ROOT}/${previewSlug}-demo.vue`, 'utf8');
+      return /https?:\/\//.test(source);
+    });
+
+    expect([...AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS].sort()).toEqual(detected.sort());
+    for (const component of AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS) {
+      const result = parseAuditFixtureQuery({ component });
+      expect(result.errors).toContain(
+        `component=${component} 的现有 demo 含已知直接远程 URL，演练场拒绝渲染`
+      );
+    }
+  });
+
+  it('normalizes a complete shell-baseline query without implying interaction support', () => {
+    const result = parseAuditFixtureQuery({
+      component: 'lk-button',
+      profile: 'render-baseline',
+      scenario: 'none',
+      theme: 'DARK',
+      brand: '#ABCDEF',
+      locale: 'pt-br',
+      motion: 'full',
+      clock: '2026-01-02T03:04:05.000Z',
+      seed: '42',
+      viewport: '430x932',
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.config).toMatchObject({
+      component: 'button',
+      componentKind: 'public',
+      previewSlug: 'button',
+      profile: 'render-baseline',
+      scenario: 'none',
+      interactionCapability: 'none',
+      theme: 'dark',
+      brand: '#abcdef',
+      locale: 'pt-BR',
+      motion: 'full',
+      motionCoverage: 'css-tokens-only',
+      clock: '2026-01-02T03:04:05.000Z',
+      seed: 42,
+      viewport: '430x932',
+      viewportMetric: 'uni-window-css-px',
+      resourcePolicy: 'known-direct-remote-deny',
+      resourceEnforcement: 'direct-demo-literal-scan',
+    });
+  });
+
+  it('fails closed and reports every invalid input', () => {
+    const result = parseAuditFixtureQuery({
+      component: 'missing',
+      profile: 'interactive',
+      scenario: '../bad',
+      theme: 'system',
+      brand: 'red',
+      locale: 'xx',
+      motion: 'sometimes',
+      clock: 'never',
+      seed: '-1',
+      viewport: 'wide',
+    });
+
+    expect(result.errors).toHaveLength(10);
+    expect(result.config).toMatchObject({
+      component: 'button',
+      profile: 'render-baseline',
+      scenario: 'none',
+      interactionCapability: 'none',
+      theme: 'light',
+      brand: '#6965db',
+      locale: 'zh-Hans',
+      motion: 'css-tokens-reduced',
+      seed: 20260813,
+      viewport: '390x844',
+    });
+  });
+
+  it('rejects a named scenario until a component-level adapter exists', () => {
+    const result = parseAuditFixtureQuery({ component: 'button', scenario: 'loading-race' });
+    expect(result.config.scenario).toBe('none');
+    expect(result.errors).toContain('scenario=loading-race 尚未注册组件级适配器');
+  });
+
+  it('serializes and fingerprints equal configs identically', () => {
+    const first = parseAuditFixtureQuery({ component: 'button' }).config;
+    const second = parseAuditFixtureQuery({ component: 'lk-button' }).config;
+    expect(stableAuditConfigJson(first)).toBe(stableAuditConfigJson(second));
+    expect(fingerprintAuditConfig(first)).toBe(fingerprintAuditConfig(second));
+  });
+
+  it('produces reproducible seeded random sequences', () => {
+    const first = createSeededRandom(7);
+    const second = createSeededRandom(7);
+    expect([first(), first(), first()]).toEqual([second(), second(), second()]);
+  });
+
+  it('anchors the wall clock while allowing monotonic time to advance', () => {
+    const originalDate = globalThis.Date;
+    const originalRandom = Math.random;
+    const config = parseAuditFixtureQuery({
+      clock: '2026-01-02T03:04:05.000Z',
+      seed: '7',
+    }).config;
+    const expectedRandom = createSeededRandom(7);
+    let monotonicMs = 100;
+    const restore = installAuditDeterminism(config, () => monotonicMs);
+
+    try {
+      expect(Date.now()).toBe(config.clockMs);
+      monotonicMs += 250;
+      expect(Date.now()).toBe(config.clockMs + 250);
+      expect(new Date().toISOString()).toBe(new originalDate(config.clockMs + 250).toISOString());
+      expect(Date()).toBe(new originalDate(config.clockMs + 250).toString());
+      expect(Math.random()).toBe(expectedRandom());
+    } finally {
+      restore();
+    }
+
+    expect(globalThis.Date).toBe(originalDate);
+    expect(Math.random).toBe(originalRandom);
+  });
+
+  it('never moves the deterministic clock backwards', () => {
+    const config = parseAuditFixtureQuery({ clock: '2026-01-02T03:04:05.000Z' }).config;
+    const readings = [100, 350, 120];
+    const restore = installAuditDeterminism(config, () => readings.shift() ?? 120);
+
+    try {
+      expect(Date.now()).toBe(config.clockMs + 250);
+      expect(Date.now()).toBe(config.clockMs + 250);
+    } finally {
+      restore();
+    }
+  });
+
+  it('fails explicitly when the monotonic clock is not finite', () => {
+    const config = parseAuditFixtureQuery().config;
+    expect(() => installAuditDeterminism(config, () => Number.NaN)).toThrow(
+      'audit-clock:non-finite:NaN'
+    );
+  });
+
+  it('keeps fixture validity distinct from component evidence', () => {
+    const source = readFileSync(FIXTURE_PAGE_PATH, 'utf8');
+    expect(source).toContain(':data-audit-fixture-valid="String(fixtureValid)"');
+    expect(source).not.toContain('data-audit-valid');
+    expect(source).toContain(':data-audit-evidence-ready="String(evidenceReady)"');
+    expect(source).toContain('data-audit-component-status="pending-adapter"');
+    expect(source).toContain(':data-audit-build-mode="buildIdentity.buildMode"');
+    expect(source).toContain(':data-audit-provenance="buildIdentity.provenance"');
+  });
+
+  it('does not overwrite a newer global owner during cleanup', () => {
+    const originalDate = globalThis.Date;
+    const originalRandom = Math.random;
+    const config = parseAuditFixtureQuery().config;
+    const restore = installAuditDeterminism(config, () => 0);
+    const newerDate = class NewerDate extends originalDate {};
+    const newerRandom = () => 0.25;
+    globalThis.Date = newerDate;
+    Math.random = newerRandom;
+
+    try {
+      restore();
+      expect(globalThis.Date).toBe(newerDate);
+      expect(Math.random).toBe(newerRandom);
+    } finally {
+      globalThis.Date = originalDate;
+      Math.random = originalRandom;
+    }
+  });
+
+  it('restores existing and missing storage keys after success', () => {
+    const values = new Map<string, unknown>([['theme', 'dark']]);
+    const storage: AuditStorageAdapter = {
+      listKeys: () => [...values.keys()],
+      get: key => values.get(key),
+      set: (key, value) => values.set(key, value),
+      remove: key => void values.delete(key),
+    };
+
+    applyTemporaryStorageOverlay(storage, { theme: 'light', brand: '#6965db' }, () => {
+      expect(values.get('theme')).toBe('light');
+      expect(values.get('brand')).toBe('#6965db');
+    });
+
+    expect(values.get('theme')).toBe('dark');
+    expect(values.has('brand')).toBe(false);
+  });
+
+  it('restores storage after the environment callback fails', () => {
+    const values = new Map<string, unknown>([['theme', 'dark']]);
+    const storage: AuditStorageAdapter = {
+      listKeys: () => [...values.keys()],
+      get: key => values.get(key),
+      set: (key, value) => values.set(key, value),
+      remove: key => void values.delete(key),
+    };
+
+    expect(() =>
+      applyTemporaryStorageOverlay(storage, { theme: 'light', brand: '#6965db' }, () => {
+        throw new Error('apply-failed');
+      })
+    ).toThrow('storage-overlay:apply:Error: apply-failed');
+    expect(values.get('theme')).toBe('dark');
+    expect(values.has('brand')).toBe(false);
+  });
+
+  it('does not swallow an explicit undefined throw from the environment callback', () => {
+    const values = new Map<string, unknown>([['theme', 'dark']]);
+    const storage: AuditStorageAdapter = {
+      listKeys: () => [...values.keys()],
+      get: key => values.get(key),
+      set: (key, value) => values.set(key, value),
+      remove: key => void values.delete(key),
+    };
+
+    expect(() =>
+      applyTemporaryStorageOverlay(storage, { theme: 'light' }, () => {
+        throw undefined;
+      })
+    ).toThrow('storage-overlay:apply:undefined');
+    expect(values.get('theme')).toBe('dark');
+  });
+
+  it('performs no writes when the complete storage snapshot cannot be read', () => {
+    let writes = 0;
+    const storage: AuditStorageAdapter = {
+      listKeys: () => {
+        throw new Error('snapshot-failed');
+      },
+      get: () => undefined,
+      set: () => {
+        writes += 1;
+      },
+      remove: () => {
+        writes += 1;
+      },
+    };
+
+    expect(() => applyTemporaryStorageOverlay(storage, { theme: 'light' }, () => {})).toThrow(
+      'snapshot-failed'
+    );
+    expect(writes).toBe(0);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,106 @@ import { defineConfig, type Plugin } from "vite";
 import uni from "@dcloudio/vite-plugin-uni";
 import path from 'node:path';
 import fs from 'node:fs';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 
 const LUCKY_UI_H5_PORT = 5188;
+
+interface LuckyUiBuildIdentity {
+  commit: string;
+  branch: string;
+  dirty: boolean;
+  sourceDigest: string;
+  version: string;
+  buildMode: 'static-build' | 'dev-server';
+  provenance: 'git-worktree' | 'unverified';
+  valid: boolean;
+}
+
+function runGitText(args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: __dirname,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function runGitBuffer(args: string[]): Buffer {
+  return execFileSync('git', args, {
+    cwd: __dirname,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function readPackageVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')
+    );
+    return typeof packageJson.version === 'string' ? packageJson.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function resolveBuildIdentity(command: 'build' | 'serve'): LuckyUiBuildIdentity {
+  const environmentCommit = process.env.GITHUB_SHA || process.env.VITE_GIT_COMMIT || '';
+  const environmentBranch = process.env.GITHUB_REF_NAME || process.env.VITE_GIT_BRANCH || '';
+  let commit = environmentCommit.slice(0, 40) || 'unknown';
+  let branch = environmentBranch.slice(0, 160) || 'unknown';
+  let dirty = true;
+  let sourceDigest = process.env.VITE_SOURCE_DIGEST || 'unknown';
+  let provenance: LuckyUiBuildIdentity['provenance'] = 'unverified';
+
+  try {
+    commit = runGitText(['rev-parse', 'HEAD']);
+    branch = environmentBranch.slice(0, 160) || runGitText(['rev-parse', '--abbrev-ref', 'HEAD']);
+    const status = runGitBuffer(['status', '--porcelain=v1', '-z', '--untracked-files=all']);
+    dirty = status.length > 0;
+
+    const hash = crypto.createHash('sha256');
+    hash.update(commit);
+    hash.update('\0');
+    hash.update(branch);
+    hash.update('\0');
+    hash.update(status);
+    hash.update(runGitBuffer(['diff', '--binary', '--no-ext-diff', 'HEAD', '--']));
+
+    const untracked = runGitBuffer(['ls-files', '--others', '--exclude-standard', '-z'])
+      .toString('utf8')
+      .split('\0')
+      .filter(Boolean)
+      .sort();
+    for (const relativePath of untracked) {
+      const filePath = path.resolve(__dirname, relativePath);
+      const insideRepository =
+        filePath === __dirname || filePath.startsWith(`${path.resolve(__dirname)}${path.sep}`);
+      if (!insideRepository) continue;
+      const fileInfo = fs.lstatSync(filePath);
+      if (!fileInfo.isFile() || fileInfo.isSymbolicLink()) continue;
+      hash.update(relativePath.replace(/\\/g, '/'));
+      hash.update('\0');
+      hash.update(fs.readFileSync(filePath));
+      hash.update('\0');
+    }
+    sourceDigest = hash.digest('hex');
+    provenance = 'git-worktree';
+  } catch {
+    // Provenance must remain unverified when any Git or source read fails.
+  }
+
+  const version = readPackageVersion();
+  const buildMode = command === 'build' ? 'static-build' : 'dev-server';
+  const valid =
+    buildMode === 'static-build' &&
+    provenance === 'git-worktree' &&
+    !dirty &&
+    /^[0-9a-f]{40}$/i.test(commit) &&
+    branch !== 'unknown' &&
+    /^[0-9a-f]{64}$/i.test(sourceDigest) &&
+    version !== 'unknown';
+  return { commit, branch, dirty, sourceDigest, version, buildMode, provenance, valid };
+}
 
 const WXSS_CHILD_TAGS = [
   'view',
@@ -131,33 +229,41 @@ function wxssCompatPlugin(): Plugin {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    port: LUCKY_UI_H5_PORT,
-    strictPort: true,
-  },
+export default defineConfig(({ command }) => {
+  const luckyUiBuildIdentity = resolveBuildIdentity(command);
 
-  plugins: [uni(), wxssCompatPlugin()],
+  return {
+    define: {
+      __LUCKY_UI_BUILD_IDENTITY__: JSON.stringify(luckyUiBuildIdentity),
+    },
 
-  worker: {
-    format: 'es',
-  },
+    server: {
+      port: LUCKY_UI_H5_PORT,
+      strictPort: true,
+    },
 
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-        silenceDeprecations: ['legacy-js-api'],
+    plugins: [uni(), wxssCompatPlugin()],
+
+    worker: {
+      format: 'es',
+    },
+
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: 'modern-compiler',
+          silenceDeprecations: ['legacy-js-api'],
+        },
       },
     },
-  },
 
-  resolve: {
-    alias: {
-      // 创建一个名为 @bootstrap-icons 的别名
-      // 它指向 node_modules 中的 bootstrap-icons 文件夹
-      // 这能让我们的 import 路径更清晰且不受文件层级影响
-      '@bootstrap-icons': path.resolve(__dirname, 'node_modules/bootstrap-icons'),
+    resolve: {
+      alias: {
+        // 创建一个名为 @bootstrap-icons 的别名
+        // 它指向 node_modules 中的 bootstrap-icons 文件夹
+        // 这能让我们的 import 路径更清晰且不受文件层级影响
+        '@bootstrap-icons': path.resolve(__dirname, 'node_modules/bootstrap-icons'),
+      },
     },
-  },
+  };
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
     },
   },
   test: {
-    api: false,
+    // Vite 5.2 opens its fallback HMR WebSocket on 24678 even in middleware mode.
+    // A dedicated loopback API server keeps unit runs isolated from unrelated dev servers.
+    api: { host: '127.0.0.1', port: 51204, strictPort: true },
     environment: 'node',
     include: ['tests/unit/**/*.spec.ts'],
   },


### PR DESCRIPTION
## 变更

- 新增覆盖 73 个 `lk-*` 组件目录的审计演练场路由与配置契约。
- 将演练场有效性与组件证据严格分离：当前只允许 `fixture-shell`，组件状态固定为 `pending-adapter`，交互能力固定为 `none`。
- 仅接受干净 Git 工作树生成的一次性静态构建，暴露提交、分支、源码摘要、构建模式和来源。
- 参数、视口、已知直接远程资源、运行时错误与未处理 Promise 全部 fail-closed。
- H5 与微信分别接入全局错误捕获，并按相同监听引用定向卸载。
- 主题和品牌变量只作用于演练场根节点，不读写全局主题 storage；语言在卸载时回滚。
- Vitest 使用独立回环 API 端口，避免 Vite 5.2 固定 HMR 端口与其他项目冲突。

## 验证

- `pnpm run test:unit`：78 个文件、446 个测试通过。
- `pnpm run type-check`：通过。
- `pnpm run lint`：0 error；保留基线已有 13 个 Stylelint warning。
- `pnpm run compat-check:strict`：0 error；保留基线已有 60 个跨端 warning。
- `pnpm run build:h5`：通过。
- `pnpm run build:mp-weixin`：通过。
- H5 Peekit capability level 4：两个全新浏览器会话的壳层 rect/style/attributes/state 完全一致；console 与 runtime errors 均为空；非法 scenario 和已知远程资源均拒绝渲染。
- H5 证据绑定提交 `dad2faebacaaa67974c699a5768ac9cf11b46905`、源码摘要 `2939d5942119a334e00e78fc6583d4c7115e0b1dcb3737a90d6699541bc86cc3`、`dirty=false`。

## 证据边界

本 PR 只完成确定性演练场壳层，不把按钮节点存在或外层点击解释为组件通过。`evidence-ready=false`，尚未建立 73 个组件的专属场景、事件与后置条件适配器。

微信产物已包含 `onError/onUnhandledRejection` 捕获并构建成功，但当前本机微信开发者工具 AUTO 项目窗口仍受审计台账 `AUD-MP-002` 阻断，因此本 PR 不声明微信运行态或任一组件验收通过。

完整静态审计见 #45。