### PR TITLE
fix(toast): enforce exact-once lifecycle

### DIFF
--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -36,10 +36,10 @@ phone: toast
 
 ```vue
 <script setup lang="ts">
-import { toastStore } from '@/uni_modules/lucky-ui/components/lk-toast/toast-manager'
+import { toastStore } from '@/uni_modules/lucky-ui/components/lk-toast/toast-manager';
 
 function showMsg() {
-  toastStore.show('操作成功！')
+  toastStore.show('操作成功！');
 }
 </script>
 
@@ -52,11 +52,17 @@ function showMsg() {
 
 ```vue
 <script setup lang="ts">
-import { toastStore } from '@/uni_modules/lucky-ui'
+import { toastStore } from '@/uni_modules/lucky-ui';
 
-function top() { toastStore.show({ message: '顶部提示', position: 'top' }) }
-function center() { toastStore.show({ message: '居中提示', position: 'center' }) }
-function bottom() { toastStore.show({ message: '底部提示', position: 'bottom' }) }
+function top() {
+  toastStore.show({ message: '顶部提示', position: 'top' });
+}
+function center() {
+  toastStore.show({ message: '居中提示', position: 'center' });
+}
+function bottom() {
+  toastStore.show({ message: '底部提示', position: 'bottom' });
+}
 </script>
 
 <template>
@@ -72,11 +78,17 @@ function bottom() { toastStore.show({ message: '底部提示', position: 'bottom
 
 ```vue
 <script setup lang="ts">
-import { toastStore } from '@/uni_modules/lucky-ui'
+import { toastStore } from '@/uni_modules/lucky-ui';
 
-function show1s() { toastStore.show({ message: '显示 1 秒', duration: 1000 }) }
-function show4s() { toastStore.show({ message: '显示 4 秒', duration: 4000 }) }
-function stay() { toastStore.show({ message: '不自动关闭', duration: 0 }) }
+function show1s() {
+  toastStore.show({ message: '显示 1 秒', duration: 1000 });
+}
+function show4s() {
+  toastStore.show({ message: '显示 4 秒', duration: 4000 });
+}
+function stay() {
+  toastStore.show({ message: '不自动关闭', duration: 0 });
+}
 </script>
 
 <template>
@@ -92,7 +104,7 @@ function stay() { toastStore.show({ message: '不自动关闭', duration: 0 }) }
 
 ```vue
 <script setup lang="ts">
-import { toastStore } from '@/uni_modules/lucky-ui'
+import { toastStore } from '@/uni_modules/lucky-ui';
 </script>
 
 <template>
@@ -100,12 +112,8 @@ import { toastStore } from '@/uni_modules/lucky-ui'
     <lk-button @click="toastStore.show({ message: 'slide-up', transition: 'slide-up' })">
       SlideUp
     </lk-button>
-    <lk-button @click="toastStore.show({ message: 'fade', transition: 'fade' })">
-      Fade
-    </lk-button>
-    <lk-button @click="toastStore.show({ message: 'zoom', transition: 'zoom' })">
-      Zoom
-    </lk-button>
+    <lk-button @click="toastStore.show({ message: 'fade', transition: 'fade' })"> Fade </lk-button>
+    <lk-button @click="toastStore.show({ message: 'zoom', transition: 'zoom' })"> Zoom </lk-button>
   </view>
 </template>
 ```
@@ -114,19 +122,19 @@ import { toastStore } from '@/uni_modules/lucky-ui'
 
 ```vue
 <script setup lang="ts">
-import { toastStore } from '@/uni_modules/lucky-ui'
-import { ref } from 'vue'
+import { toastStore } from '@/uni_modules/lucky-ui';
+import { ref } from 'vue';
 
-const toastId = ref<number | null>(null)
+const toastId = ref<number | null>(null);
 
 function open() {
-  toastId.value = toastStore.show({ message: '长时间 Toast，点击关闭', duration: 0 })
+  toastId.value = toastStore.show({ message: '长时间 Toast，点击关闭', duration: 0 });
 }
 
 function close() {
   if (toastId.value !== null) {
-    toastStore.close(toastId.value)
-    toastId.value = null
+    toastStore.close(toastId.value);
+    toastId.value = null;
   }
 }
 </script>
@@ -137,50 +145,112 @@ function close() {
 </template>
 ```
 
+## 受控 Toast 生命周期
+
+直接使用 `LkToast` 时，`v-model` 是显示状态的唯一来源。组件在每次从隐藏进入显示时触发一次 `open` 并重新计算自动关闭计时；计时到期会请求 `update:modelValue=false`，只有实际观察到 `v-model=false` 才触发 `close`。若父层拒绝这次更新并保持显示，组件不会误报关闭，也不会进行微任务忙重试，而是在又一个完整的正数 `duration` 后重新请求。无论关闭来自计时还是外部把 `v-model` 改为 `false`，本轮都只触发一次 `close`，离场动画真正结束后只触发一次 `after-leave`。
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const visible = ref(true);
+const openCount = ref(0);
+const closeCount = ref(0);
+const afterLeaveCount = ref(0);
+
+function onOpen() {
+  openCount.value += 1;
+}
+
+function onClose() {
+  closeCount.value += 1;
+}
+
+function onAfterLeave() {
+  afterLeaveCount.value += 1;
+}
+</script>
+
+<template>
+  <lk-toast
+    v-model="visible"
+    message="保存成功"
+    :duration="1600"
+    @open="onOpen"
+    @close="onClose"
+    @after-leave="onAfterLeave"
+  />
+  <lk-button @click="visible = false">手动关闭</lk-button>
+  <text> open={{ openCount }} / close={{ closeCount }} / after-leave={{ afterLeaveCount }} </text>
+</template>
+```
+
+每个已交付给 Toast 的 `false → true` 边沿都会取消上一轮尚未到期的计时和离场完成信号，并为新一轮重新计时。若父组件在同一个 Vue 渲染批次内先写 `false` 再写 `true`，子组件只会收到最终的 `true`，因此这不构成一次关闭和重开；需要把 `false` 作为真实边沿交付时，应在写入 `false` 后等待一次 `nextTick()` 再重开。显示期间修改 `duration` 会从修改时刻重新计算：改为正数会按新时长调度，改为 `0` 会立即取消自动关闭。组件卸载时也会废弃计时，不会在卸载后继续发出更新或生命周期事件。`duration=0` 表示不自动关闭。
+
 ## API
 
 ### toastStore 方法
 
-| 方法 | 说明 | 参数 | 返回值 |
-|------|------|------|--------|
-| show | 显示 Toast | `string \| ToastOptions` | `id: number` |
-| close | 关闭指定 Toast（带退出动画） | `(id: number) => void` | — |
-| clear | 关闭所有 Toast | `() => void` | — |
+| 方法  | 说明                         | 参数                     | 返回值       |
+| ----- | ---------------------------- | ------------------------ | ------------ |
+| show  | 显示 Toast                   | `string \| ToastOptions` | `id: number` |
+| close | 关闭指定 Toast（带退出动画） | `(id: number) => void`   | —            |
+| clear | 关闭所有 Toast               | `() => void`             | —            |
 
 ### ToastOptions
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
-| customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
-| message | 提示内容 | `string` | — |
-| duration | 自动关闭时长（ms），0 表示不关闭 | `number` | `2000` |
-| position | 显示位置 | `top \| center \| bottom` | `center` |
-| transition | 动画效果 | `slide-up \| fade \| zoom` | `slide-up` |
+| 参数        | 说明                             | 类型                        | 默认值     |
+| ----------- | -------------------------------- | --------------------------- | ---------- |
+| customClass | 组件可视根节点自定义类名         | `string \| object \| array` | `''`       |
+| customStyle | 组件可视根节点自定义样式         | `string \| object`          | `''`       |
+| message     | 提示内容                         | `string`                    | —          |
+| duration    | 自动关闭时长（ms），0 表示不关闭 | `number`                    | `2000`     |
+| position    | 显示位置                         | `top \| center \| bottom`   | `center`   |
+| transition  | 动画效果                         | `slide-up \| fade \| zoom`  | `slide-up` |
 
 ### LkToastManager 组件
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
-| customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
-| zIndex | 全局 Toast 宿主层级 | `number` | `2000` |
+| 参数        | 说明                     | 类型                        | 默认值 |
+| ----------- | ------------------------ | --------------------------- | ------ |
+| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''`   |
+| customStyle | 组件可视根节点自定义样式 | `string \| object`          | `''`   |
+| zIndex      | 全局 Toast 宿主层级      | `number`                    | `2000` |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
+| 事件名            | 说明                         | 回调参数           |
+| ----------------- | ---------------------------- | ------------------ |
 | update:modelValue | 显隐状态变化，用于 `v-model` | `(value: boolean)` |
-| open | Toast 显示时触发 | `()` |
-| close | Toast 关闭时触发 | `()` |
-| after-leave | 离开动画结束后触发 | `()` |
+| open              | Toast 显示时触发             | `()`               |
+| close             | Toast 关闭时触发             | `()`               |
+| after-leave       | 离开动画结束后触发           | `()`               |
 
 ## 发布验收
 
 `lk-toast` 已纳入 needs-hardening showcase 回归，发布前按下面边界验收：
 
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
-| 全局管理 | 自动/人工 | 多个 Toast 连续触发时 id、关闭动画和 `clear()` 行为稳定 |
-| 定位与时序 | 人工验收 | `top/center/bottom` 与自动关闭时长在 H5/App/小程序端一致 |
+| 场景       | 验收方式  | 要点                                                                                    |
+| ---------- | --------- | --------------------------------------------------------------------------------------- |
+| 展示台基线 | 自动回归  | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
+| 全局管理   | 自动/人工 | 多个 Toast 连续触发时 id、关闭动画和 `clear()` 行为稳定                                 |
+| 定位与时序 | 人工验收  | `top/center/bottom` 与自动关闭时长在 H5/App/小程序端一致                                |
+
+### H5 与微信小程序 Peekit 验收
+
+Toast 演练页提供了不依赖文案和 DOM 层级的稳定选择器：
+
+| 选择器                          | 用途                                                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `#toast-lifecycle-fixture`      | 读取 `data-toast-visible`、`data-toast-open-count`、`data-toast-close-count`、`data-toast-after-leave-count` |
+| `#toast-lifecycle-open`         | 开始一轮新的受控 Toast                                                                                       |
+| `#toast-lifecycle-close`        | 在 duration 到期前手动关闭                                                                                   |
+| `#toast-lifecycle-rapid-reopen` | 触发一次关闭并在下一次响应式刷新后立即重开                                                                   |
+
+H5 和微信小程序必须分别通过 Peekit 连接真实运行页并留存查询结果或快照，按同一套断言验收：
+
+1. 重新载入演练页。初始 `open=1`；经过 `1600ms + 260ms` 后，状态必须收敛为 `visible=false / close=1 / after-leave=1`，且继续等待不再增长。
+2. 点击 `#toast-lifecycle-open`，在 1600ms 内点击 `#toast-lifecycle-close`。本轮三个计数各只增加 1；继续等待超过原 duration，计数不得再次变化。
+3. 再次打开后点击 `#toast-lifecycle-rapid-reopen`。等待 300ms 时必须仍为 `visible=true`，上一轮的 `after-leave` 不得增加；新一轮到期后 `close` 与 `after-leave` 才各增加 1。
+4. 全流程页面错误与控制台错误均为 0，截图中 Toast 位置、文字和离场后的页面布局无跳动。
+
+H5 构建、微信小程序构建和单元测试只是静态门禁，不能替代以上两端运行态证据；任一端未实际连接时，应明确记录为“未验收”，不能标记为通过。

--- a/src/components/demos/toast-demo.vue
+++ b/src/components/demos/toast-demo.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { nextTick, ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+import LkToast from '@/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue';
 import LkToastManager from '@/uni_modules/lucky-ui/components/lk-toast/lk-toast-manager.vue';
 import { useToast } from '@/uni_modules/lucky-ui/components/lk-toast/toast-manager';
 
@@ -59,6 +61,25 @@ const showBottom = () => {
     position: 'bottom',
   });
 };
+
+const lifecycleVisible = ref(true);
+const lifecycleOpenCount = ref(0);
+const lifecycleCloseCount = ref(0);
+const lifecycleAfterLeaveCount = ref(0);
+
+const openLifecycleToast = () => {
+  lifecycleVisible.value = true;
+};
+
+const closeLifecycleToast = () => {
+  lifecycleVisible.value = false;
+};
+
+const rapidReopenLifecycleToast = async () => {
+  lifecycleVisible.value = false;
+  await nextTick();
+  lifecycleVisible.value = true;
+};
 </script>
 
 <template>
@@ -66,6 +87,39 @@ const showBottom = () => {
     <lk-toast-manager />
     <demo-block title="基础用法">
       <lk-button type="primary" @click="showToast1">显示提示</lk-button>
+    </demo-block>
+
+    <demo-block title="生命周期演练">
+      <view
+        id="toast-lifecycle-fixture"
+        class="toast-lifecycle-fixture"
+        :data-toast-visible="lifecycleVisible ? 'true' : 'false'"
+        :data-toast-open-count="lifecycleOpenCount"
+        :data-toast-close-count="lifecycleCloseCount"
+        :data-toast-after-leave-count="lifecycleAfterLeaveCount"
+      >
+        <lk-toast
+          v-model="lifecycleVisible"
+          message="生命周期演练提示"
+          :duration="1600"
+          position="bottom"
+          @open="lifecycleOpenCount += 1"
+          @close="lifecycleCloseCount += 1"
+          @after-leave="lifecycleAfterLeaveCount += 1"
+        />
+        <view class="toast-lifecycle-fixture__evidence">
+          open={{ lifecycleOpenCount }} / close={{ lifecycleCloseCount }} / after-leave={{
+            lifecycleAfterLeaveCount
+          }}
+        </view>
+        <lk-space wrap>
+          <lk-button id="toast-lifecycle-open" @click="openLifecycleToast">重新打开</lk-button>
+          <lk-button id="toast-lifecycle-close" @click="closeLifecycleToast">手动关闭</lk-button>
+          <lk-button id="toast-lifecycle-rapid-reopen" @click="rapidReopenLifecycleToast">
+            快速重开
+          </lk-button>
+        </lk-space>
+      </view>
     </demo-block>
 
     <demo-block title="动画效果">
@@ -93,5 +147,12 @@ const showBottom = () => {
   > :not(:first-child) {
     margin-top: 32rpx;
   }
+}
+
+.toast-lifecycle-fixture__evidence {
+  margin-bottom: 20rpx;
+  color: var(--lk-text-secondary);
+  font-size: 24rpx;
+  line-height: 1.5;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue
+++ b/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { watch, computed, onUnmounted } from 'vue';
+import { computed, onBeforeUnmount } from 'vue';
 import type { StyleValue } from 'vue';
 import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition';
+import { createToastLifecycle, watchToastLifecycle } from './toast.lifecycle';
 import { toastProps, toastEmits } from './toast.props';
 import {
   resolveToastOverlayClass,
@@ -9,7 +10,6 @@ import {
   resolveToastRootClass,
   resolveToastRootStyle,
   resolveToastTransition,
-  shouldScheduleToastClose,
 } from './toast.utils';
 
 defineOptions({ name: 'LkToast' });
@@ -18,40 +18,18 @@ const props = defineProps(toastProps);
 const emit = defineEmits(toastEmits);
 
 const show = computed(() => props.modelValue);
-let timer: ReturnType<typeof setTimeout> | null = null;
+const lifecycle = createToastLifecycle({
+  getDuration: () => props.duration,
+  onOpen: () => emit('open'),
+  onRequestClose: () => emit('update:modelValue', false),
+  onClose: () => emit('close'),
+  onAfterLeave: () => emit('after-leave'),
+});
 
-function clearTimers() {
-  if (timer) {
-    clearTimeout(timer);
-    timer = null;
-  }
-}
-
-function scheduleClose() {
-  clearTimers();
-  if (shouldScheduleToastClose(props.duration)) {
-    timer = setTimeout(() => close(), props.duration);
-  }
-}
-
-watch(
-  () => props.modelValue,
-  v => {
-    if (v) {
-      emit('open');
-      scheduleClose();
-    } else {
-      emit('close');
-      setTimeout(() => emit('after-leave'), 260);
-    }
-  }
-);
-
-function close() {
-  if (!show.value) return;
-  emit('update:modelValue', false);
-  emit('close');
-}
+const stopLifecycleWatches = watchToastLifecycle(lifecycle, {
+  visible: () => props.modelValue,
+  duration: () => props.duration,
+});
 
 const transitionName = computed(() => {
   return resolveToastTransition({
@@ -69,11 +47,12 @@ const {
   classes: transitionClasses,
   styles: transitionStyles,
   display,
+  cancel: cancelTransition,
 } = useTransition(
   () => props.modelValue,
   { name: transitionName.value, duration: 260, easing: 'ease-out' },
   {
-    onAfterLeave: () => emit('after-leave'),
+    onAfterLeave: () => lifecycle.finishLeave(),
   }
 );
 const innerClass = computed(() => [transitionClasses.value, props.customClass]);
@@ -81,7 +60,11 @@ const innerStyle = computed<StyleValue>(
   () => [props.customStyle, transitionStyles.value] as StyleValue
 );
 
-onUnmounted(() => clearTimers());
+onBeforeUnmount(() => {
+  stopLifecycleWatches();
+  lifecycle.dispose();
+  cancelTransition();
+});
 </script>
 
 <template>

--- a/src/uni_modules/lucky-ui/components/lk-toast/toast.lifecycle.ts
+++ b/src/uni_modules/lucky-ui/components/lk-toast/toast.lifecycle.ts
@@ -1,0 +1,136 @@
+import { watch, type WatchSource } from 'vue';
+import { shouldScheduleToastClose } from './toast.utils';
+
+export interface ToastLifecycleHooks {
+  getDuration: () => number;
+  onOpen: () => void;
+  onRequestClose: () => void;
+  onClose: () => void;
+  onAfterLeave: () => void;
+}
+
+export interface ToastLifecycleController {
+  syncVisibility: (visible: boolean) => void;
+  requestClose: () => void;
+  reschedule: () => void;
+  finishLeave: () => void;
+  dispose: () => void;
+}
+
+export interface ToastLifecycleSources {
+  visible: WatchSource<boolean>;
+  duration: WatchSource<number>;
+}
+
+type ToastLifecyclePhase = 'idle' | 'open' | 'leaving' | 'left' | 'disposed';
+
+/**
+ * Owns the lifecycle of one controlled Toast instance.
+ *
+ * A generation token makes every scheduled close disposable. Close and
+ * after-leave are latched per visible cycle so external updates, timer expiry,
+ * and transition completion cannot report the same boundary twice.
+ */
+export function createToastLifecycle(hooks: ToastLifecycleHooks): ToastLifecycleController {
+  let phase: ToastLifecyclePhase = 'idle';
+  let visible = false;
+  let generation = 0;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const invalidateCloseTimer = () => {
+    generation += 1;
+    if (closeTimer !== null) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  };
+
+  const isDisposed = () => phase === 'disposed';
+
+  const requestClose = () => {
+    if (isDisposed() || !visible || phase !== 'open') return;
+
+    invalidateCloseTimer();
+    const requestGeneration = generation;
+    hooks.onRequestClose();
+    // A controlled parent may reject the update. In that case retry only after
+    // another complete positive duration, rather than spinning in a microtask.
+    if (!isDisposed() && visible && phase === 'open' && generation === requestGeneration) {
+      scheduleClose();
+    }
+  };
+
+  const scheduleClose = () => {
+    invalidateCloseTimer();
+    const duration = hooks.getDuration();
+    if (!shouldScheduleToastClose(duration)) return;
+
+    const scheduledGeneration = generation;
+    closeTimer = setTimeout(() => {
+      closeTimer = null;
+      if (isDisposed() || generation !== scheduledGeneration) return;
+      requestClose();
+    }, duration);
+  };
+
+  const syncVisibility = (nextVisible: boolean) => {
+    if (isDisposed() || nextVisible === visible) return;
+
+    invalidateCloseTimer();
+    visible = nextVisible;
+
+    if (nextVisible) {
+      phase = 'open';
+      hooks.onOpen();
+      if (!isDisposed() && visible && phase === 'open') scheduleClose();
+      return;
+    }
+
+    phase = 'leaving';
+    hooks.onClose();
+  };
+
+  const reschedule = () => {
+    if (isDisposed() || !visible || phase !== 'open') return;
+    scheduleClose();
+  };
+
+  const finishLeave = () => {
+    if (isDisposed() || visible || phase !== 'leaving') return;
+
+    phase = 'left';
+    hooks.onAfterLeave();
+  };
+
+  const dispose = () => {
+    if (isDisposed()) return;
+    invalidateCloseTimer();
+    visible = false;
+    phase = 'disposed';
+  };
+
+  return {
+    syncVisibility,
+    requestClose,
+    reschedule,
+    finishLeave,
+    dispose,
+  };
+}
+
+/** Processes every source edge synchronously after Vue has delivered it to this component. */
+export function watchToastLifecycle(
+  lifecycle: ToastLifecycleController,
+  sources: ToastLifecycleSources
+): () => void {
+  const stopVisibility = watch(sources.visible, visible => lifecycle.syncVisibility(visible), {
+    immediate: true,
+    flush: 'sync',
+  });
+  const stopDuration = watch(sources.duration, () => lifecycle.reschedule(), { flush: 'sync' });
+
+  return () => {
+    stopDuration();
+    stopVisibility();
+  };
+}

--- a/tests/unit/lk-toast.spec.ts
+++ b/tests/unit/lk-toast.spec.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent, h, nextTick, ref, type App } from 'vue';
+import {
+  createToastLifecycle,
+  watchToastLifecycle,
+} from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.lifecycle';
 import { toastManagerProps } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.props';
 import {
   createToastItem,
@@ -18,28 +23,33 @@ describe('lk-toast display and manager rules', () => {
     const customStyle = { top: '24rpx', zIndex: 3000 };
 
     expect(toastManagerProps.zIndex.default).toBe(2000);
-    expect(resolveToastManagerStyle({
-      customStyle,
-      zIndex: 2100,
-    })).toEqual([
-      customStyle,
-      { zIndex: 2100 },
-    ]);
+    expect(
+      resolveToastManagerStyle({
+        customStyle,
+        zIndex: 2100,
+      })
+    ).toEqual([customStyle, { zIndex: 2100 }]);
   });
 
   it('resolves controlled toast transition by position', () => {
-    expect(resolveToastTransition({
-      transition: 'slide-up',
-      position: 'top',
-    })).toBe('slide-down');
-    expect(resolveToastTransition({
-      transition: 'slide-up',
-      position: 'center',
-    })).toBe('zoom-in');
-    expect(resolveToastTransition({
-      transition: 'fade',
-      position: 'bottom',
-    })).toBe('fade');
+    expect(
+      resolveToastTransition({
+        transition: 'slide-up',
+        position: 'top',
+      })
+    ).toBe('slide-down');
+    expect(
+      resolveToastTransition({
+        transition: 'slide-up',
+        position: 'center',
+      })
+    ).toBe('zoom-in');
+    expect(
+      resolveToastTransition({
+        transition: 'fade',
+        position: 'bottom',
+      })
+    ).toBe('fade');
   });
 
   it('builds overlay and root classes/styles', () => {
@@ -52,24 +62,32 @@ describe('lk-toast display and manager rules', () => {
   });
 
   it('normalizes manager transition and item class', () => {
-    expect(resolveToastManagerTransition({
-      position: 'top',
-    })).toBe('slide-down');
-    expect(resolveToastManagerTransition({
-      position: 'center',
-    })).toBe('zoom-in');
-    expect(resolveToastManagerTransition({
-      position: 'bottom',
-      transition: 'fade',
-    })).toBe('fade');
+    expect(
+      resolveToastManagerTransition({
+        position: 'top',
+      })
+    ).toBe('slide-down');
+    expect(
+      resolveToastManagerTransition({
+        position: 'center',
+      })
+    ).toBe('zoom-in');
+    expect(
+      resolveToastManagerTransition({
+        position: 'bottom',
+        transition: 'fade',
+      })
+    ).toBe('fade');
     expect(resolveToastManagerItemClass('center')).toEqual(['pos-center']);
   });
 
   it('creates manager items from string or object options', () => {
-    expect(createToastItem({
-      id: 1,
-      input: '保存成功',
-    })).toEqual({
+    expect(
+      createToastItem({
+        id: 1,
+        input: '保存成功',
+      })
+    ).toEqual({
       id: 1,
       message: '保存成功',
       transition: 'zoom-in',
@@ -78,14 +96,16 @@ describe('lk-toast display and manager rules', () => {
       visible: true,
     });
 
-    expect(createToastItem({
-      id: 2,
-      input: {
-        message: '顶部提示',
-        position: 'top',
-        duration: 0,
-      },
-    })).toEqual({
+    expect(
+      createToastItem({
+        id: 2,
+        input: {
+          message: '顶部提示',
+          position: 'top',
+          duration: 0,
+        },
+      })
+    ).toEqual({
       id: 2,
       message: '顶部提示',
       transition: 'slide-down',
@@ -93,5 +113,354 @@ describe('lk-toast display and manager rules', () => {
       position: 'top',
       visible: true,
     });
+  });
+});
+
+describe('lk-toast controlled lifecycle', () => {
+  const mountedApps: App[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    for (const app of mountedApps.splice(0).reverse()) app.unmount();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  function createHarness(initialDuration = 1000) {
+    const events: string[] = [];
+    let duration = initialDuration;
+    const lifecycle = createToastLifecycle({
+      getDuration: () => duration,
+      onOpen: () => events.push('open'),
+      onRequestClose: () => events.push('update:false'),
+      onClose: () => events.push('close'),
+      onAfterLeave: () => events.push('after-leave'),
+    });
+
+    return {
+      events,
+      lifecycle,
+      setDuration(nextDuration: number) {
+        duration = nextDuration;
+        lifecycle.reschedule();
+      },
+    };
+  }
+
+  it('schedules an initially visible toast and retries a rejected update after a full duration', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    expect(events).toEqual(['open']);
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(events).toEqual(['open', 'update:false']);
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(999);
+    expect(events).toEqual(['open', 'update:false']);
+    vi.advanceTimersByTime(1);
+    expect(events).toEqual(['open', 'update:false', 'update:false']);
+    expect(vi.getTimerCount()).toBe(1);
+
+    lifecycle.syncVisibility(false);
+    lifecycle.finishLeave();
+    lifecycle.finishLeave();
+    expect(events).toEqual(['open', 'update:false', 'update:false', 'close', 'after-leave']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('treats an external false update as one close without an update echo', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    lifecycle.syncVisibility(false);
+    lifecycle.syncVisibility(false);
+    lifecycle.finishLeave();
+    lifecycle.finishLeave();
+    vi.advanceTimersByTime(2000);
+
+    expect(events).toEqual(['open', 'close', 'after-leave']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('allows a rejected close request to retry without reporting close', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    lifecycle.requestClose();
+    lifecycle.requestClose();
+
+    expect(events).toEqual(['open', 'update:false', 'update:false']);
+    expect(vi.getTimerCount()).toBe(1);
+
+    lifecycle.syncVisibility(false);
+    expect(events).toEqual(['open', 'update:false', 'update:false', 'close']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not rearm when the parent accepts a close request synchronously', () => {
+    const events: string[] = [];
+    const lifecycle = createToastLifecycle({
+      getDuration: () => 1000,
+      onOpen: () => events.push('open'),
+      onRequestClose: () => {
+        events.push('update:false');
+        lifecycle.syncVisibility(false);
+      },
+      onClose: () => events.push('close'),
+      onAfterLeave: () => events.push('after-leave'),
+    });
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(2000);
+
+    expect(events).toEqual(['open', 'update:false', 'close']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('invalidates the old timer and leave completion when reopened quickly', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(200);
+    lifecycle.syncVisibility(false);
+    lifecycle.syncVisibility(true);
+    lifecycle.finishLeave();
+
+    vi.advanceTimersByTime(800);
+    expect(events).toEqual(['open', 'close', 'open']);
+
+    vi.advanceTimersByTime(200);
+    expect(events).toEqual(['open', 'close', 'open', 'update:false']);
+
+    lifecycle.syncVisibility(false);
+    lifecycle.finishLeave();
+    lifecycle.finishLeave();
+    expect(events).toEqual(['open', 'close', 'open', 'update:false', 'close', 'after-leave']);
+  });
+
+  it('starts a fresh timer when externally reopened after leaving', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(300);
+    lifecycle.syncVisibility(false);
+    lifecycle.finishLeave();
+    lifecycle.syncVisibility(true);
+
+    vi.advanceTimersByTime(700);
+    expect(events).toEqual(['open', 'close', 'after-leave', 'open']);
+
+    vi.advanceTimersByTime(300);
+    expect(events).toEqual(['open', 'close', 'after-leave', 'open', 'update:false']);
+
+    lifecycle.syncVisibility(false);
+    expect(events.at(-1)).toBe('close');
+  });
+
+  it('keeps duration zero open until an explicit close request', () => {
+    const { events, lifecycle } = createHarness(0);
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(5000);
+    expect(events).toEqual(['open']);
+    expect(vi.getTimerCount()).toBe(0);
+
+    lifecycle.requestClose();
+    lifecycle.requestClose();
+    expect(events).toEqual(['open', 'update:false', 'update:false']);
+  });
+
+  it('reschedules or cancels automatic close when duration changes while visible', () => {
+    const cancelHarness = createHarness(100);
+    cancelHarness.lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(40);
+    cancelHarness.setDuration(0);
+    vi.advanceTimersByTime(500);
+    expect(cancelHarness.events).toEqual(['open']);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const scheduleHarness = createHarness(0);
+    scheduleHarness.lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(500);
+    scheduleHarness.setDuration(100);
+    vi.advanceTimersByTime(99);
+    expect(scheduleHarness.events).toEqual(['open']);
+    vi.advanceTimersByTime(1);
+    expect(scheduleHarness.events).toEqual(['open', 'update:false']);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('resets a positive duration from the change point without keeping the old deadline', () => {
+    const { events, lifecycle, setDuration } = createHarness(100);
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(40);
+    setDuration(200);
+
+    vi.advanceTimersByTime(60);
+    expect(events).toEqual(['open']);
+    vi.advanceTimersByTime(139);
+    expect(events).toEqual(['open']);
+    vi.advanceTimersByTime(1);
+    expect(events).toEqual(['open', 'update:false']);
+
+    lifecycle.syncVisibility(false);
+    vi.advanceTimersByTime(1000);
+    expect(events).toEqual(['open', 'update:false', 'close']);
+  });
+
+  function createTestRenderer() {
+    return createRenderer<Record<string, unknown>, Record<string, unknown>>({
+      patchProp() {},
+      insert() {},
+      remove() {},
+      createElement() {
+        return {};
+      },
+      createText() {
+        return {};
+      },
+      createComment() {
+        return {};
+      },
+      setText() {},
+      setElementText() {},
+      parentNode() {
+        return null;
+      },
+      nextSibling() {
+        return null;
+      },
+    });
+  }
+
+  it('processes every delivered source edge synchronously in a mounted component', async () => {
+    const renderer = createTestRenderer();
+    const visible = ref(true);
+    const duration = ref(1000);
+    const events: string[] = [];
+    let lifecycle: ReturnType<typeof createToastLifecycle> | undefined;
+    const App = defineComponent({
+      setup() {
+        lifecycle = createToastLifecycle({
+          getDuration: () => duration.value,
+          onOpen: () => events.push('open'),
+          onRequestClose: () => events.push('update:false'),
+          onClose: () => events.push('close'),
+          onAfterLeave: () => events.push('after-leave'),
+        });
+        watchToastLifecycle(lifecycle, { visible, duration });
+        return () => null;
+      },
+    });
+    const app = renderer.createApp(App);
+    app.mount({});
+    mountedApps.push(app);
+
+    visible.value = false;
+    visible.value = true;
+
+    expect(events).toEqual(['open', 'close', 'open']);
+    await nextTick();
+    expect(events).toEqual(['open', 'close', 'open']);
+    lifecycle?.finishLeave();
+    expect(events).toEqual(['open', 'close', 'open']);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('treats only parent edges delivered across render batches as lifecycle boundaries', async () => {
+    const renderer = createTestRenderer();
+    const parentVisible = ref(true);
+    const events: string[] = [];
+    let childLifecycle: ReturnType<typeof createToastLifecycle> | undefined;
+    const Child = defineComponent({
+      props: {
+        visible: { type: Boolean, required: true },
+        duration: { type: Number, required: true },
+      },
+      setup(props) {
+        childLifecycle = createToastLifecycle({
+          getDuration: () => props.duration,
+          onOpen: () => events.push('open'),
+          onRequestClose: () => events.push('update:false'),
+          onClose: () => events.push('close'),
+          onAfterLeave: () => events.push('after-leave'),
+        });
+        watchToastLifecycle(childLifecycle, {
+          visible: () => props.visible,
+          duration: () => props.duration,
+        });
+        return () => null;
+      },
+    });
+    const Parent = defineComponent({
+      setup() {
+        return () => h(Child, { visible: parentVisible.value, duration: 1000 });
+      },
+    });
+    const app = renderer.createApp(Parent);
+    app.mount({});
+    mountedApps.push(app);
+
+    parentVisible.value = false;
+    parentVisible.value = true;
+    await nextTick();
+    expect(events).toEqual(['open']);
+
+    parentVisible.value = false;
+    await nextTick();
+    expect(events).toEqual(['open', 'close']);
+
+    parentVisible.value = true;
+    await nextTick();
+    expect(events).toEqual(['open', 'close', 'open']);
+    childLifecycle?.finishLeave();
+    expect(events).toEqual(['open', 'close', 'open']);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('disposes a pending close without later events', () => {
+    const { events, lifecycle } = createHarness();
+
+    lifecycle.syncVisibility(true);
+    expect(vi.getTimerCount()).toBe(1);
+
+    lifecycle.dispose();
+    lifecycle.dispose();
+    lifecycle.requestClose();
+    lifecycle.syncVisibility(false);
+    lifecycle.finishLeave();
+    vi.advanceTimersByTime(2000);
+
+    expect(events).toEqual(['open']);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not emit close when the update request synchronously disposes the instance', () => {
+    const events: string[] = [];
+    const lifecycle = createToastLifecycle({
+      getDuration: () => 1000,
+      onOpen: () => events.push('open'),
+      onRequestClose: () => {
+        events.push('update:false');
+        lifecycle.dispose();
+      },
+      onClose: () => events.push('close'),
+      onAfterLeave: () => events.push('after-leave'),
+    });
+
+    lifecycle.syncVisibility(true);
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(1000);
+
+    expect(events).toEqual(['open', 'update:false']);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(toast): enforce exact-once lifecycle`。
- 保留提交 `46d43083333b` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。