### PR TITLE
fix(picker): commit inline selections

### DIFF
--- a/docs/components/picker.md
+++ b/docs/components/picker.md
@@ -5,20 +5,24 @@ phone: picker
 
 # Picker 选择器
 
-用于从单列、多列或级联数据中选择值，适合城市、分类、规格等确认式选择场景。
+用于从单列、多列或级联数据中选择值。弹层模式适合确认式选择，内联模式适合即时生效的常驻选择器。
 
 ## 基础用法
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const visible = ref(false)
-const value = ref('apple')
+const visible = ref(false);
+const value = ref('apple');
 const columns = [
   { label: '苹果', value: 'apple' },
   { label: '香蕉', value: 'banana' },
-]
+];
+
+function onConfirm(nextValue: string | number | (string | number)[]) {
+  console.log('confirmed', nextValue);
+}
 </script>
 
 <template>
@@ -37,7 +41,7 @@ const columns = [
 
 ```vue
 <script setup lang="ts">
-const value = ref(['2026', '04'])
+const value = ref(['2026', '04']);
 const columns = [
   [
     { label: '2025', value: '2025' },
@@ -47,7 +51,7 @@ const columns = [
     { label: '03 月', value: '03' },
     { label: '04 月', value: '04' },
   ],
-]
+];
 </script>
 
 <template>
@@ -72,67 +76,79 @@ const columns = [
 ## 内联模式
 
 ```vue
-<lk-picker inline v-model="value" :columns="columns" />
+<template>
+  <text>当前值：{{ value }}</text>
+  <lk-picker inline v-model="value" :columns="columns" @change="onChange" />
+</template>
 ```
+
+内联模式没有确认按钮。用户选择新项后会在同一次事件中依次触发 `pick`、`update:modelValue`、`change`，因此 `v-model` 会立即更新。选择仍停留在当前索引时不会重复触发这些事件。
+
+弹层模式中的滚动选择只更新内部草稿并触发 `pick`；点击确认后才依次触发 `update:modelValue`、`change`、`confirm`。点击取消会恢复已提交值，不触发 `update:modelValue` 或 `change`。
 
 ## API
 
 ### Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 当前选中值 | `string / number / array` | — | `undefined` |
-| visible | 是否显示弹层，支持 `v-model:visible` | `boolean` | — | `false` |
-| mode | 选择模式 | `string` | `single / multi / cascade` | `single` |
-| columns | 选项列数据 | `PickerOption[] / PickerOption[][]` | — | `[]` |
-| inline | 是否内联显示，不使用弹层 | `boolean` | — | `false` |
-| title | 标题 | `string` | — | `''` |
-| confirmText | 确认按钮文字 | `string` | — | `确定` |
-| cancelText | 取消按钮文字 | `string` | — | `取消` |
-| round | 弹层是否圆角 | `boolean` | — | `true` |
-| visibleCount | 可见选项数量 | `number` | — | `5` |
-| itemHeight | 选项高度，单位 rpx | `number` | — | `100` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数         | 说明                                 | 类型                                | 可选值                     | 默认值      |
+| ------------ | ------------------------------------ | ----------------------------------- | -------------------------- | ----------- |
+| modelValue   | 当前选中值                           | `string / number / array`           | —                          | `undefined` |
+| visible      | 是否显示弹层，支持 `v-model:visible` | `boolean`                           | —                          | `false`     |
+| mode         | 选择模式                             | `string`                            | `single / multi / cascade` | `single`    |
+| columns      | 选项列数据                           | `PickerOption[] / PickerOption[][]` | —                          | `[]`        |
+| inline       | 是否内联显示，不使用弹层             | `boolean`                           | —                          | `false`     |
+| title        | 标题                                 | `string`                            | —                          | `''`        |
+| confirmText  | 确认按钮文字                         | `string`                            | —                          | `确定`      |
+| cancelText   | 取消按钮文字                         | `string`                            | —                          | `取消`      |
+| round        | 弹层是否圆角                         | `boolean`                           | —                          | `true`      |
+| visibleCount | 可见选项数量                         | `number`                            | —                          | `5`         |
+| itemHeight   | 选项高度，单位 rpx                   | `number`                            | —                          | `100`       |
+| id           | 根节点 id                            | `string`                            | —                          | `''`        |
+| customClass  | 自定义类名                           | `string / object / array`           | —                          | `''`        |
+| customStyle  | 自定义样式                           | `string / object`                   | —                          | `''`        |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 确认选择后触发 | `(value: PickerValue)` |
-| update:visible | 弹层显示状态变化时触发 | `(visible: boolean)` |
-| pick | 滚动选择项时触发，不提交 `modelValue` | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
-| change | 确认选择后触发 | `(value: PickerValue)` |
-| confirm | 点击确认时触发 | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
-| cancel | 点击取消时触发 | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
-| open | 弹层打开时触发 | `()` |
-| close | 弹层关闭时触发 | `()` |
+| 事件名            | 说明                                                         | 回调参数                                                           |
+| ----------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ |
+| update:modelValue | 内联模式选择变化时立即触发；弹层模式点击确认时触发           | `(value: PickerValue)`                                             |
+| update:visible    | 弹层显示状态变化时触发                                       | `(visible: boolean)`                                               |
+| pick              | 选择索引变化时触发；内联模式随后立即提交，弹层模式仅更新草稿 | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
+| change            | 内联模式选择变化时立即触发；弹层模式点击确认时触发           | `(value: PickerValue)`                                             |
+| confirm           | 弹层模式点击确认并提交后触发                                 | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
+| cancel            | 弹层模式点击取消并恢复已提交值时触发                         | `(value: PickerValue, indexes: number[], options: PickerOption[])` |
+| open              | 弹层打开时触发                                               | `()`                                                               |
+| close             | 弹层关闭时触发                                               | `()`                                                               |
 
 ### PickerOption
 
-| 字段 | 说明 | 类型 |
-|------|------|------|
-| label | 展示文本 | `string` |
-| value | 选项值 | `string / number` |
-| children | 子级选项，级联模式使用 | `PickerOption[]` |
+| 字段     | 说明                   | 类型              |
+| -------- | ---------------------- | ----------------- |
+| label    | 展示文本               | `string`          |
+| value    | 选项值                 | `string / number` |
+| children | 子级选项，级联模式使用 | `PickerOption[]`  |
 
 ## 注意事项
 
 ::: tip
-`pick` 只表示当前滚动草稿值，只有点击确认后才会触发 `update:modelValue`、`change` 和 `confirm`。
+`pick` 表示真实选择索引已经变化。内联模式会紧接着提交 `v-model` 并触发 `change`；弹层模式则保留草稿，只有点击确认才提交。取消弹层不会提交草稿。
 :::
 
 ## 发布验收
 
-`lk-picker` 已纳入 high-risk showcase 回归，发布前按下面边界验收：
+发布前必须在全新干净构建上分别抓取 H5 与微信小程序运行态；两端执行相同用例：
 
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/high-risk-showcase.spec.ts` 校验组件路由、verified 状态与高风险标记 |
-| H5 / App | 人工验收 | 单列、多列、级联滚动后确认值一致；弹层打开关闭无滚动穿透 |
-| 小程序 | 人工验收 | 选择器滚动惯性、确认/取消事件顺序与 H5 保持一致 |
+| 场景         | Peekit 操作                                                                                           | 客观通过条件                                                                                                                                         |
+| ------------ | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 内联即时提交 | 在 `#picker-inline-demo` 的组件 scope 内查询 `.lk-picker__item`，轻点“蓝色”                           | `#picker-inline-value` 严格变为 `value=blue；label=蓝色；events=pick:blue > update:blue > change:blue`，三个事件各一次                               |
+| 相同项去重   | 页面刷新后轻点当前选中的“绿色”                                                                        | `#picker-inline-value` 仍为 `value=green；label=绿色；events=none`                                                                                   |
+| 弹层草稿     | 轻点 `#picker-popup-open`，在 `#picker-popup-demo` scope 选“蓝色”，确认前后查询 `#picker-popup-state` | 确认前 `value=green` 且事件为 `open > pick:blue`；确认后严格为 `open > pick:blue > update:blue > change:blue > confirm:blue > visible:false > close` |
+| 弹层取消     | 重新打开弹层，选未提交项，再点取消并查询 `#picker-popup-state`                                        | value 保持打开前值；尾部为 `cancel:<已提交值> > visible:false > close`；整条记录没有 `update` 或 `change`                                            |
+| 级联父项变化 | 在级联数据切换父列                                                                                    | 子列索引归零，value、indexes、options 与新分支同一路径；H5 与微信结果完全一致                                                                        |
+| 几何与错误   | 查询每列、选中指示器及可视区 rect，并读取 console/runtime errors                                      | 每列和指示器 rect 非零且位于可视区；无重复目标、无越界、无 console/runtime error                                                                     |
+
+H5 可从页面查询组件内部节点；微信端必须先进入 `lk-picker` 组件 scope 再查询 `.lk-picker__item`。构建成功、showcase 的 `verified` 字段、静态 WXML 或只点击外层容器均不能替代上述运行证据。
 
 ::: warning
-不同端的滚轮手感和选择器 UI 会有平台差异，公开示例只承诺事件和值同步语义一致，不承诺原生滚动视觉完全一致。
+H5 与微信的滚动手感可以存在平台差异，但提交值、完整 payload、事件顺序和事件次数必须一致。
 :::

--- a/src/components/demos/picker-demo.vue
+++ b/src/components/demos/picker-demo.vue
@@ -18,10 +18,38 @@ const display = computed(() => {
   const m = new Map(columns.map(o => [o.value, o.label]));
   return m.get(value.value) || '';
 });
+const popupEvents = ref<string[]>([]);
+const inlineValue = ref('green');
+const inlineDisplay = computed(
+  () => columns.find(option => option.value === inlineValue.value)?.label || ''
+);
+const inlineEvents = ref<string[]>([]);
+
+function recordInlinePick(nextValue: string | number | (string | number)[]) {
+  inlineEvents.value.push(`pick:${String(nextValue)}`);
+}
+
+function recordInlineUpdate(nextValue: string | number | (string | number)[]) {
+  inlineEvents.value.push(`update:${String(nextValue)}`);
+}
+
+function recordInlineChange(nextValue: string | number | (string | number)[]) {
+  inlineEvents.value.push(`change:${String(nextValue)}`);
+}
 
 function onConfirm(v: string | number | (string | number)[]) {
+  popupEvents.value.push(`confirm:${String(v)}`);
   const selected = Array.isArray(v) ? undefined : columns.find(o => o.value === v);
   uni.showToast({ title: `已选择: ${selected?.label || display.value}`, icon: 'none' });
+}
+
+function openSinglePicker() {
+  popupEvents.value = [];
+  show.value = true;
+}
+
+function recordPopupEvent(name: string, nextValue?: unknown) {
+  popupEvents.value.push(nextValue === undefined ? name : `${name}:${String(nextValue)}`);
 }
 
 // 多列选择器
@@ -100,16 +128,47 @@ const cascadeDisplay = computed(() => {
 
 <template>
   <view class="component-demo">
-    <demo-block title="单列选择器">
-      <lk-button @click="show = true">选择颜色</lk-button>
-      <view class="result">当前：{{ display }}</view>
+    <demo-block title="内联即时提交">
+      <view id="picker-inline-value" class="result picker-inline-value">
+        value={{ inlineValue }}；label={{ inlineDisplay }}；events={{
+          inlineEvents.join(' > ') || 'none'
+        }}
+      </view>
       <lk-picker
+        id="picker-inline-demo"
+        v-model="inlineValue"
+        inline
+        mode="single"
+        title="选择颜色（即时生效）"
+        :columns="columns"
+        @pick="recordInlinePick"
+        @update:model-value="recordInlineUpdate"
+        @change="recordInlineChange"
+      />
+    </demo-block>
+
+    <demo-block title="单列选择器">
+      <lk-button id="picker-popup-open" @click="openSinglePicker">选择颜色</lk-button>
+      <view id="picker-popup-state" class="result">
+        value={{ value }}；label={{ display }}；visible={{ show }}；events={{
+          popupEvents.join(' > ') || 'none'
+        }}
+      </view>
+      <lk-picker
+        id="picker-popup-demo"
         v-model:visible="show"
         v-model="value"
         mode="single"
         title="请选择颜色"
         :columns="columns"
+        @open="recordPopupEvent('open')"
+        @pick="nextValue => recordPopupEvent('pick', nextValue)"
+        @update:model-value="nextValue => recordPopupEvent('update', nextValue)"
+        @change="nextValue => recordPopupEvent('change', nextValue)"
         @confirm="onConfirm"
+        @cancel="nextValue => recordPopupEvent('cancel', nextValue)"
+        @update:visible="nextVisible => recordPopupEvent('visible', nextVisible)"
+        @close="recordPopupEvent('close')"
       />
     </demo-block>
 

--- a/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue
+++ b/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
-import { pickerProps, pickerEmits, type PickerOption, type PickerValue } from './picker.props';
+import { pickerProps, pickerEmits, type PickerOption } from './picker.props';
 import LkPopup from '../lk-popup/lk-popup.vue';
 import { useLocale } from '../../composables/useLocale';
 import {
   clampPickerIndex,
+  dispatchPickerCancelEvents,
+  dispatchPickerConfirmEvents,
+  dispatchPickerSelectionEvents,
   resolvePickerColumnOffset,
   resolvePickerColumnOffsetByDelta,
   resolvePickerColumnWrapperStyle,
-  getPickerOptionsByIndexes,
-  getPickerValueByIndexes,
-  resolveCascadePickerIndexes,
   resolvePickerClass,
+  resolvePickerColumnSelection,
   resolvePickerColumns,
+  resolvePickerDraftSelection,
   resolvePickerIndicatorStyle,
   resolvePickerItemStyle,
   resolvePickerItemLabelClass,
@@ -21,8 +23,7 @@ import {
   resolvePickerScrollEnd,
   resolvePickerViewHeight,
   resolvePickerViewWrapStyle,
-  resolvePickerIndexes,
-  syncPickerInnerValueFromModel,
+  resolvePickerSelectionSnapshot,
   type PickerRenderedColumn,
   type PickerPrimitiveValue,
 } from './picker.utils';
@@ -80,43 +81,6 @@ function getTouchY(event: unknown, changed = false): number {
   const touchEvent = event as PickerTouchEvent;
   const points = changed ? touchEvent.changedTouches : touchEvent.touches;
   return points?.[0]?.clientY || 0;
-}
-
-function normalizeIndexesForColumns(indexes: number[], columns: PickerOption[][]): number[] {
-  return columns.map((column, index) => clampPickerIndex(indexes[index] ?? 0, column.length));
-}
-
-function resolveSelectionSnapshot(indexes: number[], columns = computedColumns.value) {
-  let resolvedColumns = columns;
-  let resolvedIndexes = normalizeIndexesForColumns(indexes, resolvedColumns);
-
-  if (props.mode === 'cascade') {
-    const draftValue = getPickerValueByIndexes({
-      mode: props.mode,
-      columns: resolvedColumns,
-      indexes: resolvedIndexes,
-    });
-    resolvedColumns = resolvePickerColumns({
-      mode: props.mode,
-      columns: props.columns,
-      innerValue: Array.isArray(draftValue) ? (draftValue as PickerPrimitiveValue[]) : [],
-    });
-    resolvedIndexes = normalizeIndexesForColumns(resolvedIndexes, resolvedColumns);
-  }
-
-  const value = getPickerValueByIndexes({
-    mode: props.mode,
-    columns: resolvedColumns,
-    indexes: resolvedIndexes,
-  });
-  const options = getPickerOptionsByIndexes(resolvedColumns, resolvedIndexes);
-
-  return {
-    columns: resolvedColumns,
-    indexes: resolvedIndexes,
-    value,
-    options,
-  };
 }
 
 function setColumnScrollState(columnIndex: number, offset: number, duration: number) {
@@ -185,7 +149,9 @@ function updateRenderedColumns(skipColumnIndex = -1) {
 
 function syncColumnScrollState(indexes = selectedIndexes.value, skipColumnIndex = -1) {
   const columns = computedColumns.value;
-  const nextIndexes = normalizeIndexesForColumns(indexes, columns);
+  const nextIndexes = columns.map((column, index) =>
+    clampPickerIndex(indexes[index] ?? 0, column.length)
+  );
   columnOffsets.value = columns.map((column, columnIndex) => {
     if (columnIndex === skipColumnIndex && columnOffsets.value[columnIndex] !== undefined) {
       return columnOffsets.value[columnIndex];
@@ -208,62 +174,24 @@ function scheduleRenderedColumnSettle(columnIndex: number, offset: number, durat
   }, duration + 40);
 }
 
-// 根据 modelValue 初始化选中索引
-function initIndexes() {
-  const cols = computedColumns.value;
-  const mv = props.modelValue;
-
-  if (!cols.length) {
-    selectedIndexes.value = [];
-    return;
-  }
-
-  if (props.mode === 'single') {
-    selectedIndexes.value = normalizeIndexesForColumns(
-      resolvePickerIndexes({
-        mode: props.mode,
-        columns: cols,
-        modelValue: mv,
-      }),
-      cols
-    );
-  } else {
-    const arr = Array.isArray(mv) ? mv : [];
-    innerValue.value = arr.slice();
-    selectedIndexes.value = normalizeIndexesForColumns(
-      resolvePickerIndexes({
-        mode: props.mode,
-        columns: cols,
-        modelValue: mv,
-      }),
-      cols
-    );
-  }
-}
-
-function syncInnerValueFromModel() {
-  innerValue.value = syncPickerInnerValueFromModel({
+function getSelectionSnapshot(indexes = selectedIndexes.value) {
+  return resolvePickerSelectionSnapshot({
     mode: props.mode,
-    modelValue: props.modelValue,
-  });
-}
-
-function getValueByIndexes(indexes: number[]): PickerValue {
-  return getPickerValueByIndexes({
-    mode: props.mode,
-    columns: computedColumns.value,
+    columns: props.columns,
+    resolvedColumns: computedColumns.value,
     indexes,
   });
 }
 
-function getOptionsByIndexes(indexes: number[]): PickerOption[] {
-  return getPickerOptionsByIndexes(computedColumns.value, indexes);
-}
-
 function resetDraftSelection() {
-  syncInnerValueFromModel();
-  initIndexes();
-  syncColumnScrollState();
+  const draft = resolvePickerDraftSelection({
+    mode: props.mode,
+    columns: props.columns,
+    modelValue: props.modelValue,
+  });
+  innerValue.value = draft.innerValue;
+  selectedIndexes.value = draft.indexes;
+  syncColumnScrollState(draft.indexes);
 }
 
 watch(
@@ -296,32 +224,35 @@ watch(
 
 function commitColumnIndex(columnIndex: number, optionIndex: number) {
   const columns = computedColumns.value;
-  const nextIndexes = columns.map((column, index) => {
-    if (index === columnIndex) return clampPickerIndex(optionIndex, column.length);
-    return clampPickerIndex(selectedIndexes.value[index] ?? 0, column.length);
-  });
-  const cascadeIndexes = resolveCascadePickerIndexes({
-    nextIndexes,
-    previousIndexes: selectedIndexes.value,
+  const selection = resolvePickerColumnSelection({
     mode: props.mode,
+    columns: props.columns,
+    resolvedColumns: columns,
+    previousIndexes: selectedIndexes.value,
+    columnIndex,
+    optionIndex,
   });
-  const snapshot = resolveSelectionSnapshot(cascadeIndexes, columns);
-  const changed = snapshot.indexes.some((item, index) => item !== selectedIndexes.value[index]);
 
-  selectedIndexes.value = snapshot.indexes;
+  selectedIndexes.value = selection.indexes;
 
   if (props.mode !== 'single') {
-    innerValue.value = Array.isArray(snapshot.value)
-      ? (snapshot.value as PickerPrimitiveValue[])
+    innerValue.value = Array.isArray(selection.value)
+      ? (selection.value as PickerPrimitiveValue[])
       : [];
   }
 
-  if (changed) {
-    emit('pick', snapshot.value, snapshot.indexes, snapshot.options);
-  }
+  dispatchPickerSelectionEvents({
+    inline: props.inline,
+    selection,
+    onPick: (value, indexes, options) => emit('pick', value, indexes, options),
+    onUpdateModelValue: value => emit('update:modelValue', value),
+    onChange: value => emit('change', value),
+  });
 
   nextTick(() => {
-    const normalized = normalizeIndexesForColumns(selectedIndexes.value, computedColumns.value);
+    const normalized = computedColumns.value.map((column, index) =>
+      clampPickerIndex(selectedIndexes.value[index] ?? 0, column.length)
+    );
     selectedIndexes.value = normalized;
     syncColumnScrollState(normalized, columnIndex);
   });
@@ -398,21 +329,21 @@ onBeforeUnmount(() => {
 
 function onCancel() {
   resetDraftSelection();
-  const value = getValueByIndexes(selectedIndexes.value);
-  emit('cancel', value, selectedIndexes.value, getOptionsByIndexes(selectedIndexes.value));
-  emit('update:visible', false);
+  dispatchPickerCancelEvents({
+    snapshot: getSelectionSnapshot(),
+    onCancel: (value, indexes, options) => emit('cancel', value, indexes, options),
+    onVisibleChange: visible => emit('update:visible', visible),
+  });
 }
 
 function onConfirm() {
-  const snapshot = resolveSelectionSnapshot(selectedIndexes.value);
-  const value = snapshot.value;
-  const indexes = [...snapshot.indexes];
-  const options = snapshot.options;
-
-  emit('update:modelValue', value);
-  emit('change', value);
-  emit('confirm', value, indexes, options);
-  emit('update:visible', false);
+  dispatchPickerConfirmEvents({
+    snapshot: getSelectionSnapshot(),
+    onUpdateModelValue: value => emit('update:modelValue', value),
+    onChange: value => emit('change', value),
+    onConfirm: (value, indexes, options) => emit('confirm', value, [...indexes], options),
+    onVisibleChange: visible => emit('update:visible', visible),
+  });
 }
 
 /** 分层样式挂在 text 上，减少整项节点在滚动选中时的样式抖动。 */

--- a/src/uni_modules/lucky-ui/components/lk-picker/picker.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-picker/picker.utils.ts
@@ -19,6 +19,22 @@ export interface PickerRenderedColumn {
   virtual: boolean;
 }
 
+export interface PickerSelectionSnapshot {
+  columns: PickerOption[][];
+  indexes: number[];
+  value: PickerValue;
+  options: PickerOption[];
+}
+
+export interface PickerColumnSelection extends PickerSelectionSnapshot {
+  changed: boolean;
+}
+
+interface PickerCommitCallbacks {
+  onUpdateModelValue: (value: PickerValue) => void;
+  onChange: (value: PickerValue) => void;
+}
+
 export function normalizePickerColumns(columns: PickerColumns): PickerOption[][] {
   if (!Array.isArray(columns) || columns.length === 0) return [];
   if (Array.isArray(columns[0])) return columns as PickerOption[][];
@@ -43,6 +59,22 @@ export function buildCascadePickerColumns(
   return result;
 }
 
+export function buildCascadePickerColumnsByIndexes(
+  data: PickerOption[],
+  indexes: number[]
+): PickerOption[][] {
+  const result: PickerOption[][] = [];
+  let currentLevel = data;
+
+  for (let level = 0; currentLevel && currentLevel.length > 0; level++) {
+    result.push(currentLevel);
+    const selectedIndex = clampPickerIndex(indexes[level] ?? 0, currentLevel.length);
+    currentLevel = currentLevel[selectedIndex]?.children || [];
+  }
+
+  return result;
+}
+
 export function resolvePickerColumns(options: {
   mode: PickerMode;
   columns: PickerColumns;
@@ -61,6 +93,13 @@ export function syncPickerInnerValueFromModel(options: {
 }): PickerPrimitiveValue[] {
   if (options.mode !== 'cascade' && options.mode !== 'multi') return [];
   return Array.isArray(options.modelValue) ? options.modelValue.slice() : [];
+}
+
+export function normalizePickerIndexesForColumns(
+  indexes: number[],
+  columns: PickerOption[][]
+): number[] {
+  return columns.map((column, index) => clampPickerIndex(indexes[index] ?? 0, column.length));
 }
 
 export function resolvePickerIndexes(options: {
@@ -121,6 +160,126 @@ export function resolveCascadePickerIndexes(options: {
   }
 
   return indexes;
+}
+
+export function resolvePickerDraftSelection(options: {
+  mode: PickerMode;
+  columns: PickerColumns;
+  modelValue: PickerValue | undefined;
+}): Pick<PickerSelectionSnapshot, 'columns' | 'indexes'> & {
+  innerValue: PickerPrimitiveValue[];
+} {
+  const innerValue = syncPickerInnerValueFromModel({
+    mode: options.mode,
+    modelValue: options.modelValue,
+  });
+  const columns = resolvePickerColumns({
+    mode: options.mode,
+    columns: options.columns,
+    innerValue,
+  });
+  const indexes = normalizePickerIndexesForColumns(
+    resolvePickerIndexes({
+      mode: options.mode,
+      columns,
+      modelValue: options.modelValue,
+    }),
+    columns
+  );
+
+  return { innerValue, columns, indexes };
+}
+
+export function resolvePickerSelectionSnapshot(options: {
+  mode: PickerMode;
+  columns: PickerColumns;
+  resolvedColumns: PickerOption[][];
+  indexes: number[];
+}): PickerSelectionSnapshot {
+  const columns =
+    options.mode === 'cascade'
+      ? buildCascadePickerColumnsByIndexes(options.columns as PickerOption[], options.indexes)
+      : options.resolvedColumns;
+  const indexes = normalizePickerIndexesForColumns(options.indexes, columns);
+
+  return {
+    columns,
+    indexes,
+    value: getPickerValueByIndexes({ mode: options.mode, columns, indexes }),
+    options: getPickerOptionsByIndexes(columns, indexes),
+  };
+}
+
+export function resolvePickerColumnSelection(options: {
+  mode: PickerMode;
+  columns: PickerColumns;
+  resolvedColumns: PickerOption[][];
+  previousIndexes: number[];
+  columnIndex: number;
+  optionIndex: number;
+}): PickerColumnSelection {
+  const nextIndexes = options.resolvedColumns.map((column, index) => {
+    if (index === options.columnIndex) return clampPickerIndex(options.optionIndex, column.length);
+    return clampPickerIndex(options.previousIndexes[index] ?? 0, column.length);
+  });
+  const indexes = resolveCascadePickerIndexes({
+    nextIndexes,
+    previousIndexes: options.previousIndexes,
+    mode: options.mode,
+  });
+  const snapshot = resolvePickerSelectionSnapshot({
+    mode: options.mode,
+    columns: options.columns,
+    resolvedColumns: options.resolvedColumns,
+    indexes,
+  });
+  const changed =
+    snapshot.indexes.length !== options.previousIndexes.length ||
+    snapshot.indexes.some((item, index) => item !== options.previousIndexes[index]);
+
+  return { ...snapshot, changed };
+}
+
+export function commitPickerValue(value: PickerValue, callbacks: PickerCommitCallbacks): void {
+  callbacks.onUpdateModelValue(value);
+  callbacks.onChange(value);
+}
+
+export function dispatchPickerSelectionEvents(options: {
+  inline: boolean;
+  selection: PickerColumnSelection;
+  onPick: (value: PickerValue, indexes: number[], selected: PickerOption[]) => void;
+  onUpdateModelValue: PickerCommitCallbacks['onUpdateModelValue'];
+  onChange: PickerCommitCallbacks['onChange'];
+}): boolean {
+  if (!options.selection.changed) return false;
+
+  options.onPick(options.selection.value, options.selection.indexes, options.selection.options);
+  if (options.inline) {
+    commitPickerValue(options.selection.value, options);
+  }
+  return true;
+}
+
+export function dispatchPickerConfirmEvents(options: {
+  snapshot: PickerSelectionSnapshot;
+  onUpdateModelValue: PickerCommitCallbacks['onUpdateModelValue'];
+  onChange: PickerCommitCallbacks['onChange'];
+  onConfirm: (value: PickerValue, indexes: number[], selected: PickerOption[]) => void;
+  onVisibleChange: (visible: boolean) => void;
+}): void {
+  commitPickerValue(options.snapshot.value, options);
+  options.onConfirm(options.snapshot.value, options.snapshot.indexes, options.snapshot.options);
+  options.onVisibleChange(false);
+}
+
+export function dispatchPickerCancelEvents(options: {
+  snapshot: PickerSelectionSnapshot;
+  onCancel: (value: PickerValue, indexes: number[], selected: PickerOption[]) => void;
+  onVisibleChange: (visible: boolean) => void;
+}): void {
+  options.onCancel(options.snapshot.value, options.snapshot.indexes, options.snapshot.options);
+  options.onVisibleChange(false);
 }
 
 export function clampPickerNumber(value: number, min: number, max: number): number {

--- a/tests/unit/lk-picker.spec.ts
+++ b/tests/unit/lk-picker.spec.ts
@@ -1,21 +1,39 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCascadePickerColumns,
+  buildCascadePickerColumnsByIndexes,
+  dispatchPickerCancelEvents,
+  dispatchPickerConfirmEvents,
+  dispatchPickerSelectionEvents,
   getPickerOptionsByIndexes,
   getPickerValueByIndexes,
   normalizePickerColumns,
   resolveCascadePickerIndexes,
   resolvePickerClass,
+  resolvePickerColumnSelection,
   resolvePickerColumns,
   resolvePickerDistanceBucket,
+  resolvePickerDraftSelection,
   resolvePickerIndexes,
   resolvePickerIndicatorStyle,
   resolvePickerItemLabelClass,
+  resolvePickerSelectionSnapshot,
   resolvePickerViewHeight,
   resolvePickerViewWrapStyle,
   syncPickerInnerValueFromModel,
 } from '../../src/uni_modules/lucky-ui/components/lk-picker/picker.utils';
-import type { PickerOption } from '../../src/uni_modules/lucky-ui/components/lk-picker/picker.props';
+import type {
+  PickerOption,
+  PickerValue,
+} from '../../src/uni_modules/lucky-ui/components/lk-picker/picker.props';
+
+type PickerEventRecord = [name: string, ...payload: unknown[]];
+
+function recordPickerEvent(events: PickerEventRecord[], name: string) {
+  return (...payload: unknown[]) => {
+    events.push([name, ...payload]);
+  };
+}
 
 describe('lk-picker column and selection rules', () => {
   const singleColumn: PickerOption[] = [
@@ -57,17 +75,20 @@ describe('lk-picker column and selection rules', () => {
   });
 
   it('builds cascade columns from current values', () => {
-    expect(buildCascadePickerColumns(cascade, ['js']).map(column => column.map(item => item.value)))
-      .toEqual([
-        ['zj', 'js'],
-        ['nj', 'sz'],
-      ]);
+    expect(
+      buildCascadePickerColumns(cascade, ['js']).map(column => column.map(item => item.value))
+    ).toEqual([
+      ['zj', 'js'],
+      ['nj', 'sz'],
+    ]);
 
-    expect(resolvePickerColumns({
-      mode: 'cascade',
-      columns: cascade,
-      innerValue: ['zj', 'nb'],
-    }).map(column => column.map(item => item.value))).toEqual([
+    expect(
+      resolvePickerColumns({
+        mode: 'cascade',
+        columns: cascade,
+        innerValue: ['zj', 'nb'],
+      }).map(column => column.map(item => item.value))
+    ).toEqual([
       ['zj', 'js'],
       ['hz', 'nb'],
     ]);
@@ -75,73 +96,97 @@ describe('lk-picker column and selection rules', () => {
 
   it('syncs draft value only for multi and cascade modes', () => {
     expect(syncPickerInnerValueFromModel({ mode: 'single', modelValue: 'bj' })).toEqual([]);
-    expect(syncPickerInnerValueFromModel({ mode: 'multi', modelValue: ['bj', 2] }))
-      .toEqual(['bj', 2]);
+    expect(syncPickerInnerValueFromModel({ mode: 'multi', modelValue: ['bj', 2] })).toEqual([
+      'bj',
+      2,
+    ]);
     expect(syncPickerInnerValueFromModel({ mode: 'cascade', modelValue: 'zj' })).toEqual([]);
   });
 
   it('resolves selected indexes for single and multi modes with fallback to first item', () => {
-    expect(resolvePickerIndexes({
-      mode: 'single',
-      columns: [singleColumn],
-      modelValue: 'sh',
-    })).toEqual([1]);
-    expect(resolvePickerIndexes({
-      mode: 'single',
-      columns: [singleColumn],
-      modelValue: 'missing',
-    })).toEqual([0]);
-    expect(resolvePickerIndexes({
-      mode: 'multi',
-      columns: multiColumns,
-      modelValue: ['bj', 2],
-    })).toEqual([0, 1]);
+    expect(
+      resolvePickerIndexes({
+        mode: 'single',
+        columns: [singleColumn],
+        modelValue: 'sh',
+      })
+    ).toEqual([1]);
+    expect(
+      resolvePickerIndexes({
+        mode: 'single',
+        columns: [singleColumn],
+        modelValue: 'missing',
+      })
+    ).toEqual([0]);
+    expect(
+      resolvePickerIndexes({
+        mode: 'multi',
+        columns: multiColumns,
+        modelValue: ['bj', 2],
+      })
+    ).toEqual([0, 1]);
   });
 
   it('resolves values and options by indexes', () => {
-    expect(getPickerValueByIndexes({
-      mode: 'single',
-      columns: [singleColumn],
-      indexes: [1],
-    })).toBe('sh');
-    expect(getPickerValueByIndexes({
-      mode: 'multi',
-      columns: multiColumns,
-      indexes: [1, 0],
-    })).toEqual(['sh', 1]);
-    expect(getPickerOptionsByIndexes(multiColumns, [1, 0]).map(item => item.label))
-      .toEqual(['上海', '上午']);
+    expect(
+      getPickerValueByIndexes({
+        mode: 'single',
+        columns: [singleColumn],
+        indexes: [1],
+      })
+    ).toBe('sh');
+    expect(
+      getPickerValueByIndexes({
+        mode: 'multi',
+        columns: multiColumns,
+        indexes: [1, 0],
+      })
+    ).toEqual(['sh', 1]);
+    expect(getPickerOptionsByIndexes(multiColumns, [1, 0]).map(item => item.label)).toEqual([
+      '上海',
+      '上午',
+    ]);
   });
 
   it('resets following indexes when cascade parent changes', () => {
-    expect(resolveCascadePickerIndexes({
-      mode: 'cascade',
-      previousIndexes: [0, 1, 1],
-      nextIndexes: [1, 1, 1],
-    })).toEqual([1, 0, 0]);
-    expect(resolveCascadePickerIndexes({
-      mode: 'multi',
-      previousIndexes: [0, 1],
-      nextIndexes: [1, 1],
-    })).toEqual([1, 1]);
+    expect(
+      resolveCascadePickerIndexes({
+        mode: 'cascade',
+        previousIndexes: [0, 1, 1],
+        nextIndexes: [1, 1, 1],
+      })
+    ).toEqual([1, 0, 0]);
+    expect(
+      resolveCascadePickerIndexes({
+        mode: 'multi',
+        previousIndexes: [0, 1],
+        nextIndexes: [1, 1],
+      })
+    ).toEqual([1, 1]);
   });
 
   it('builds distance bucket and label class metadata', () => {
-    expect(resolvePickerDistanceBucket({
-      selectedIndexes: [2],
-      columnIndex: 0,
-      optionIndex: 2,
-    })).toBe(0);
-    expect(resolvePickerDistanceBucket({
-      selectedIndexes: [2],
-      columnIndex: 0,
-      optionIndex: 8,
-    })).toBe(3);
-    expect(resolvePickerItemLabelClass({
-      selectedIndexes: [1],
-      columnIndex: 0,
-      optionIndex: 2,
-    })).toBe('lk-picker__item-label lk-picker__item-label--dist1');
+    expect(
+      resolvePickerDistanceBucket({
+        selectedIndexes: [2],
+        columnIndex: 0,
+        optionIndex: 2,
+      })
+    ).toBe(0);
+    expect(
+      resolvePickerDistanceBucket({
+        selectedIndexes: [2],
+        columnIndex: 0,
+        optionIndex: 8,
+      })
+    ).toBe(3);
+    expect(
+      resolvePickerItemLabelClass({
+        selectedIndexes: [1],
+        columnIndex: 0,
+        optionIndex: 2,
+      })
+    ).toBe('lk-picker__item-label lk-picker__item-label--dist1');
   });
 
   it('builds view styles and root classes', () => {
@@ -153,5 +198,306 @@ describe('lk-picker column and selection rules', () => {
       { 'lk-picker--inline': true },
       'custom',
     ]);
+  });
+});
+
+describe('lk-picker inline and popup commit behavior', () => {
+  const singleColumn: PickerOption[] = [
+    { label: '北京', value: 'bj' },
+    { label: '上海', value: 'sh' },
+  ];
+  const multiColumns: PickerOption[][] = [
+    singleColumn,
+    [
+      { label: '上午', value: 'am' },
+      { label: '下午', value: 'pm' },
+    ],
+  ];
+  const cascadeColumns: PickerOption[] = [
+    {
+      label: '浙江',
+      value: 'zj',
+      children: [
+        { label: '杭州', value: 'hz' },
+        { label: '宁波', value: 'nb' },
+      ],
+    },
+    {
+      label: '江苏',
+      value: 'js',
+      children: [
+        { label: '南京', value: 'nj' },
+        { label: '苏州', value: 'sz' },
+      ],
+    },
+  ];
+  const deepCascadeColumns: PickerOption[] = [
+    {
+      label: '旧父级',
+      value: 'old-parent',
+      children: [
+        {
+          label: '旧共享值',
+          value: 'shared-child',
+          children: [{ label: '旧叶子', value: 'old-leaf' }],
+        },
+      ],
+    },
+    {
+      label: '新父级',
+      value: 'new-parent',
+      children: [
+        {
+          label: '新首项',
+          value: 'new-first-child',
+          children: [{ label: '正确叶子', value: 'correct-leaf' }],
+        },
+        {
+          label: '新共享值',
+          value: 'shared-child',
+          children: [{ label: '错误分支叶子', value: 'wrong-branch-leaf' }],
+        },
+      ],
+    },
+  ];
+
+  function dispatchSelection(
+    inline: boolean,
+    selection: ReturnType<typeof resolvePickerColumnSelection>,
+    events: PickerEventRecord[]
+  ) {
+    return dispatchPickerSelectionEvents({
+      inline,
+      selection,
+      onPick: recordPickerEvent(events, 'pick'),
+      onUpdateModelValue: recordPickerEvent(events, 'update:modelValue'),
+      onChange: recordPickerEvent(events, 'change'),
+    });
+  }
+
+  it('rebuilds controlled draft state after model, columns and mode updates', () => {
+    expect(
+      resolvePickerDraftSelection({
+        mode: 'single',
+        columns: singleColumn,
+        modelValue: 'sh',
+      })
+    ).toMatchObject({ innerValue: [], indexes: [1] });
+
+    expect(
+      resolvePickerDraftSelection({
+        mode: 'multi',
+        columns: multiColumns,
+        modelValue: ['bj', 'pm'],
+      })
+    ).toMatchObject({ innerValue: ['bj', 'pm'], indexes: [0, 1] });
+
+    const cascadeDraft = resolvePickerDraftSelection({
+      mode: 'cascade',
+      columns: cascadeColumns,
+      modelValue: ['js', 'sz'],
+    });
+    expect(cascadeDraft.innerValue).toEqual(['js', 'sz']);
+    expect(cascadeDraft.indexes).toEqual([1, 1]);
+    expect(cascadeDraft.columns[1].map(option => option.value)).toEqual(['nj', 'sz']);
+
+    expect(
+      resolvePickerDraftSelection({
+        mode: 'single',
+        columns: [{ label: '广州', value: 'gz' }],
+        modelValue: 'sh',
+      }).indexes
+    ).toEqual([0]);
+  });
+
+  it('commits an inline single selection once in pick-update-change order', () => {
+    const selection = resolvePickerColumnSelection({
+      mode: 'single',
+      columns: singleColumn,
+      resolvedColumns: [singleColumn],
+      previousIndexes: [0],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+    const events: PickerEventRecord[] = [];
+
+    expect(dispatchSelection(true, selection, events)).toBe(true);
+    expect(events.map(([name]) => name)).toEqual(['pick', 'update:modelValue', 'change']);
+    expect(events.map(([, value]) => value)).toEqual(['sh', 'sh', 'sh']);
+    expect(events[0][2]).toEqual([1]);
+    expect((events[0][3] as PickerOption[]).map(option => option.value)).toEqual(['sh']);
+  });
+
+  it('does not emit for an unchanged index and commits a full multi value', () => {
+    const unchanged = resolvePickerColumnSelection({
+      mode: 'multi',
+      columns: multiColumns,
+      resolvedColumns: multiColumns,
+      previousIndexes: [0, 1],
+      columnIndex: 0,
+      optionIndex: 0,
+    });
+    const events: PickerEventRecord[] = [];
+
+    expect(dispatchSelection(true, unchanged, events)).toBe(false);
+    expect(events).toEqual([]);
+
+    const changed = resolvePickerColumnSelection({
+      mode: 'multi',
+      columns: multiColumns,
+      resolvedColumns: multiColumns,
+      previousIndexes: [0, 1],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+    expect(dispatchSelection(true, changed, events)).toBe(true);
+    expect(events.map(([name]) => name)).toEqual(['pick', 'update:modelValue', 'change']);
+    expect(events.map(([, value]) => value)).toEqual([
+      ['sh', 'pm'],
+      ['sh', 'pm'],
+      ['sh', 'pm'],
+    ]);
+  });
+
+  it('commits the rebuilt full cascade value when a parent column changes', () => {
+    const resolvedColumns = resolvePickerColumns({
+      mode: 'cascade',
+      columns: cascadeColumns,
+      innerValue: ['zj', 'nb'],
+    });
+    const selection = resolvePickerColumnSelection({
+      mode: 'cascade',
+      columns: cascadeColumns,
+      resolvedColumns,
+      previousIndexes: [0, 1],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+    const events: PickerEventRecord[] = [];
+
+    expect(selection.indexes).toEqual([1, 0]);
+    expect(selection.value).toEqual(['js', 'nj']);
+    expect(selection.options.map(option => option.value)).toEqual(['js', 'nj']);
+    expect(dispatchSelection(true, selection, events)).toBe(true);
+    expect(events.map(([name]) => name)).toEqual(['pick', 'update:modelValue', 'change']);
+    expect(events.map(([, value]) => value)).toEqual([
+      ['js', 'nj'],
+      ['js', 'nj'],
+      ['js', 'nj'],
+    ]);
+  });
+
+  it('rebuilds deep cascade columns from reset indexes instead of matching stale branch values', () => {
+    const resolvedColumns = resolvePickerColumns({
+      mode: 'cascade',
+      columns: deepCascadeColumns,
+      innerValue: ['old-parent', 'shared-child', 'old-leaf'],
+    });
+    const selection = resolvePickerColumnSelection({
+      mode: 'cascade',
+      columns: deepCascadeColumns,
+      resolvedColumns,
+      previousIndexes: [0, 0, 0],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+
+    expect(selection.indexes).toEqual([1, 0, 0]);
+    expect(selection.value).toEqual(['new-parent', 'new-first-child', 'correct-leaf']);
+    expect(selection.options.map(option => option.value)).toEqual([
+      'new-parent',
+      'new-first-child',
+      'correct-leaf',
+    ]);
+    expect(
+      buildCascadePickerColumnsByIndexes(deepCascadeColumns, [1, 0, 0]).map(column =>
+        column.map(option => option.value)
+      )
+    ).toEqual([
+      ['old-parent', 'new-parent'],
+      ['new-first-child', 'shared-child'],
+      ['correct-leaf'],
+    ]);
+  });
+
+  it('keeps popup selection as draft until confirm commits it', () => {
+    const selection = resolvePickerColumnSelection({
+      mode: 'single',
+      columns: singleColumn,
+      resolvedColumns: [singleColumn],
+      previousIndexes: [0],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+    const events: PickerEventRecord[] = [];
+
+    expect(dispatchSelection(false, selection, events)).toBe(true);
+    expect(events.map(([name]) => name)).toEqual(['pick']);
+
+    dispatchPickerConfirmEvents({
+      snapshot: selection,
+      onUpdateModelValue: recordPickerEvent(events, 'update:modelValue'),
+      onChange: recordPickerEvent(events, 'change'),
+      onConfirm: recordPickerEvent(events, 'confirm'),
+      onVisibleChange: recordPickerEvent(events, 'update:visible'),
+    });
+
+    expect(events.map(([name]) => name)).toEqual([
+      'pick',
+      'update:modelValue',
+      'change',
+      'confirm',
+      'update:visible',
+    ]);
+    expect(events[1][1]).toBe('sh');
+    expect(events[4][1]).toBe(false);
+  });
+
+  it('resets popup cancel payload to the controlled value without committing', () => {
+    const draft = resolvePickerDraftSelection({
+      mode: 'single',
+      columns: singleColumn,
+      modelValue: 'bj',
+    });
+    const resetSnapshot = resolvePickerSelectionSnapshot({
+      mode: 'single',
+      columns: singleColumn,
+      resolvedColumns: draft.columns,
+      indexes: draft.indexes,
+    });
+    const events: PickerEventRecord[] = [];
+
+    dispatchPickerCancelEvents({
+      snapshot: resetSnapshot,
+      onCancel: recordPickerEvent(events, 'cancel'),
+      onVisibleChange: recordPickerEvent(events, 'update:visible'),
+    });
+
+    expect(events.map(([name]) => name)).toEqual(['cancel', 'update:visible']);
+    expect(events[0][1]).toBe('bj');
+    expect(events[1][1]).toBe(false);
+    expect(events.some(([name]) => name === 'update:modelValue' || name === 'change')).toBe(false);
+  });
+
+  it('keeps callback payloads within the public PickerValue contract', () => {
+    const values: PickerValue[] = [];
+    const selection = resolvePickerColumnSelection({
+      mode: 'single',
+      columns: singleColumn,
+      resolvedColumns: [singleColumn],
+      previousIndexes: [0],
+      columnIndex: 0,
+      optionIndex: 1,
+    });
+
+    dispatchPickerSelectionEvents({
+      inline: true,
+      selection,
+      onPick: value => values.push(value),
+      onUpdateModelValue: value => values.push(value),
+      onChange: value => values.push(value),
+    });
+
+    expect(values).toEqual(['sh', 'sh', 'sh']);
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(picker): commit inline selections`。
- 保留提交 `df85d32388b0` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。