### PR TITLE
feat(audit): add component evidence adapters

### DIFF
--- a/src/components/audit/AuditAdapterRenderer.vue
+++ b/src/components/audit/AuditAdapterRenderer.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import ButtonAuditAdapter from './adapters/ButtonAuditAdapter.vue';
+import type {
+  AuditAdapterErrorPayload,
+  AuditAdapterEventPayload,
+  AuditAdapterReadyPayload,
+  AuditComponentSlug,
+  AuditRuntimePlatform,
+} from './audit-fixture';
+
+defineProps<{
+  component: AuditComponentSlug;
+  fingerprint: string;
+  generation: number;
+  platform: AuditRuntimePlatform;
+}>();
+
+defineEmits<{
+  ready: [payload: AuditAdapterReadyPayload];
+  event: [payload: AuditAdapterEventPayload];
+  error: [payload: AuditAdapterErrorPayload];
+}>();
+</script>
+
+<template>
+  <button-audit-adapter
+    v-if="component === 'button'"
+    :fingerprint="fingerprint"
+    :generation="generation"
+    :platform="platform"
+    @ready="$emit('ready', $event)"
+    @event="$emit('event', $event)"
+    @error="$emit('error', $event)"
+  />
+</template>

--- a/src/components/audit/adapters/ButtonAuditAdapter.vue
+++ b/src/components/audit/adapters/ButtonAuditAdapter.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+import { computed, getCurrentInstance, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
+import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
+import {
+  auditElementRectsEqual,
+  createAuditTargetLocator,
+  normalizeAuditElementRect,
+  type AuditAdapterErrorPayload,
+  type AuditAdapterEventPayload,
+  type AuditAdapterReadyPayload,
+  type AuditElementRect,
+  type AuditRuntimePlatform,
+} from '../audit-fixture';
+
+const props = defineProps<{
+  fingerprint: string;
+  generation: number;
+  platform: AuditRuntimePlatform;
+}>();
+
+const emit = defineEmits<{
+  ready: [payload: AuditAdapterReadyPayload];
+  event: [payload: AuditAdapterEventPayload];
+  error: [payload: AuditAdapterErrorPayload];
+}>();
+
+const TARGET_SELECTOR = '#audit-button-target';
+const MAX_PROBE_ATTEMPTS = 90;
+const PROBE_INTERVAL_MS = 16;
+const QUERY_CALLBACK_TIMEOUT_MS = 250;
+const instance = getCurrentInstance();
+const adapterFingerprint = props.fingerprint;
+const adapterGeneration = props.generation;
+const adapterPlatform = props.platform;
+const clickCount = ref(0);
+const targetLocator = createAuditTargetLocator(adapterPlatform, TARGET_SELECTOR);
+const state = computed(() => ({
+  enabled: true,
+  clickCount: clickCount.value,
+}));
+const stateJson = computed(() => JSON.stringify(state.value));
+let active = true;
+let readyEmitted = false;
+let failureEmitted = false;
+let probeAttempts = 0;
+let stableReads = 0;
+let previousRect: AuditElementRect | null = null;
+let probeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function envelope() {
+  return {
+    component: 'button' as const,
+    fingerprint: adapterFingerprint,
+    generation: adapterGeneration,
+  };
+}
+
+function fail(message: string) {
+  if (!active || failureEmitted || readyEmitted) return;
+  failureEmitted = true;
+  emit('error', { ...envelope(), message });
+}
+
+function queryTargetRect(): Promise<AuditElementRect | null> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (result: AuditElementRect | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(callbackTimer);
+      resolve(result);
+    };
+    const failQuery = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(callbackTimer);
+      reject(error);
+    };
+    const callbackTimer = setTimeout(() => finish(null), QUERY_CALLBACK_TIMEOUT_MS);
+
+    try {
+      const query = uni.createSelectorQuery();
+      if (adapterPlatform === 'mp-weixin' && !instance?.proxy) {
+        failQuery(new Error('mp-selector-scope-unavailable'));
+        return;
+      }
+      if (adapterPlatform === 'unknown') {
+        failQuery(new Error('runtime-platform-unsupported'));
+        return;
+      }
+      const targetQuery = adapterPlatform === 'mp-weixin' ? query.in(instance!.proxy!) : query;
+      targetQuery
+        .selectAll(TARGET_SELECTOR)
+        .boundingClientRect(result => {
+          const matches = Array.isArray(result) ? result : [];
+          finish(matches.length === 1 ? normalizeAuditElementRect(matches[0]) : null);
+        })
+        .exec();
+    } catch (error) {
+      failQuery(error);
+    }
+  });
+}
+
+function scheduleProbe() {
+  if (!active || readyEmitted || failureEmitted) return;
+  probeTimer = setTimeout(runProbe, PROBE_INTERVAL_MS);
+}
+
+async function runProbe() {
+  probeTimer = null;
+  if (!active || readyEmitted || failureEmitted) return;
+  probeAttempts += 1;
+  try {
+    const rect = await queryTargetRect();
+    if (!active) return;
+    if (rect && auditElementRectsEqual(previousRect, rect)) stableReads += 1;
+    else stableReads = rect ? 1 : 0;
+    previousRect = rect;
+    if (rect && stableReads >= 2) {
+      const locator = targetLocator;
+      if (!locator) {
+        fail('runtime-platform-unsupported');
+        return;
+      }
+      readyEmitted = true;
+      emit('ready', {
+        ...envelope(),
+        targetLocator: locator,
+        rect,
+        state: { ...state.value },
+      });
+      return;
+    }
+    if (probeAttempts >= MAX_PROBE_ATTEMPTS) {
+      fail(`target-not-stable:${TARGET_SELECTOR}:attempts=${probeAttempts}`);
+      return;
+    }
+    scheduleProbe();
+  } catch (error) {
+    fail(`target-query:${String(error)}`);
+  }
+}
+
+function handleClick() {
+  if (targetLocator?.interactionCapability !== 'tap') return;
+  clickCount.value += 1;
+  const payload: AuditAdapterEventPayload = {
+    ...envelope(),
+    name: 'click',
+    detail: { ...state.value },
+  };
+  emit('event', payload);
+}
+
+onMounted(async () => {
+  await nextTick();
+  if (active) void runProbe();
+});
+
+onBeforeUnmount(() => {
+  active = false;
+  if (probeTimer !== null) clearTimeout(probeTimer);
+  probeTimer = null;
+});
+</script>
+
+<template>
+  <view
+    id="audit-button-adapter"
+    class="audit-component-evidence"
+    data-audit-adapter="button"
+    :data-audit-generation="String(adapterGeneration)"
+    :data-audit-click-count="String(clickCount)"
+    :data-audit-locator-kind="targetLocator?.kind || 'unavailable'"
+    :data-audit-locator-scope="targetLocator?.scope || 'unavailable'"
+    :data-audit-locator-interaction="targetLocator?.interactionCapability || 'none'"
+  >
+    <lk-button id="audit-button-target" :ripple="false" @click="handleClick">
+      确定性按钮
+    </lk-button>
+    <text class="audit-component-evidence__state">{{ stateJson }}</text>
+  </view>
+</template>
+
+<style scoped lang="scss">
+.audit-component-evidence {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.audit-component-evidence__state {
+  display: block;
+  margin-top: 16rpx;
+  color: var(--lk-text-secondary);
+  font-family: monospace;
+  font-size: 20rpx;
+  line-height: 1.4;
+}
+</style>

--- a/src/components/audit/audit-fixture.ts
+++ b/src/components/audit/audit-fixture.ts
@@ -80,8 +80,112 @@ export type AuditMotion = 'full' | 'css-tokens-reduced';
 export type AuditProfile = 'render-baseline';
 export type AuditScenario = 'none';
 export type AuditComponentKind = 'public' | 'internal-debug';
-export type AuditInteractionCapability = 'none';
+export type AuditInteractionCapability = 'none' | 'tap';
 export type AuditMotionCoverage = 'css-tokens-only';
+export type AuditComponentStatus = 'pending-adapter' | 'booting' | 'ready' | 'failed';
+export type AuditEvidenceScope = 'fixture-shell' | 'component';
+export type AuditRuntimePlatform = 'h5' | 'mp-weixin' | 'unknown';
+export type AuditEvidenceSessionStatus = 'idle' | 'booting' | 'ready' | 'failed';
+export type AuditJsonPrimitive = string | number | boolean | null;
+export type AuditJsonValue = AuditJsonPrimitive | AuditJsonValue[] | AuditJsonObject;
+export interface AuditJsonObject {
+  readonly [key: string]: AuditJsonValue;
+}
+
+export interface AuditElementRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface AuditAdapterEnvelope {
+  component: AuditComponentSlug;
+  fingerprint: string;
+  generation: number;
+}
+
+export interface AuditH5TargetLocator {
+  kind: 'page-selector';
+  platform: 'h5';
+  scope: 'page';
+  selector: string;
+  measurement: 'page-selector-query';
+  interactionCapability: 'tap';
+}
+
+export interface AuditMpTargetLocator {
+  kind: 'scoped-render';
+  platform: 'mp-weixin';
+  scope: 'adapter-component';
+  selector: string;
+  measurement: 'component-scoped-selector-query';
+  interactionCapability: 'none';
+}
+
+export type AuditTargetLocator = AuditH5TargetLocator | AuditMpTargetLocator;
+
+export interface AuditAdapterReadyPayload extends AuditAdapterEnvelope {
+  targetLocator: AuditTargetLocator;
+  rect: AuditElementRect;
+  state: Readonly<Record<string, unknown>>;
+}
+
+export interface AuditAdapterEventPayload extends AuditAdapterEnvelope {
+  name: string;
+  detail: Readonly<Record<string, unknown>>;
+}
+
+export interface AuditAdapterErrorPayload extends AuditAdapterEnvelope {
+  message: string;
+}
+
+export interface AuditEvidenceHistoryEntry {
+  sequence: number;
+  generation: number;
+  name: string;
+  /** reducer ingress 已验证并复制为 JSON-safe 值；保留 unknown 避免 Vue 深层解包递归类型。 */
+  detail?: unknown;
+}
+
+export interface AuditEvidenceFailure {
+  kind: 'viewport' | 'terminal';
+  reason: string;
+  generation: number;
+}
+
+export interface AuditEvidenceSessionState {
+  component: AuditComponentSlug;
+  fingerprint: string;
+  platform: AuditRuntimePlatform;
+  generation: number;
+  viewportValid: boolean;
+  status: AuditEvidenceSessionStatus;
+  evidence: AuditAdapterReadyPayload | null;
+  targetLocator: AuditTargetLocator | null;
+  activeInteractionCapability: AuditInteractionCapability;
+  failure: AuditEvidenceFailure | null;
+  history: AuditEvidenceHistoryEntry[];
+}
+
+export type AuditEvidenceSessionAction =
+  | { type: 'viewport'; valid: boolean; reason?: string }
+  | { type: 'adapter-ready'; payload: AuditAdapterReadyPayload }
+  | { type: 'adapter-event'; payload: AuditAdapterEventPayload }
+  | { type: 'adapter-error'; payload: AuditAdapterErrorPayload }
+  | { type: 'runtime-error'; message: string }
+  | { type: 'note'; name: string; detail?: unknown };
+
+export const AUDIT_ADAPTED_COMPONENT_SLUGS = [
+  'button',
+] as const satisfies readonly AuditComponentSlug[];
+
+const AUDIT_ADAPTER_CAPABILITIES = {
+  button: 'tap',
+} as const satisfies Record<
+  (typeof AUDIT_ADAPTED_COMPONENT_SLUGS)[number],
+  AuditInteractionCapability
+>;
 
 export const AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS = [
   'anchor',
@@ -153,6 +257,7 @@ interface AuditStorageSnapshot {
 }
 
 const COMPONENT_SET = new Set<string>(AUDIT_COMPONENT_SLUGS);
+const ADAPTED_COMPONENT_SET = new Set<string>(AUDIT_ADAPTED_COMPONENT_SLUGS);
 const REMOTE_RESOURCE_COMPONENT_SET = new Set<string>(AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS);
 const SUPPORTED_LOCALES = ['zh-Hans', 'zh-Hant', 'en', 'ja', 'ko', 'fr', 'es', 'pt-BR'] as const;
 const LOCALE_MAP = new Map(SUPPORTED_LOCALES.map(locale => [locale.toLowerCase(), locale]));
@@ -161,6 +266,12 @@ const DEFAULT_VIEWPORT = '390x844';
 const BRAND_PATTERN = /^#[0-9a-f]{6}$/i;
 const VIEWPORT_PATTERN = /^(\d{3,4})x(\d{3,4})$/;
 const CANONICAL_UTC_CLOCK_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const AUDIT_JSON_MAX_DEPTH = 32;
+const AUDIT_JSON_MAX_NODES = 10000;
+const AUDIT_JSON_MAX_STRING_LENGTH = 16384;
+const AUDIT_JSON_MAX_KEY_LENGTH = 256;
+const AUDIT_JSON_MAX_TOTAL_CHARACTERS = 65536;
+const AUDIT_HISTORY_MAX_ENTRIES = 512;
 
 function normalizeComponent(value: string | undefined): string {
   return (value || 'button').trim().toLowerCase().replace(/^lk-/, '');
@@ -185,6 +296,678 @@ function getPreviewSlug(component: AuditComponentSlug): string {
 
 function getComponentKind(component: AuditComponentSlug): AuditComponentKind {
   return component === 'preload-debugger' ? 'internal-debug' : 'public';
+}
+
+export function hasAuditComponentAdapter(
+  component: AuditComponentSlug
+): component is (typeof AUDIT_ADAPTED_COMPONENT_SLUGS)[number] {
+  return ADAPTED_COMPONENT_SET.has(component);
+}
+
+export function getAuditInteractionCapability(
+  component: AuditComponentSlug
+): AuditInteractionCapability {
+  return hasAuditComponentAdapter(component) ? AUDIT_ADAPTER_CAPABILITIES[component] : 'none';
+}
+
+function roundAuditMetric(value: number): number {
+  const rounded = Math.round(value * 1000) / 1000;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+export function normalizeAuditElementRect(value: unknown): AuditElementRect | null {
+  const inspected = readAuditIngressData(value, ['left', 'top', 'width', 'height'], 'element-rect');
+  if (inspected.error) return null;
+  const candidate = inspected.value!;
+  const metrics = [candidate.left, candidate.top, candidate.width, candidate.height];
+  if (!metrics.every(metric => typeof metric === 'number' && Number.isFinite(metric))) return null;
+  if ((candidate.width as number) <= 0 || (candidate.height as number) <= 0) return null;
+  const normalized = {
+    left: roundAuditMetric(candidate.left as number),
+    top: roundAuditMetric(candidate.top as number),
+    width: roundAuditMetric(candidate.width as number),
+    height: roundAuditMetric(candidate.height as number),
+  };
+  const normalizedMetrics = [normalized.left, normalized.top, normalized.width, normalized.height];
+  if (!normalizedMetrics.every(Number.isFinite)) return null;
+  if (normalized.width <= 0 || normalized.height <= 0) return null;
+  return normalized;
+}
+
+interface AuditJsonNormalizationResult {
+  value?: AuditJsonValue;
+  error?: string;
+}
+
+/**
+ * 将跨组件证据复制为有界、无环且不会被 JSON.stringify 静默改写的 JSON 值。
+ */
+export function normalizeAuditJsonValue(value: unknown): AuditJsonNormalizationResult {
+  const ancestors = new WeakSet<object>();
+  let nodes = 0;
+  let characters = 0;
+
+  function consumeCharacters(
+    candidate: string,
+    path: string,
+    kind: 'string' | 'key'
+  ): string | null {
+    const limit = kind === 'string' ? AUDIT_JSON_MAX_STRING_LENGTH : AUDIT_JSON_MAX_KEY_LENGTH;
+    if (candidate.length > limit) return `${path}:${kind}-too-long`;
+    characters += candidate.length;
+    return characters > AUDIT_JSON_MAX_TOTAL_CHARACTERS ? `${path}:character-limit` : null;
+  }
+
+  function visit(candidate: unknown, path: string, depth: number): AuditJsonNormalizationResult {
+    nodes += 1;
+    if (nodes > AUDIT_JSON_MAX_NODES) return { error: `${path}:node-limit` };
+    if (depth > AUDIT_JSON_MAX_DEPTH) return { error: `${path}:depth-limit` };
+    if (candidate === null || typeof candidate === 'boolean') {
+      return { value: candidate };
+    }
+    if (typeof candidate === 'string') {
+      const error = consumeCharacters(candidate, path, 'string');
+      return error ? { error } : { value: candidate };
+    }
+    if (typeof candidate === 'number') {
+      return Number.isFinite(candidate)
+        ? { value: Object.is(candidate, -0) ? 0 : candidate }
+        : { error: `${path}:number-not-finite` };
+    }
+    if (typeof candidate !== 'object') return { error: `${path}:type-${typeof candidate}` };
+    if (ancestors.has(candidate)) return { error: `${path}:cycle` };
+    ancestors.add(candidate);
+    try {
+      if (Object.getOwnPropertySymbols(candidate).length > 0) {
+        return { error: `${path}:symbol-key` };
+      }
+      if (Array.isArray(candidate)) {
+        if (Object.getPrototypeOf(candidate) !== Array.prototype) {
+          return { error: `${path}:non-standard-array` };
+        }
+        const lengthDescriptor = Object.getOwnPropertyDescriptor(candidate, 'length');
+        if (
+          !lengthDescriptor ||
+          !('value' in lengthDescriptor) ||
+          !Number.isSafeInteger(lengthDescriptor.value) ||
+          lengthDescriptor.value < 0
+        ) {
+          return { error: `${path}:array-length-invalid` };
+        }
+        const length = lengthDescriptor.value;
+        if (length > AUDIT_JSON_MAX_NODES - nodes) return { error: `${path}:node-limit` };
+        const ownNames = Object.getOwnPropertyNames(candidate);
+        if (ownNames.length !== length + 1 || !ownNames.includes('length')) {
+          return { error: `${path}:array-extra-key-or-hole` };
+        }
+        const result: AuditJsonValue[] = [];
+        for (let index = 0; index < length; index += 1) {
+          const descriptor = Object.getOwnPropertyDescriptor(candidate, String(index));
+          if (!descriptor) {
+            return { error: `${path}[${index}]:array-hole` };
+          }
+          if (!('value' in descriptor)) {
+            return { error: `${path}[${index}]:accessor` };
+          }
+          const normalized = visit(descriptor.value, `${path}[${index}]`, depth + 1);
+          if (normalized.error) return normalized;
+          result.push(normalized.value!);
+        }
+        return { value: result };
+      }
+
+      const prototype = Object.getPrototypeOf(candidate);
+      if (prototype !== Object.prototype && prototype !== null) {
+        return { error: `${path}:non-plain-object` };
+      }
+      const ownNames = Object.getOwnPropertyNames(candidate);
+      const enumerableKeys = Object.keys(candidate);
+      if (ownNames.length !== enumerableKeys.length) {
+        return { error: `${path}:non-enumerable-key` };
+      }
+      const result: Record<string, AuditJsonValue> = {};
+      for (const key of enumerableKeys) {
+        const keyError = consumeCharacters(key, path, 'key');
+        if (keyError) return { error: keyError };
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (!descriptor || !('value' in descriptor)) {
+          return { error: `${path}.${key}:accessor` };
+        }
+        const normalized = visit(descriptor.value, `${path}.${key}`, depth + 1);
+        if (normalized.error) return normalized;
+        Object.defineProperty(result, key, {
+          value: normalized.value!,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+      return { value: result };
+    } catch {
+      return { error: `${path}:inspection-failed` };
+    } finally {
+      ancestors.delete(candidate);
+    }
+  }
+
+  return visit(value, '$', 0);
+}
+
+function normalizeAuditJsonObject(
+  value: unknown,
+  field: string
+): { value?: AuditJsonObject; error?: string } {
+  const normalized = normalizeAuditJsonValue(value);
+  if (normalized.error) return { error: `${field}:${normalized.error}` };
+  if (
+    !normalized.value ||
+    typeof normalized.value !== 'object' ||
+    Array.isArray(normalized.value)
+  ) {
+    return { error: `${field}:must-be-object` };
+  }
+  return { value: normalized.value };
+}
+
+export function auditElementRectsEqual(
+  first: AuditElementRect | null,
+  second: AuditElementRect | null
+): boolean {
+  return Boolean(
+    first &&
+      second &&
+      first.left === second.left &&
+      first.top === second.top &&
+      first.width === second.width &&
+      first.height === second.height
+  );
+}
+
+export function createAuditTargetLocator(
+  platform: AuditRuntimePlatform,
+  selector: string
+): AuditTargetLocator | null {
+  if (platform === 'h5') {
+    return {
+      kind: 'page-selector',
+      platform,
+      scope: 'page',
+      selector,
+      measurement: 'page-selector-query',
+      interactionCapability: 'tap',
+    };
+  }
+  if (platform === 'mp-weixin') {
+    return {
+      kind: 'scoped-render',
+      platform,
+      scope: 'adapter-component',
+      selector,
+      measurement: 'component-scoped-selector-query',
+      interactionCapability: 'none',
+    };
+  }
+  return null;
+}
+
+export function createAuditEvidenceSession(options: {
+  component: AuditComponentSlug;
+  fingerprint: string;
+  platform: AuditRuntimePlatform;
+  initialGeneration?: number;
+}): AuditEvidenceSessionState {
+  return {
+    component: options.component,
+    fingerprint: options.fingerprint,
+    platform: options.platform,
+    generation: options.initialGeneration ?? 0,
+    viewportValid: false,
+    status: 'idle',
+    evidence: null,
+    targetLocator: null,
+    activeInteractionCapability: 'none',
+    failure: null,
+    history: [],
+  };
+}
+
+function appendAuditEvidenceHistory(
+  state: AuditEvidenceSessionState,
+  entries: Array<Omit<AuditEvidenceHistoryEntry, 'sequence'>>
+): AuditEvidenceHistoryEntry[] {
+  let sequence = state.history.at(-1)?.sequence ?? 0;
+  const history = [
+    ...state.history,
+    ...entries.map(entry => ({
+      ...entry,
+      sequence: (sequence += 1),
+    })),
+  ];
+  return history.length > AUDIT_HISTORY_MAX_ENTRIES
+    ? history.slice(-AUDIT_HISTORY_MAX_ENTRIES)
+    : history;
+}
+
+function failAuditEvidenceSession(
+  state: AuditEvidenceSessionState,
+  kind: AuditEvidenceFailure['kind'],
+  reason: string
+): AuditEvidenceSessionState {
+  const revokedGeneration = state.generation;
+  const shouldRevoke = state.status === 'booting' || state.status === 'ready';
+  const entries: Array<Omit<AuditEvidenceHistoryEntry, 'sequence'>> = [];
+  if (shouldRevoke) {
+    entries.push({
+      generation: revokedGeneration,
+      name: 'component-revoked',
+      detail: { reason, hadEvidence: state.evidence !== null },
+    });
+  }
+  entries.push({
+    generation: revokedGeneration,
+    name: 'component-failed',
+    detail: { kind, reason },
+  });
+  return {
+    ...state,
+    generation: shouldRevoke ? revokedGeneration + 1 : revokedGeneration,
+    status: 'failed',
+    evidence: null,
+    targetLocator: null,
+    activeInteractionCapability: 'none',
+    failure: { kind, reason, generation: revokedGeneration },
+    history: appendAuditEvidenceHistory(state, entries),
+  };
+}
+
+function recordStaleEnvelope(
+  state: AuditEvidenceSessionState,
+  envelope: AuditAdapterEnvelope,
+  envelopeType: 'ready' | 'event' | 'error'
+): AuditEvidenceSessionState {
+  return {
+    ...state,
+    history: appendAuditEvidenceHistory(state, [
+      {
+        generation: state.generation,
+        name: 'component-stale-ignored',
+        detail: {
+          envelopeType,
+          staleGeneration: envelope.generation,
+          currentGeneration: state.generation,
+        },
+      },
+    ]),
+  };
+}
+
+function validateAuditAdapterEnvelope(
+  state: AuditEvidenceSessionState,
+  envelope: AuditAdapterEnvelope
+): string | null {
+  if (envelope.component !== state.component) {
+    return `component-mismatch:expected=${state.component},actual=${envelope.component}`;
+  }
+  if (envelope.fingerprint !== state.fingerprint) {
+    return `fingerprint-mismatch:expected=${state.fingerprint},actual=${envelope.fingerprint}`;
+  }
+  return null;
+}
+
+function readAuditIngressData(
+  value: unknown,
+  fields: readonly string[],
+  label: string
+): { value?: Record<string, unknown>; error?: string } {
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { error: `${label}-malformed` };
+    }
+    const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    for (const field of fields) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, field);
+      if (!descriptor) return { error: `${label}-${field}-missing` };
+      if (!('value' in descriptor)) return { error: `${label}-${field}-accessor` };
+      result[field] = descriptor.value;
+    }
+    return { value: result };
+  } catch {
+    return { error: `${label}-inspection-failed` };
+  }
+}
+
+function formatAuditDiagnosticValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'undefined') {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return value.length <= AUDIT_JSON_MAX_KEY_LENGTH ? value : 'string-too-long';
+  }
+  if (typeof value === 'bigint') return 'bigint';
+  if (typeof value === 'symbol') return 'symbol';
+  if (typeof value === 'function') return 'function';
+  return 'object';
+}
+
+function normalizeAuditTargetLocator(
+  platform: AuditRuntimePlatform,
+  value: unknown
+): { value?: AuditTargetLocator; error?: string } {
+  if (!value || typeof value !== 'object') {
+    return { error: 'target-locator-malformed' };
+  }
+  try {
+    if (Array.isArray(value)) return { error: 'target-locator-malformed' };
+  } catch {
+    return { error: 'target-locator-inspection-failed' };
+  }
+  const normalized = normalizeAuditJsonObject(value, 'target-locator');
+  if (normalized.error) return { error: normalized.error };
+  const locator = normalized.value!;
+  const expectedKeys = [
+    'interactionCapability',
+    'kind',
+    'measurement',
+    'platform',
+    'scope',
+    'selector',
+  ];
+  if (Object.keys(locator).sort().join('|') !== expectedKeys.join('|')) {
+    return { error: 'target-locator-fields-invalid' };
+  }
+  if (typeof locator.selector !== 'string' || locator.selector.trim() === '') {
+    return { error: 'target-locator-selector-empty' };
+  }
+  if (platform === 'h5') {
+    return locator.platform === 'h5' &&
+      locator.kind === 'page-selector' &&
+      locator.scope === 'page' &&
+      locator.measurement === 'page-selector-query' &&
+      locator.interactionCapability === 'tap'
+      ? {
+          value: {
+            kind: 'page-selector',
+            platform: 'h5',
+            scope: 'page',
+            selector: locator.selector,
+            measurement: 'page-selector-query',
+            interactionCapability: 'tap',
+          },
+        }
+      : { error: 'h5-locator-must-be-page-tappable' };
+  }
+  if (platform === 'mp-weixin') {
+    return locator.platform === 'mp-weixin' &&
+      locator.kind === 'scoped-render' &&
+      locator.scope === 'adapter-component' &&
+      locator.measurement === 'component-scoped-selector-query' &&
+      locator.interactionCapability === 'none'
+      ? {
+          value: {
+            kind: 'scoped-render',
+            platform: 'mp-weixin',
+            scope: 'adapter-component',
+            selector: locator.selector,
+            measurement: 'component-scoped-selector-query',
+            interactionCapability: 'none',
+          },
+        }
+      : { error: 'mp-locator-must-be-scoped-noninteractive' };
+  }
+  return { error: 'runtime-platform-unsupported' };
+}
+
+export function reduceAuditEvidenceSession(
+  state: AuditEvidenceSessionState,
+  action: AuditEvidenceSessionAction
+): AuditEvidenceSessionState {
+  if (state.failure?.kind === 'terminal') {
+    return action.type === 'viewport' ? { ...state, viewportValid: action.valid } : state;
+  }
+  if (state.history.length >= AUDIT_HISTORY_MAX_ENTRIES - 2) {
+    return failAuditEvidenceSession(state, 'terminal', 'history-entry-limit');
+  }
+  if (action.type === 'note') {
+    if (
+      typeof action.name !== 'string' ||
+      action.name.trim() === '' ||
+      action.name.length > AUDIT_JSON_MAX_KEY_LENGTH
+    ) {
+      return failAuditEvidenceSession(state, 'terminal', 'note-name-invalid');
+    }
+    const normalizedDetail =
+      action.detail === undefined ? undefined : normalizeAuditJsonValue(action.detail);
+    if (normalizedDetail?.error) {
+      return failAuditEvidenceSession(state, 'terminal', `note-detail:${normalizedDetail.error}`);
+    }
+    return {
+      ...state,
+      history: appendAuditEvidenceHistory(state, [
+        { generation: state.generation, name: action.name, detail: normalizedDetail?.value },
+      ]),
+    };
+  }
+
+  if (action.type === 'viewport') {
+    if (!action.valid) {
+      if (!state.viewportValid && state.failure?.kind === 'viewport') return state;
+      const failed = failAuditEvidenceSession(
+        state,
+        'viewport',
+        action.reason || 'viewport-mismatch'
+      );
+      return { ...failed, viewportValid: false };
+    }
+
+    if (state.viewportValid && (state.status === 'booting' || state.status === 'ready')) {
+      return state;
+    }
+
+    const generation = state.generation === 0 ? 1 : state.generation;
+    const nextState: AuditEvidenceSessionState = {
+      ...state,
+      generation,
+      viewportValid: true,
+      status: 'booting',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: null,
+    };
+    return {
+      ...nextState,
+      history: appendAuditEvidenceHistory(state, [
+        { generation, name: 'component-generation-started' },
+      ]),
+    };
+  }
+
+  if (action.type === 'runtime-error') {
+    if (
+      typeof action.message !== 'string' ||
+      action.message.length > AUDIT_JSON_MAX_STRING_LENGTH
+    ) {
+      return failAuditEvidenceSession(state, 'terminal', 'runtime-message-invalid');
+    }
+    return failAuditEvidenceSession(state, 'terminal', `runtime:${action.message}`);
+  }
+
+  const ingressEnvelope = readAuditIngressData(
+    action.payload,
+    ['component', 'fingerprint', 'generation'],
+    'adapter-envelope'
+  );
+  if (ingressEnvelope.error) {
+    return failAuditEvidenceSession(state, 'terminal', ingressEnvelope.error);
+  }
+  const component = ingressEnvelope.value!.component;
+  const fingerprint = ingressEnvelope.value!.fingerprint;
+  const generation = ingressEnvelope.value!.generation;
+  if (typeof component !== 'string' || component.length > AUDIT_JSON_MAX_KEY_LENGTH) {
+    return failAuditEvidenceSession(state, 'terminal', 'adapter-envelope-component-invalid');
+  }
+  if (typeof fingerprint !== 'string' || fingerprint.length > AUDIT_JSON_MAX_STRING_LENGTH) {
+    return failAuditEvidenceSession(state, 'terminal', 'adapter-envelope-fingerprint-invalid');
+  }
+  const envelope: AuditAdapterEnvelope = {
+    component: component as AuditComponentSlug,
+    fingerprint,
+    generation: typeof generation === 'number' ? generation : Number.NaN,
+  };
+  const envelopeType =
+    action.type === 'adapter-ready' ? 'ready' : action.type === 'adapter-event' ? 'event' : 'error';
+  if (typeof generation !== 'number' || !Number.isSafeInteger(generation) || generation <= 0) {
+    return failAuditEvidenceSession(
+      state,
+      'terminal',
+      `generation-invalid:${formatAuditDiagnosticValue(generation)}`
+    );
+  }
+  if (envelope.generation < state.generation) {
+    return recordStaleEnvelope(state, envelope, envelopeType);
+  }
+  if (envelope.generation > state.generation) {
+    return failAuditEvidenceSession(
+      state,
+      'terminal',
+      `generation-ahead:expected=${state.generation},actual=${envelope.generation}`
+    );
+  }
+
+  const envelopeError = validateAuditAdapterEnvelope(state, envelope);
+  if (envelopeError) return failAuditEvidenceSession(state, 'terminal', envelopeError);
+
+  if (action.type === 'adapter-error') {
+    const errorPayload = readAuditIngressData(action.payload, ['message'], 'adapter-error');
+    if (errorPayload.error) {
+      return failAuditEvidenceSession(state, 'terminal', errorPayload.error);
+    }
+    const message = errorPayload.value!.message;
+    if (typeof message !== 'string' || message.length > AUDIT_JSON_MAX_STRING_LENGTH) {
+      return failAuditEvidenceSession(state, 'terminal', 'adapter-error-message-invalid');
+    }
+    return failAuditEvidenceSession(
+      state,
+      'terminal',
+      `adapter-error:${envelope.component}:${message}`
+    );
+  }
+
+  if (action.type === 'adapter-ready') {
+    if (state.status === 'ready') {
+      return failAuditEvidenceSession(state, 'terminal', `duplicate-ready:${envelope.component}`);
+    }
+    if (!state.viewportValid || state.status !== 'booting') {
+      return failAuditEvidenceSession(
+        state,
+        'terminal',
+        `ready-outside-booting:${envelope.component}`
+      );
+    }
+    const readyPayload = readAuditIngressData(
+      action.payload,
+      ['targetLocator', 'rect', 'state'],
+      'adapter-ready'
+    );
+    if (readyPayload.error) {
+      return failAuditEvidenceSession(state, 'terminal', readyPayload.error);
+    }
+    const normalizedLocator = normalizeAuditTargetLocator(
+      state.platform,
+      readyPayload.value!.targetLocator
+    );
+    if (normalizedLocator.error) {
+      return failAuditEvidenceSession(state, 'terminal', normalizedLocator.error);
+    }
+    const rect = normalizeAuditElementRect(readyPayload.value!.rect);
+    if (!rect) return failAuditEvidenceSession(state, 'terminal', 'ready-rect-invalid');
+    const normalizedState = normalizeAuditJsonObject(readyPayload.value!.state, 'ready-state');
+    if (normalizedState.error) {
+      return failAuditEvidenceSession(state, 'terminal', normalizedState.error);
+    }
+    const targetLocator = normalizedLocator.value!;
+    const evidence: AuditAdapterReadyPayload = {
+      component: state.component,
+      fingerprint: state.fingerprint,
+      generation: state.generation,
+      targetLocator,
+      rect,
+      state: normalizedState.value!,
+    };
+    return {
+      ...state,
+      status: 'ready',
+      evidence,
+      targetLocator,
+      activeInteractionCapability: targetLocator.interactionCapability,
+      failure: null,
+      history: appendAuditEvidenceHistory(state, [
+        {
+          generation: state.generation,
+          name: 'component-ready',
+          detail: {
+            component: envelope.component,
+            targetLocator,
+            rect,
+            state: normalizedState.value!,
+          },
+        },
+      ]),
+    };
+  }
+
+  const eventPayload = readAuditIngressData(action.payload, ['name', 'detail'], 'adapter-event');
+  if (eventPayload.error) {
+    return failAuditEvidenceSession(state, 'terminal', eventPayload.error);
+  }
+  const eventName = eventPayload.value!.name;
+  if (
+    typeof eventName !== 'string' ||
+    eventName.trim() === '' ||
+    eventName.length > AUDIT_JSON_MAX_KEY_LENGTH
+  ) {
+    return failAuditEvidenceSession(state, 'terminal', 'event-name-invalid');
+  }
+  if (state.status !== 'ready' || !state.evidence) {
+    return failAuditEvidenceSession(
+      state,
+      'terminal',
+      `event-before-ready:${envelope.component}:${eventName}`
+    );
+  }
+  if (state.activeInteractionCapability !== 'tap') {
+    return failAuditEvidenceSession(
+      state,
+      'terminal',
+      `interaction-not-supported:${state.platform}:${eventName}`
+    );
+  }
+  const normalizedDetail = normalizeAuditJsonObject(eventPayload.value!.detail, 'event-detail');
+  if (normalizedDetail.error) {
+    return failAuditEvidenceSession(state, 'terminal', normalizedDetail.error);
+  }
+  return {
+    ...state,
+    history: appendAuditEvidenceHistory(state, [
+      {
+        generation: state.generation,
+        name: `component:${envelope.component}:${eventName}`,
+        detail: normalizedDetail.value!,
+      },
+    ]),
+  };
+}
+
+export function getCurrentAuditComponentEvents(
+  state: AuditEvidenceSessionState | null,
+  evidenceReady: boolean
+): AuditEvidenceHistoryEntry[] {
+  if (!evidenceReady || !state || state.status !== 'ready' || !state.evidence) return [];
+  const eventPrefix = `component:${state.component}:`;
+  return state.history.filter(
+    entry => entry.generation === state.generation && entry.name.startsWith(eventPrefix)
+  );
 }
 
 export function stableAuditConfigJson(config: AuditFixtureConfig): string {
@@ -317,7 +1100,7 @@ export function parseAuditFixtureQuery(query: AuditFixtureQuery = {}): AuditFixt
     previewSlug: getPreviewSlug(component),
     profile: 'render-baseline',
     scenario: 'none',
-    interactionCapability: 'none',
+    interactionCapability: getAuditInteractionCapability(component),
     theme,
     brand,
     locale,

--- a/src/pages_sub/audit-fixture/index.vue
+++ b/src/pages_sub/audit-fixture/index.vue
@@ -1,22 +1,29 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, ref } from 'vue';
 import { onLoad, onUnload } from '@dcloudio/uni-app';
+import AuditAdapterRenderer from '@/components/audit/AuditAdapterRenderer.vue';
 import PreviewDemoRenderer from '@/components/preview/PreviewDemoRenderer.vue';
 import {
+  createAuditEvidenceSession,
+  getCurrentAuditComponentEvents,
+  hasAuditComponentAdapter,
   installAuditDeterminism,
   parseAuditFixtureQuery,
+  reduceAuditEvidenceSession,
   stableAuditConfigJson,
+  type AuditAdapterErrorPayload,
+  type AuditAdapterEventPayload,
+  type AuditAdapterReadyPayload,
+  type AuditComponentStatus,
+  type AuditEvidenceSessionAction,
+  type AuditEvidenceSessionState,
+  type AuditEvidenceScope,
   type AuditFixtureParseResult,
   type AuditFixtureQuery,
+  type AuditRuntimePlatform,
 } from '@/components/audit/audit-fixture';
 import { Locale } from '@/uni_modules/lucky-ui/locale';
 import { generateBrandVars } from '@/uni_modules/lucky-ui/theme/src/brand-color';
-
-interface AuditEvent {
-  sequence: number;
-  name: string;
-  detail?: string;
-}
 
 type WindowResizeUni = typeof uni & {
   onWindowResize?: (callback: () => void) => void;
@@ -34,21 +41,27 @@ const buildIdentity = __LUCKY_UI_BUILD_IDENTITY__;
 const parseResult = ref<AuditFixtureParseResult | null>(null);
 const initialized = ref(false);
 const shellReady = ref(false);
-const evidenceReady = ref(false);
 const environmentValid = ref(false);
 const runtimeErrors = ref<string[]>([]);
-const auditEvents = ref<AuditEvent[]>([]);
+const evidenceSession = ref<AuditEvidenceSessionState | null>(null);
 const actualViewport = ref('pending');
 const viewportMatches = ref(false);
-const platform = ref('unknown');
+const platform = ref<AuditRuntimePlatform>('unknown');
 const runtimeErrorCapture = ref<'pending' | 'h5-global' | 'mp-global' | 'unsupported'>('pending');
 let restoreDeterminism: (() => void) | null = null;
 let restoreEnvironment: (() => void) | null = null;
 let restoreRuntimeCapture: (() => void) | null = null;
 let restoreResizeCapture: (() => void) | null = null;
-let eventSequence = 0;
 let disposed = false;
 let lifecycleGeneration = 0;
+let evidenceGenerationEpoch = 0;
+
+// #ifdef H5
+platform.value = 'h5';
+// #endif
+// #ifdef MP-WEIXIN
+platform.value = 'mp-weixin';
+// #endif
 
 const config = computed(() => parseResult.value?.config);
 const configJson = computed(() => (config.value ? stableAuditConfigJson(config.value) : '{}'));
@@ -65,7 +78,7 @@ const validationErrors = computed(() => {
   return [...new Set(errors)];
 });
 const errorsJson = computed(() => JSON.stringify(validationErrors.value));
-const eventsJson = computed(() => JSON.stringify(auditEvents.value));
+const eventsJson = computed(() => JSON.stringify(evidenceSession.value?.history || []));
 const fixtureValid = computed(
   () =>
     initialized.value &&
@@ -75,15 +88,60 @@ const fixtureValid = computed(
     validationErrors.value.length === 0
 );
 const canRenderPreview = computed(() => fixtureValid.value);
+const adapterSupported = computed(() =>
+  config.value ? hasAuditComponentAdapter(config.value.component) : false
+);
+const componentEvidence = computed(() => evidenceSession.value?.evidence || null);
+const componentStatus = computed<AuditComponentStatus>(() => {
+  if (!adapterSupported.value) return 'pending-adapter';
+  if (evidenceSession.value?.status === 'failed') return 'failed';
+  if (evidenceSession.value?.status === 'ready') return 'ready';
+  return 'booting';
+});
+const evidenceReady = computed(
+  () =>
+    shellReady.value &&
+    fixtureValid.value &&
+    componentStatus.value === 'ready' &&
+    componentEvidence.value !== null
+);
+const componentEvents = computed(() =>
+  getCurrentAuditComponentEvents(evidenceSession.value, evidenceReady.value)
+);
+const lastComponentEvent = computed(() => componentEvents.value.at(-1) || null);
+const lastComponentEventDetailJson = computed(() =>
+  JSON.stringify(lastComponentEvent.value?.detail ?? null)
+);
+const evidenceScope = computed<AuditEvidenceScope>(() =>
+  evidenceReady.value ? 'component' : 'fixture-shell'
+);
+const activeInteractionCapability = computed(() =>
+  evidenceReady.value ? evidenceSession.value?.activeInteractionCapability || 'none' : 'none'
+);
+const targetLocator = computed(() => evidenceSession.value?.targetLocator || null);
+const targetLocatorJson = computed(() => JSON.stringify(targetLocator.value));
+const adapterGeneration = computed(() => evidenceSession.value?.generation || 0);
+const canMountAdapter = computed(
+  () =>
+    canRenderPreview.value &&
+    adapterSupported.value &&
+    (evidenceSession.value?.status === 'booting' || evidenceSession.value?.status === 'ready')
+);
+const componentEvidenceJson = computed(() => JSON.stringify(componentEvidence.value));
 const stateJson = computed(() =>
   JSON.stringify({
     initialized: initialized.value,
     shellReady: shellReady.value,
     evidenceReady: evidenceReady.value,
     fixtureValid: fixtureValid.value,
-    evidenceScope: 'fixture-shell',
-    componentStatus: 'pending-adapter',
-    interactionCapability: config.value?.interactionCapability || 'none',
+    evidenceScope: evidenceScope.value,
+    componentStatus: componentStatus.value,
+    generation: adapterGeneration.value,
+    interactionCapability: activeInteractionCapability.value,
+    targetLocator: targetLocator.value,
+    componentEventCount: componentEvents.value.length,
+    lastComponentEvent: lastComponentEvent.value?.name || '',
+    lastComponentEventDetail: lastComponentEvent.value?.detail ?? null,
     build: buildIdentity,
     platform: platform.value,
     actualViewport: actualViewport.value,
@@ -145,11 +203,15 @@ function installRuntimeCapture(): () => void {
   const originalWarn = console.warn;
   let active = true;
   const capturedError = (...args: unknown[]) => {
-    if (active) runtimeErrors.value.push(`console-error:${args.map(formatConsoleValue).join(' ')}`);
+    if (active) {
+      recordRuntimeFailure(`console-error:${args.map(formatConsoleValue).join(' ')}`);
+    }
     Reflect.apply(originalError, console, args);
   };
   const capturedWarn = (...args: unknown[]) => {
-    if (active) runtimeErrors.value.push(`console-warn:${args.map(formatConsoleValue).join(' ')}`);
+    if (active) {
+      recordRuntimeFailure(`console-warn:${args.map(formatConsoleValue).join(' ')}`);
+    }
     Reflect.apply(originalWarn, console, args);
   };
 
@@ -158,12 +220,14 @@ function installRuntimeCapture(): () => void {
   const handleWindowError = (event: ErrorEvent) => {
     if (!active) return;
     const target = event.target as (EventTarget & { src?: string; href?: string }) | null;
-    runtimeErrors.value.push(
+    recordRuntimeFailure(
       `window-error:${event.message || target?.src || target?.href || 'resource-error'}`
     );
   };
   const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-    if (active) runtimeErrors.value.push(`unhandled-rejection:${formatConsoleValue(event.reason)}`);
+    if (active) {
+      recordRuntimeFailure(`unhandled-rejection:${formatConsoleValue(event.reason)}`);
+    }
   };
   // #endif
 
@@ -172,11 +236,11 @@ function installRuntimeCapture(): () => void {
   let appErrorInstalled = false;
   let rejectionInstalled = false;
   const handleAppError = (error: string) => {
-    if (active) runtimeErrors.value.push(`mp-app-error:${error}`);
+    if (active) recordRuntimeFailure(`mp-app-error:${error}`);
   };
   const handleAppUnhandledRejection = (result: { reason: unknown }) => {
     if (active) {
-      runtimeErrors.value.push(`mp-unhandled-rejection:${formatConsoleValue(result.reason)}`);
+      recordRuntimeFailure(`mp-unhandled-rejection:${formatConsoleValue(result.reason)}`);
     }
   };
   // #endif
@@ -275,9 +339,45 @@ function installResizeCapture(): () => void {
   };
 }
 
-function recordEvent(name: string, detail?: string) {
-  eventSequence += 1;
-  auditEvents.value.push({ sequence: eventSequence, name, detail });
+function dispatchEvidence(action: AuditEvidenceSessionAction) {
+  if (!evidenceSession.value) return;
+  evidenceSession.value = reduceAuditEvidenceSession(evidenceSession.value, action);
+  evidenceGenerationEpoch = Math.max(evidenceGenerationEpoch, evidenceSession.value.generation);
+}
+
+function recordEvent(name: string, detail?: unknown) {
+  dispatchEvidence({ type: 'note', name, detail });
+}
+
+function recordRuntimeFailure(message: string) {
+  dispatchEvidence({ type: 'runtime-error', message });
+  runtimeErrors.value.push(message);
+}
+
+function dispatchAdapterAction(action: AuditEvidenceSessionAction) {
+  if (!evidenceSession.value || disposed || !initialized.value) return;
+  const previousFailure = evidenceSession.value.failure;
+  dispatchEvidence(action);
+  const currentFailure = evidenceSession.value?.failure;
+  if (
+    currentFailure?.kind === 'terminal' &&
+    (currentFailure.generation !== previousFailure?.generation ||
+      currentFailure.reason !== previousFailure?.reason)
+  ) {
+    runtimeErrors.value.push(`adapter:${currentFailure.reason}`);
+  }
+}
+
+function handleAdapterReady(payload: AuditAdapterReadyPayload) {
+  dispatchAdapterAction({ type: 'adapter-ready', payload });
+}
+
+function handleAdapterEvent(payload: AuditAdapterEventPayload) {
+  dispatchAdapterAction({ type: 'adapter-event', payload });
+}
+
+function handleAdapterError(payload: AuditAdapterErrorPayload) {
+  dispatchAdapterAction({ type: 'adapter-error', payload });
 }
 
 function restoreOwnedEnvironment() {
@@ -300,14 +400,19 @@ function initialize(query: AuditFixtureQuery) {
   const result = parseAuditFixtureQuery(query);
   parseResult.value = result;
   runtimeErrors.value = [];
-  auditEvents.value = [];
-  eventSequence = 0;
+  evidenceSession.value = createAuditEvidenceSession({
+    component: result.config.component,
+    fingerprint: result.fingerprint,
+    platform: platform.value,
+    initialGeneration: evidenceGenerationEpoch + 1,
+  });
+  evidenceGenerationEpoch = evidenceSession.value.generation;
   disposed = false;
   runtimeErrorCapture.value = 'pending';
   try {
     restoreRuntimeCapture = installRuntimeCapture();
   } catch (error) {
-    runtimeErrors.value.push(`runtime-capture:${String(error)}`);
+    recordRuntimeFailure(`runtime-capture:${String(error)}`);
     environmentValid.value = false;
     initialized.value = true;
     return;
@@ -319,7 +424,7 @@ function initialize(query: AuditFixtureQuery) {
       restoreDeterminism = installAuditDeterminism(result.config);
       environmentValid.value = true;
     } catch (error) {
-      runtimeErrors.value.push(`initialize:${String(error)}`);
+      recordRuntimeFailure(`initialize:${String(error)}`);
       environmentValid.value = false;
       restoreOwnedEnvironment();
     }
@@ -339,10 +444,15 @@ function readViewport() {
     actualViewport.value = `${width}x${height}`;
     viewportMatches.value =
       width === config.value?.viewportWidth && height === config.value?.viewportHeight;
+    dispatchEvidence({
+      type: 'viewport',
+      valid: viewportMatches.value,
+      reason: `viewport-mismatch:expected=${config.value?.viewport || 'unknown'},actual=${actualViewport.value}`,
+    });
   } catch (error) {
-    runtimeErrors.value.push(`viewport:${String(error)}`);
     actualViewport.value = 'unavailable';
     viewportMatches.value = false;
+    recordRuntimeFailure(`viewport:${String(error)}`);
   }
 }
 
@@ -351,7 +461,7 @@ function cleanup() {
   disposed = true;
   lifecycleGeneration += 1;
   shellReady.value = false;
-  evidenceReady.value = false;
+  evidenceSession.value = null;
   environmentValid.value = false;
   try {
     restoreResizeCapture?.();
@@ -370,7 +480,7 @@ function cleanup() {
 }
 
 onErrorCaptured((error, _instance, info) => {
-  runtimeErrors.value.push(`vue-descendant:${info}:${formatConsoleValue(error)}`);
+  recordRuntimeFailure(`vue-descendant:${info}:${formatConsoleValue(error)}`);
 });
 
 onLoad((query?: AuditFixtureQuery) => {
@@ -380,12 +490,6 @@ onLoad((query?: AuditFixtureQuery) => {
 onMounted(async () => {
   if (!initialized.value) initialize({});
   const generation = ++lifecycleGeneration;
-  // #ifdef H5
-  platform.value = 'h5';
-  // #endif
-  // #ifdef MP-WEIXIN
-  platform.value = 'mp-weixin';
-  // #endif
   readViewport();
   restoreResizeCapture = installResizeCapture();
   await nextTick();
@@ -409,13 +513,23 @@ onBeforeUnmount(cleanup);
     :data-audit-evidence-ready="String(evidenceReady)"
     :data-audit-fixture-valid="String(fixtureValid)"
     :data-audit-error-count="String(validationErrors.length)"
-    data-audit-evidence-scope="fixture-shell"
-    data-audit-component-status="pending-adapter"
+    :data-audit-evidence-scope="evidenceScope"
+    :data-audit-component-status="componentStatus"
     :data-audit-component="config.component"
     :data-audit-component-kind="config.componentKind"
     :data-audit-profile="config.profile"
     :data-audit-scenario="config.scenario"
-    :data-audit-interaction-capability="config.interactionCapability"
+    :data-audit-generation="String(adapterGeneration)"
+    :data-audit-interaction-capability="activeInteractionCapability"
+    :data-audit-target-locator="targetLocatorJson"
+    :data-audit-target-selector="
+      targetLocator?.kind === 'page-selector' ? targetLocator.selector : ''
+    "
+    :data-audit-target-scope="targetLocator?.scope || ''"
+    :data-audit-target-interaction="targetLocator?.interactionCapability || 'none'"
+    :data-audit-component-event-count="String(componentEvents.length)"
+    :data-audit-last-component-event="lastComponentEvent?.name || ''"
+    :data-audit-last-component-event-detail="lastComponentEventDetailJson"
     :data-audit-motion-coverage="config.motionCoverage"
     :data-audit-resource-policy="config.resourcePolicy"
     :data-audit-resource-enforcement="config.resourceEnforcement"
@@ -446,7 +560,18 @@ onBeforeUnmount(cleanup);
       :data-audit-preview-slug="config.previewSlug"
       :data-audit-preview-mounted="String(canRenderPreview)"
     >
-      <preview-demo-renderer v-if="canRenderPreview" :slug="config.previewSlug" />
+      <audit-adapter-renderer
+        v-if="canMountAdapter && parseResult"
+        :key="`${parseResult.fingerprint}:${adapterGeneration}`"
+        :component="config.component"
+        :fingerprint="parseResult.fingerprint"
+        :generation="adapterGeneration"
+        :platform="platform"
+        @ready="handleAdapterReady"
+        @event="handleAdapterEvent"
+        @error="handleAdapterError"
+      />
+      <preview-demo-renderer v-else-if="canRenderPreview" :slug="config.previewSlug" />
       <view v-else class="audit-fixture__invalid">
         <text>当前只允许确定性的壳层基线；配置、资源或环境不满足门槛时禁止生成组件证据。</text>
       </view>
@@ -455,6 +580,7 @@ onBeforeUnmount(cleanup);
     <view class="audit-fixture__diagnostics">
       <text class="audit-fixture__config">{{ configJson }}</text>
       <text class="audit-fixture__state">{{ stateJson }}</text>
+      <text class="audit-fixture__component-evidence">{{ componentEvidenceJson }}</text>
       <text class="audit-fixture__events">{{ eventsJson }}</text>
       <text class="audit-fixture__errors">{{ errorsJson }}</text>
     </view>
@@ -514,6 +640,7 @@ onBeforeUnmount(cleanup);
 
 .audit-fixture__config,
 .audit-fixture__state,
+.audit-fixture__component-evidence,
 .audit-fixture__events,
 .audit-fixture__errors {
   display: block;
@@ -525,6 +652,7 @@ onBeforeUnmount(cleanup);
 }
 
 .audit-fixture__state,
+.audit-fixture__component-evidence,
 .audit-fixture__events,
 .audit-fixture__errors {
   margin-top: 8rpx;

--- a/tests/unit/audit-fixture.spec.ts
+++ b/tests/unit/audit-fixture.spec.ts
@@ -3,15 +3,31 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { PREVIEW_DEMO_SLUGS } from '../../src/components/preview/preview-demo-registry';
 import {
+  AUDIT_ADAPTED_COMPONENT_SLUGS,
   AUDIT_COMPONENT_SLUGS,
   AUDIT_REMOTE_RESOURCE_COMPONENT_SLUGS,
   applyTemporaryStorageOverlay,
+  auditElementRectsEqual,
+  createAuditEvidenceSession,
   createSeededRandom,
+  createAuditTargetLocator,
   fingerprintAuditConfig,
+  getCurrentAuditComponentEvents,
+  getAuditInteractionCapability,
+  hasAuditComponentAdapter,
   installAuditDeterminism,
+  normalizeAuditElementRect,
+  normalizeAuditJsonValue,
   parseAuditFixtureQuery,
+  reduceAuditEvidenceSession,
   stableAuditConfigJson,
+  type AuditAdapterErrorPayload,
+  type AuditAdapterEventPayload,
+  type AuditAdapterReadyPayload,
+  type AuditEvidenceSessionState,
+  type AuditRuntimePlatform,
   type AuditStorageAdapter,
+  type AuditTargetLocator,
 } from '../../src/components/audit/audit-fixture';
 
 const COMPONENT_ROOT = fileURLToPath(
@@ -24,6 +40,39 @@ const RENDERER_PATH = fileURLToPath(
 const FIXTURE_PAGE_PATH = fileURLToPath(
   new URL('../../src/pages_sub/audit-fixture/index.vue', import.meta.url)
 );
+const ADAPTER_RENDERER_PATH = fileURLToPath(
+  new URL('../../src/components/audit/AuditAdapterRenderer.vue', import.meta.url)
+);
+const BUTTON_ADAPTER_PATH = fileURLToPath(
+  new URL('../../src/components/audit/adapters/ButtonAuditAdapter.vue', import.meta.url)
+);
+
+const STABLE_RECT = { left: 12, top: 24, width: 96, height: 44 } as const;
+
+function startEvidenceSession(platform: AuditRuntimePlatform = 'h5'): AuditEvidenceSessionState {
+  return reduceAuditEvidenceSession(
+    createAuditEvidenceSession({
+      component: 'button',
+      fingerprint: 'fixture-fingerprint',
+      platform,
+    }),
+    { type: 'viewport', valid: true }
+  );
+}
+
+function readyPayload(
+  state: AuditEvidenceSessionState,
+  targetLocator: AuditTargetLocator
+): AuditAdapterReadyPayload {
+  return {
+    component: 'button',
+    fingerprint: state.fingerprint,
+    generation: state.generation,
+    targetLocator,
+    rect: STABLE_RECT,
+    state: { enabled: true, clickCount: 0 },
+  };
+}
 
 describe('audit fixture contract', () => {
   it('covers exactly the 73 audited lk-* component directories', () => {
@@ -59,6 +108,21 @@ describe('audit fixture contract', () => {
     }
   });
 
+  it('only grants interaction capability to components with a concrete adapter', () => {
+    expect(AUDIT_ADAPTED_COMPONENT_SLUGS).toEqual(['button']);
+    const rendererSource = readFileSync(ADAPTER_RENDERER_PATH, 'utf8');
+    const rendererComponents = [...rendererSource.matchAll(/component === ['"]([^'"]+)['"]/g)].map(
+      match => match[1]
+    );
+    expect(rendererComponents).toEqual([...AUDIT_ADAPTED_COMPONENT_SLUGS]);
+
+    for (const component of AUDIT_COMPONENT_SLUGS) {
+      const adapted = component === 'button';
+      expect(hasAuditComponentAdapter(component)).toBe(adapted);
+      expect(getAuditInteractionCapability(component)).toBe(adapted ? 'tap' : 'none');
+    }
+  });
+
   it('fails closed for every demo that still references a remote resource', () => {
     const detected = AUDIT_COMPONENT_SLUGS.filter(component => {
       const previewSlug = component === 'preload-debugger' ? 'preload' : component;
@@ -75,7 +139,7 @@ describe('audit fixture contract', () => {
     }
   });
 
-  it('normalizes a complete shell-baseline query without implying interaction support', () => {
+  it('normalizes a complete query and exposes only the registered adapter capability', () => {
     const result = parseAuditFixtureQuery({
       component: 'lk-button',
       profile: 'render-baseline',
@@ -96,7 +160,7 @@ describe('audit fixture contract', () => {
       previewSlug: 'button',
       profile: 'render-baseline',
       scenario: 'none',
-      interactionCapability: 'none',
+      interactionCapability: 'tap',
       theme: 'dark',
       brand: '#abcdef',
       locale: 'pt-BR',
@@ -130,7 +194,7 @@ describe('audit fixture contract', () => {
       component: 'button',
       profile: 'render-baseline',
       scenario: 'none',
-      interactionCapability: 'none',
+      interactionCapability: 'tap',
       theme: 'light',
       brand: '#6965db',
       locale: 'zh-Hans',
@@ -205,18 +269,699 @@ describe('audit fixture contract', () => {
     );
   });
 
+  it('accepts only finite non-zero element rects and compares canonical metrics', () => {
+    const first = normalizeAuditElementRect({
+      left: 1.23456,
+      top: 2.34567,
+      width: 83.1919,
+      height: 41.5999,
+    });
+    const second = normalizeAuditElementRect({
+      left: 1.23451,
+      top: 2.34561,
+      width: 83.19151,
+      height: 41.59951,
+    });
+
+    expect(first).toEqual({ left: 1.235, top: 2.346, width: 83.192, height: 41.6 });
+    expect(auditElementRectsEqual(first, second)).toBe(true);
+    const normalizedNegativeZeroRect = normalizeAuditElementRect({
+      left: -0.0004,
+      top: -0,
+      width: 20,
+      height: 20,
+    });
+    expect(normalizedNegativeZeroRect).toMatchObject({ left: 0, top: 0 });
+    expect(Object.is(normalizedNegativeZeroRect?.left, -0)).toBe(false);
+    expect(Object.is(normalizedNegativeZeroRect?.top, -0)).toBe(false);
+    expect(normalizeAuditElementRect({ left: 0, top: 0, width: 0, height: 20 })).toBeNull();
+    expect(normalizeAuditElementRect({ left: 0, top: 0, width: 0.0004, height: 20 })).toBeNull();
+    expect(
+      normalizeAuditElementRect({ left: 0, top: 0, width: Number.MAX_VALUE, height: 20 })
+    ).toBeNull();
+    expect(
+      normalizeAuditElementRect({ left: 0, top: 0, width: Number.NaN, height: 20 })
+    ).toBeNull();
+    const rectWithAccessor = { left: 0, top: 0, width: 20, height: 20 };
+    Object.defineProperty(rectWithAccessor, 'width', {
+      get: () => {
+        throw new Error('must-not-run');
+      },
+    });
+    expect(() => normalizeAuditElementRect(rectWithAccessor)).not.toThrow();
+    expect(normalizeAuditElementRect(rectWithAccessor)).toBeNull();
+    expect(auditElementRectsEqual(first, null)).toBe(false);
+  });
+
+  it('copies only stable JSON evidence without silent serialization loss', () => {
+    const source = { nested: [{ count: 1 }], enabled: true };
+    const normalized = normalizeAuditJsonValue(source);
+    expect(normalized).toEqual({ value: source });
+    expect(normalized.value).not.toBe(source);
+    expect((normalized.value as { nested: unknown[] }).nested).not.toBe(source.nested);
+
+    expect(normalizeAuditJsonValue({ value: Number.NaN }).error).toContain('number-not-finite');
+    expect(normalizeAuditJsonValue({ value: undefined }).error).toContain('type-undefined');
+    expect(normalizeAuditJsonValue(new Map([['value', 1]])).error).toContain('non-plain-object');
+    expect(normalizeAuditJsonValue({ value: 1n }).error).toContain('type-bigint');
+    const normalizedNegativeZero = normalizeAuditJsonValue(-0);
+    expect(normalizedNegativeZero.value).toBe(0);
+    expect(Object.is(normalizedNegativeZero.value, -0)).toBe(false);
+    expect(normalizeAuditJsonValue('x'.repeat(16385)).error).toContain('string-too-long');
+    expect(normalizeAuditJsonValue({ ['x'.repeat(257)]: true }).error).toContain('key-too-long');
+    expect(
+      normalizeAuditJsonValue(Array.from({ length: 5 }, () => 'x'.repeat(16384))).error
+    ).toContain('character-limit');
+    const arrayWithIgnoredKey = [1] as number[] & { '01'?: number };
+    arrayWithIgnoredKey['01'] = 2;
+    expect(normalizeAuditJsonValue(arrayWithIgnoredKey).error).toContain('array-extra-key-or-hole');
+    const arrayWithHiddenKey = [1] as number[] & { hidden?: number };
+    Object.defineProperty(arrayWithHiddenKey, 'hidden', { value: 2 });
+    expect(normalizeAuditJsonValue(arrayWithHiddenKey).error).toContain('array-extra-key-or-hole');
+    const arrayWithAccessor = [1];
+    Object.defineProperty(arrayWithAccessor, '0', {
+      enumerable: true,
+      get: () => {
+        throw new Error('must-not-run');
+      },
+    });
+    expect(() => normalizeAuditJsonValue(arrayWithAccessor)).not.toThrow();
+    expect(normalizeAuditJsonValue(arrayWithAccessor).error).toContain('accessor');
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    expect(normalizeAuditJsonValue(cycle).error).toContain('cycle');
+  });
+
+  it('revokes ready evidence on viewport invalidation and requires a new generation to recover', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target');
+    expect(locator).not.toBeNull();
+    let state = startEvidenceSession();
+    const firstGeneration = state.generation;
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator!),
+    });
+    expect(state).toMatchObject({
+      generation: firstGeneration,
+      status: 'ready',
+      activeInteractionCapability: 'tap',
+    });
+    expect(state.evidence).not.toBeNull();
+    expect(state.targetLocator).toEqual(locator);
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'viewport',
+      valid: false,
+      reason: 'viewport-mismatch:expected=390x844,actual=430x932',
+    });
+    expect(state).toMatchObject({
+      generation: firstGeneration + 1,
+      viewportValid: false,
+      status: 'failed',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: { kind: 'viewport' },
+    });
+    expect(state.history.filter(entry => entry.name === 'component-revoked')).toHaveLength(1);
+
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: true });
+    expect(state).toMatchObject({
+      generation: firstGeneration + 1,
+      viewportValid: true,
+      status: 'booting',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: null,
+    });
+    expect(state.history.filter(entry => entry.name === 'component-ready')).toHaveLength(1);
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator!),
+    });
+    expect(state.status).toBe('ready');
+    expect(state.evidence?.generation).toBe(firstGeneration + 1);
+    expect(state.history.filter(entry => entry.name === 'component-ready')).toHaveLength(2);
+    expect(state.history.map(entry => entry.sequence)).toEqual(
+      state.history.map((_, index) => index + 1)
+    );
+  });
+
+  it('atomically revokes evidence when a runtime error occurs after ready', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator),
+    });
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'runtime-error',
+      message: 'console-error:render-failed',
+    });
+
+    expect(state).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: { kind: 'terminal', reason: 'runtime:console-error:render-failed' },
+    });
+    expect(state.history.slice(-2).map(entry => entry.name)).toEqual([
+      'component-revoked',
+      'component-failed',
+    ]);
+  });
+
+  it('revokes ready evidence when the current adapter generation reports an error', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator),
+    });
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-error',
+      payload: {
+        component: 'button',
+        fingerprint: state.fingerprint,
+        generation: state.generation,
+        message: 'target-query:failed',
+      },
+    });
+
+    expect(state).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: { reason: 'adapter-error:button:target-query:failed' },
+    });
+  });
+
+  it('ignores ready, event, and error envelopes from a stale generation', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    const staleReady = readyPayload(state, locator);
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload: staleReady });
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: false });
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: true });
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator),
+    });
+    const currentEvidence = state.evidence;
+    const staleEvent: AuditAdapterEventPayload = {
+      component: 'button',
+      fingerprint: state.fingerprint,
+      generation: staleReady.generation,
+      name: 'click',
+      detail: { clickCount: 99 },
+    };
+    const staleError: AuditAdapterErrorPayload = {
+      component: 'button',
+      fingerprint: state.fingerprint,
+      generation: staleReady.generation,
+      message: 'late-query-failure',
+    };
+
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload: staleReady });
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-event', payload: staleEvent });
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-error', payload: staleError });
+
+    expect(state.status).toBe('ready');
+    expect(state.failure).toBeNull();
+    expect(state.evidence).toBe(currentEvidence);
+    expect(state.history.filter(entry => entry.name === 'component-stale-ignored')).toHaveLength(3);
+  });
+
+  it('fails closed for every future envelope instead of treating it as stale', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    for (const envelopeType of ['ready', 'event', 'error'] as const) {
+      let state = startEvidenceSession();
+      state = reduceAuditEvidenceSession(state, {
+        type: 'adapter-ready',
+        payload: readyPayload(state, locator),
+      });
+      const envelope = {
+        component: 'button' as const,
+        fingerprint: state.fingerprint,
+        generation: state.generation + 1,
+      };
+      state =
+        envelopeType === 'ready'
+          ? reduceAuditEvidenceSession(state, {
+              type: 'adapter-ready',
+              payload: { ...readyPayload(state, locator), generation: envelope.generation },
+            })
+          : envelopeType === 'event'
+            ? reduceAuditEvidenceSession(state, {
+                type: 'adapter-event',
+                payload: { ...envelope, name: 'click', detail: { clickCount: 1 } },
+              })
+            : reduceAuditEvidenceSession(state, {
+                type: 'adapter-error',
+                payload: { ...envelope, message: 'future-error' },
+              });
+      expect(state).toMatchObject({
+        status: 'failed',
+        evidence: null,
+        targetLocator: null,
+        failure: { reason: 'generation-ahead:expected=1,actual=2' },
+      });
+    }
+  });
+
+  it('fails closed for an invalid generation', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+
+    let invalidState = startEvidenceSession();
+    const invalidGeneration = readyPayload(invalidState, locator);
+    invalidGeneration.generation = Number.NaN;
+    invalidState = reduceAuditEvidenceSession(invalidState, {
+      type: 'adapter-ready',
+      payload: invalidGeneration,
+    });
+    expect(invalidState).toMatchObject({ status: 'failed', evidence: null });
+    expect(invalidState.failure?.reason).toBe('generation-invalid:NaN');
+
+    for (const invalidValue of [Object.create(null), new Proxy({}, {})]) {
+      let malformedState = startEvidenceSession();
+      const malformedGeneration = readyPayload(malformedState, locator);
+      malformedGeneration.generation = invalidValue as unknown as number;
+      expect(() => {
+        malformedState = reduceAuditEvidenceSession(malformedState, {
+          type: 'adapter-ready',
+          payload: malformedGeneration,
+        });
+      }).not.toThrow();
+      expect(malformedState).toMatchObject({
+        status: 'failed',
+        evidence: null,
+        failure: { reason: 'generation-invalid:object' },
+      });
+    }
+
+    let hostileState = startEvidenceSession();
+    const hostilePayload = new Proxy(readyPayload(hostileState, locator), {
+      getOwnPropertyDescriptor: () => {
+        throw new Error('generation-inspection-failed');
+      },
+    });
+    expect(() => {
+      hostileState = reduceAuditEvidenceSession(hostileState, {
+        type: 'adapter-ready',
+        payload: hostilePayload,
+      });
+    }).not.toThrow();
+    expect(hostileState).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      failure: { reason: 'adapter-envelope-inspection-failed' },
+    });
+  });
+
+  it('rejects invalid ready geometry and non-JSON state before publishing evidence', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    for (const width of [Number.NaN, 0.0004, Number.MAX_VALUE]) {
+      let invalidRectState = startEvidenceSession();
+      const invalidRect = readyPayload(invalidRectState, locator);
+      invalidRect.rect = { left: 0, top: 0, width, height: 44 };
+      invalidRectState = reduceAuditEvidenceSession(invalidRectState, {
+        type: 'adapter-ready',
+        payload: invalidRect,
+      });
+      expect(invalidRectState).toMatchObject({
+        status: 'failed',
+        evidence: null,
+        failure: { reason: 'ready-rect-invalid' },
+      });
+    }
+
+    let invalidJsonState = startEvidenceSession();
+    const invalidJson = readyPayload(invalidJsonState, locator);
+    invalidJson.state = { value: 1n };
+    invalidJsonState = reduceAuditEvidenceSession(invalidJsonState, {
+      type: 'adapter-ready',
+      payload: invalidJson,
+    });
+    expect(invalidJsonState).toMatchObject({ status: 'failed', evidence: null });
+    expect(invalidJsonState.failure?.reason).toContain('ready-state:$');
+  });
+
+  it('copies accepted evidence and rejects non-JSON event or note details', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    const payload = readyPayload(state, locator);
+    const originalState = payload.state;
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+    expect(state.evidence?.state).toEqual(originalState);
+    expect(state.evidence?.state).not.toBe(originalState);
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-event',
+      payload: {
+        component: 'button',
+        fingerprint: state.fingerprint,
+        generation: state.generation,
+        name: 'click',
+        detail: { bad: undefined },
+      },
+    });
+    expect(state).toMatchObject({ status: 'failed', evidence: null, targetLocator: null });
+    expect(state.failure?.reason).toContain('event-detail:$');
+
+    let noteState = startEvidenceSession();
+    noteState = reduceAuditEvidenceSession(noteState, {
+      type: 'note',
+      name: 'bad-note',
+      detail: new Map([['bad', true]]),
+    });
+    expect(noteState.status).toBe('failed');
+    expect(noteState.failure?.reason).toContain('note-detail:$');
+  });
+
+  it('rebuilds ready evidence from an exact whitelist without inspecting extra fields', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    const payload = readyPayload(state, locator) as AuditAdapterReadyPayload &
+      Record<string, unknown>;
+    payload.extraBigInt = 1n;
+    payload.extraUndefined = undefined;
+    const extraSymbol = Symbol('extra');
+    Object.defineProperty(payload, extraSymbol, { value: 'ignored' });
+    Object.defineProperty(payload, 'extraAccessor', {
+      enumerable: true,
+      get: () => {
+        throw new Error('must-not-run');
+      },
+    });
+
+    expect(() => {
+      state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+    }).not.toThrow();
+    expect(state.status).toBe('ready');
+    expect(Object.keys(state.evidence!).sort()).toEqual([
+      'component',
+      'fingerprint',
+      'generation',
+      'rect',
+      'state',
+      'targetLocator',
+    ]);
+    expect(Object.getOwnPropertySymbols(state.evidence!)).toEqual([]);
+    expect(() => JSON.stringify(state)).not.toThrow();
+  });
+
+  it('fails closed before cumulative evidence history can grow without bound', () => {
+    let state = createAuditEvidenceSession({
+      component: 'button',
+      fingerprint: 'fixture-fingerprint',
+      platform: 'h5',
+    });
+    for (let index = 0; index < 512 && state.status !== 'failed'; index += 1) {
+      state = reduceAuditEvidenceSession(state, {
+        type: 'note',
+        name: 'bounded-note',
+        detail: { index },
+      });
+    }
+    expect(state).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      failure: { reason: 'history-entry-limit' },
+    });
+    expect(state.history.length).toBeLessThanOrEqual(512);
+    expect(state.history.at(-1)?.name).toBe('component-failed');
+  });
+
+  it('latches the first terminal failure when late actions arrive near the history limit', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    const payload = readyPayload(state, locator);
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+    for (let index = 0; index < 507; index += 1) {
+      state = reduceAuditEvidenceSession(state, {
+        type: 'adapter-event',
+        payload: {
+          component: 'button',
+          fingerprint: state.fingerprint,
+          generation: state.generation,
+          name: 'click',
+          detail: { clickCount: index + 1 },
+        },
+      });
+    }
+    expect(state.history).toHaveLength(509);
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+    expect(state).toMatchObject({
+      status: 'failed',
+      failure: { reason: 'duplicate-ready:button' },
+    });
+    expect(state.history).toHaveLength(511);
+    const terminalState = state;
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'runtime-error',
+      message: 'late-runtime-error',
+    });
+    expect(state).toBe(terminalState);
+    state = reduceAuditEvidenceSession(state, {
+      type: 'note',
+      name: 'late-note',
+      detail: { ignored: true },
+    });
+    expect(state).toBe(terminalState);
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: false });
+    expect(state).toMatchObject({
+      viewportValid: false,
+      failure: { reason: 'duplicate-ready:button' },
+    });
+    expect(state.history).toEqual(terminalState.history);
+  });
+
+  it('publishes a short event summary only for the ready current generation', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator),
+    });
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-event',
+      payload: {
+        component: 'button',
+        fingerprint: state.fingerprint,
+        generation: state.generation,
+        name: 'click',
+        detail: { clickCount: 1 },
+      },
+    });
+    expect(getCurrentAuditComponentEvents(state, true)).toMatchObject([
+      { generation: 1, name: 'component:button:click', detail: { clickCount: 1 } },
+    ]);
+    expect(getCurrentAuditComponentEvents(state, false)).toEqual([]);
+
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: false });
+    expect(getCurrentAuditComponentEvents(state, true)).toEqual([]);
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: true });
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-ready',
+      payload: readyPayload(state, locator),
+    });
+    expect(state.generation).toBe(2);
+    expect(getCurrentAuditComponentEvents(state, true)).toEqual([]);
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'adapter-event',
+      payload: {
+        component: 'button',
+        fingerprint: state.fingerprint,
+        generation: state.generation,
+        name: 'click',
+        detail: { clickCount: 1 },
+      },
+    });
+    expect(getCurrentAuditComponentEvents(state, true)).toMatchObject([
+      { generation: 2, name: 'component:button:click', detail: { clickCount: 1 } },
+    ]);
+
+    state = reduceAuditEvidenceSession(state, {
+      type: 'runtime-error',
+      message: 'late-runtime-error',
+    });
+    expect(getCurrentAuditComponentEvents(state, true)).toEqual([]);
+  });
+
+  it('supports a monotonically increasing generation seed across fixture lifecycles', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    const stalePayload: AuditAdapterReadyPayload = {
+      component: 'button',
+      fingerprint: 'fixture-fingerprint',
+      generation: 7,
+      targetLocator: locator,
+      rect: STABLE_RECT,
+      state: { enabled: true },
+    };
+    let state = createAuditEvidenceSession({
+      component: 'button',
+      fingerprint: 'fixture-fingerprint',
+      platform: 'h5',
+      initialGeneration: 8,
+    });
+    state = reduceAuditEvidenceSession(state, { type: 'viewport', valid: true });
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload: stalePayload });
+
+    expect(state).toMatchObject({ generation: 8, status: 'booting', evidence: null });
+    expect(state.history.at(-1)).toMatchObject({
+      name: 'component-stale-ignored',
+      detail: { staleGeneration: 7, currentGeneration: 8 },
+    });
+  });
+
+  it('models H5 as page-tappable and WeChat as scoped render-only evidence', () => {
+    const h5Locator = createAuditTargetLocator('h5', '#audit-button-target');
+    const mpLocator = createAuditTargetLocator('mp-weixin', '#audit-button-target');
+    expect(h5Locator).toEqual({
+      kind: 'page-selector',
+      platform: 'h5',
+      scope: 'page',
+      selector: '#audit-button-target',
+      measurement: 'page-selector-query',
+      interactionCapability: 'tap',
+    });
+    expect(mpLocator).toEqual({
+      kind: 'scoped-render',
+      platform: 'mp-weixin',
+      scope: 'adapter-component',
+      selector: '#audit-button-target',
+      measurement: 'component-scoped-selector-query',
+      interactionCapability: 'none',
+    });
+    expect(createAuditTargetLocator('unknown', '#audit-button-target')).toBeNull();
+
+    let malformedLocatorState = startEvidenceSession();
+    const malformedLocator = readyPayload(malformedLocatorState, h5Locator!);
+    malformedLocator.targetLocator = null as unknown as AuditTargetLocator;
+    malformedLocatorState = reduceAuditEvidenceSession(malformedLocatorState, {
+      type: 'adapter-ready',
+      payload: malformedLocator,
+    });
+    expect(malformedLocatorState.failure?.reason).toBe('target-locator-malformed');
+
+    let hostileLocatorState = startEvidenceSession();
+    const hostileLocator = readyPayload(hostileLocatorState, h5Locator!);
+    hostileLocator.targetLocator = new Proxy(h5Locator!, {
+      ownKeys: () => {
+        throw new Error('locator-inspection-failed');
+      },
+    });
+    expect(() => {
+      hostileLocatorState = reduceAuditEvidenceSession(hostileLocatorState, {
+        type: 'adapter-ready',
+        payload: hostileLocator,
+      });
+    }).not.toThrow();
+    expect(hostileLocatorState).toMatchObject({ status: 'failed', evidence: null });
+    expect(hostileLocatorState.failure?.reason).toContain('target-locator:$:inspection-failed');
+
+    let revokedLocatorState = startEvidenceSession();
+    const revokedLocator = readyPayload(revokedLocatorState, h5Locator!);
+    const revocableLocator = Proxy.revocable(h5Locator!, {});
+    revocableLocator.revoke();
+    revokedLocator.targetLocator = revocableLocator.proxy;
+    expect(() => {
+      revokedLocatorState = reduceAuditEvidenceSession(revokedLocatorState, {
+        type: 'adapter-ready',
+        payload: revokedLocator,
+      });
+    }).not.toThrow();
+    expect(revokedLocatorState).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      failure: { reason: 'target-locator-inspection-failed' },
+    });
+
+    let mpState = startEvidenceSession('mp-weixin');
+    mpState = reduceAuditEvidenceSession(mpState, {
+      type: 'adapter-ready',
+      payload: readyPayload(mpState, mpLocator!),
+    });
+    expect(mpState).toMatchObject({ status: 'ready', activeInteractionCapability: 'none' });
+
+    let invalidMpState = startEvidenceSession('mp-weixin');
+    invalidMpState = reduceAuditEvidenceSession(invalidMpState, {
+      type: 'adapter-ready',
+      payload: readyPayload(invalidMpState, h5Locator!),
+    });
+    expect(invalidMpState).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      targetLocator: null,
+      failure: { reason: 'mp-locator-must-be-scoped-noninteractive' },
+    });
+  });
+
+  it('fails closed and revokes current evidence on duplicate ready', () => {
+    const locator = createAuditTargetLocator('h5', '#audit-button-target')!;
+    let state = startEvidenceSession();
+    const payload = readyPayload(state, locator);
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+    state = reduceAuditEvidenceSession(state, { type: 'adapter-ready', payload });
+
+    expect(state).toMatchObject({
+      status: 'failed',
+      evidence: null,
+      targetLocator: null,
+      activeInteractionCapability: 'none',
+      failure: { reason: 'duplicate-ready:button' },
+    });
+  });
+
   it('keeps fixture validity distinct from component evidence', () => {
     const source = readFileSync(FIXTURE_PAGE_PATH, 'utf8');
     expect(source).toContain(':data-audit-fixture-valid="String(fixtureValid)"');
     expect(source).not.toContain('data-audit-valid');
     expect(source).toContain(':data-audit-evidence-ready="String(evidenceReady)"');
-    expect(source).toContain('data-audit-component-status="pending-adapter"');
+    expect(source).toContain(':data-audit-evidence-scope="evidenceScope"');
+    expect(source).toContain(':data-audit-component-status="componentStatus"');
+    expect(source).toContain(':data-audit-interaction-capability="activeInteractionCapability"');
+    expect(source).toContain(':data-audit-target-locator="targetLocatorJson"');
+    expect(source).toContain(':data-audit-component-event-count="String(componentEvents.length)"');
+    expect(source).toContain(':data-audit-last-component-event="lastComponentEvent?.name || \'\'"');
+    expect(source).toContain(
+      ':data-audit-last-component-event-detail="lastComponentEventDetailJson"'
+    );
+    expect(source).toContain('v-if="canMountAdapter && parseResult"');
+    expect(source).toContain(':key="`${parseResult.fingerprint}:${adapterGeneration}`"');
+    expect(source).toContain(':generation="adapterGeneration"');
+    expect(source).toContain('@ready="handleAdapterReady"');
+    expect(source).not.toContain('@tap="recordEvent');
     expect(source).toContain(':data-audit-build-mode="buildIdentity.buildMode"');
     expect(source).toContain(':data-audit-provenance="buildIdentity.provenance"');
     expect(source).toContain('data-audit-theme-scope="fixture-root"');
     expect(source).toContain('data-audit-brand-scope="fixture-root"');
     expect(source).not.toContain('themeStore');
     expect(source).not.toContain('applyTemporaryStorageOverlay');
+  });
+
+  it('binds the button adapter to the real component target and a stable postcondition', () => {
+    const source = readFileSync(BUTTON_ADAPTER_PATH, 'utf8');
+    expect(source).toContain('<lk-button id="audit-button-target"');
+    expect(source).toContain('@click="handleClick"');
+    expect(source).toContain(':data-audit-click-count="String(clickCount)"');
+    expect(source).toContain('stableReads >= 2');
+    expect(source).toContain('.selectAll(TARGET_SELECTOR)');
+    expect(source).toContain("adapterPlatform === 'mp-weixin'");
+    expect(source).toContain('targetLocator: locator');
+    expect(source).toContain('generation: adapterGeneration');
+    expect(source).toContain("name: 'click'");
+    expect(source).toContain('detail: { ...state.value }');
+    expect(source).not.toContain('detail: stateJson.value');
+    expect(source).not.toContain('uni.showToast');
   });
 
   it('does not overwrite a newer global owner during cleanup', () => {


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `feat(audit): add component evidence adapters`。
- 保留提交 `bfd780d29377` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。