### PR TITLE
fix(card): isolate native image selector

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -16,7 +16,8 @@ phone: card
     { key: 'subTitle', type: 'string', label: '副标题', default: '' },
     { key: 'shadow', type: 'enum', label: '阴影', values: ['none', 'never', 'sm', 'md', 'base', 'lg'], default: 'sm' },
     { key: 'border', type: 'boolean', label: '边框', default: false },
-    { key: 'hoverable', type: 'boolean', label: '悬浮效果', default: false },
+    { key: 'ripple', type: 'boolean', label: '点击波纹', default: false },
+    { key: 'overflow', type: 'enum', label: '内容溢出', values: ['hidden', 'visible'], default: 'hidden' },
     { key: 'transparent', type: 'boolean', label: '透明', default: false },
   ]"
   slot-content="卡片内容示例"
@@ -41,6 +42,8 @@ phone: card
   <view>封面贴边展示，适合图文内容卡片。</view>
 </lk-card>
 ```
+
+`cover` 插槽中的 UniApp `image` 会按块级元素铺满卡片宽度，高度仍由业务内容设置。Card 不会替代 UniApp 的 `mode` 控制裁切；需要等比填充裁切时，请显式设置 `mode="aspectFill"`。H5 也兼容原生 `img`，但在跨端源码中必须用 `<!-- #ifdef H5 -->` 隔离，避免原生标签及其选择器进入小程序构建。
 
 ## 底部操作区
 
@@ -72,8 +75,8 @@ phone: card
 ## 交互卡片
 
 ```vue
-<lk-card hoverable shadow="md" @click="handleClick">
-  <view>点击或按压时会有更明显的浮层感。</view>
+<lk-card ripple shadow="md" @click="handleClick">
+  <view>点击卡片时显示波纹反馈。</view>
 </lk-card>
 ```
 
@@ -83,7 +86,7 @@ phone: card
 
 ```vue
 <script setup lang="ts">
-import CardDemo from '@/components/demos/card-demo.vue'
+import CardDemo from '@/components/demos/card-demo.vue';
 </script>
 
 <template>
@@ -105,37 +108,38 @@ import CardDemo from '@/components/demos/card-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| title | 卡片标题 | `string` | `''` |
-| subTitle | 副标题 | `string` | `''` |
-| padding | 内容内边距 | `string` | `'32rpx'` |
-| border | 是否显示边框 | `boolean` | `false` |
-| shadow | 阴影等级 | `none \| never \| sm \| md \| base \| lg` | `sm` |
-| bgColor | 自定义背景色 | `string` | `''` |
-| transparent | 是否透明背景 | `boolean` | `false` |
-| hoverable | 是否启用交互悬浮效果 | `boolean` | `false` |
-| id | 根节点 id | `string` | `''` |
-| customClass | 根节点自定义类名 | `string \| object \| array` | — |
-| customStyle | 根节点自定义样式 | `string \| object` | — |
+| 参数        | 说明             | 类型                                      | 默认值    |
+| ----------- | ---------------- | ----------------------------------------- | --------- |
+| title       | 卡片标题         | `string`                                  | `''`      |
+| subTitle    | 副标题           | `string`                                  | `''`      |
+| padding     | 内容内边距       | `string`                                  | `'32rpx'` |
+| border      | 是否显示边框     | `boolean`                                 | `false`   |
+| shadow      | 阴影等级         | `none \| never \| sm \| md \| base \| lg` | `sm`      |
+| bgColor     | 自定义背景色     | `string`                                  | `''`      |
+| transparent | 是否透明背景     | `boolean`                                 | `false`   |
+| ripple      | 是否启用点击波纹 | `boolean`                                 | `false`   |
+| overflow    | 内容溢出策略     | `hidden \| visible`                       | `hidden`  |
+| id          | 根节点 id        | `string`                                  | `''`      |
+| customClass | 根节点自定义类名 | `string \| object \| array`               | —         |
+| customStyle | 根节点自定义样式 | `string \| object`                        | —         |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| click | 点击卡片时触发 | `(event)` |
+| 事件名       | 说明               | 回调参数  |
+| ------------ | ------------------ | --------- |
+| click        | 点击卡片时触发     | `(event)` |
 | header-click | 点击卡片头部时触发 | `(event)` |
 | footer-click | 点击卡片底部时触发 | `(event)` |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
-| cover | 顶部封面区域，贴边显示 |
-| header | 自定义头部标题区 |
-| header-extra | 头部右侧附加内容 |
-| default | 卡片主体内容 |
-| footer | 卡片底部区域 |
+| 插槽名       | 说明                                                                                     |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| cover        | 顶部封面区域，贴边显示；`image` 为块级并铺满宽度，等比填充裁切需设置 `mode="aspectFill"` |
+| header       | 自定义头部标题区                                                                         |
+| header-extra | 头部右侧附加内容                                                                         |
+| default      | 卡片主体内容                                                                             |
+| footer       | 卡片底部区域                                                                             |
 
 ## 使用建议
 

--- a/src/components/demos/card-demo.vue
+++ b/src/components/demos/card-demo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkCard from '@/uni_modules/lucky-ui/components/lk-card/lk-card.vue';
 import LkCell from '@/uni_modules/lucky-ui/components/lk-cell/lk-cell.vue';
@@ -8,6 +9,27 @@ import LkProgress from '@/uni_modules/lucky-ui/components/lk-progress/lk-progres
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import LkTag from '@/uni_modules/lucky-ui/components/lk-tag/lk-tag.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+
+const coverContractStatus = ref('pending');
+const uniImageObjectFit = ref('');
+const nativeImageObjectFit = ref('');
+
+// #ifdef H5
+onMounted(async () => {
+  await nextTick();
+  const uniImage = document.querySelector<HTMLElement>('#card-cover-uni-image');
+  const nativeImage = document.querySelector<HTMLImageElement>('#card-cover-native-img');
+
+  if (!uniImage || !nativeImage) {
+    coverContractStatus.value = 'missing';
+    return;
+  }
+
+  uniImageObjectFit.value = window.getComputedStyle(uniImage).objectFit;
+  nativeImageObjectFit.value = window.getComputedStyle(nativeImage).objectFit;
+  coverContractStatus.value = 'ready';
+});
+// #endif
 </script>
 
 <template>
@@ -86,6 +108,45 @@ import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.v
           </lk-space>
         </lk-space>
       </lk-card>
+    </demo-block>
+
+    <demo-block title="跨端封面契约">
+      <view
+        id="card-cover-contract"
+        class="cover-contract"
+        data-contract="card-cover-v1"
+        :data-contract-status="coverContractStatus"
+        :data-uni-object-fit="uniImageObjectFit"
+        :data-native-object-fit="nativeImageObjectFit"
+      >
+        <lk-card id="card-cover-uni-card" title="Uni Image" shadow="sm">
+          <template #cover>
+            <image
+              id="card-cover-uni-image"
+              class="cover-contract__media"
+              src="/static/logo.png"
+              mode="aspectFill"
+              data-cover-kind="uni-image"
+            />
+          </template>
+          <text class="cover-contract__copy">所有端使用 image，宽度由 Card cover 契约铺满。</text>
+        </lk-card>
+
+        <!-- #ifdef H5 -->
+        <lk-card id="card-cover-native-card" title="Native Img" shadow="sm">
+          <template #cover>
+            <img
+              id="card-cover-native-img"
+              class="cover-contract__media"
+              src="/static/logo.png"
+              alt="Card native image cover probe"
+              data-cover-kind="native-img"
+            />
+          </template>
+          <text class="cover-contract__copy">H5 原生 img 兼容分支不会进入小程序样式。</text>
+        </lk-card>
+        <!-- #endif -->
+      </view>
     </demo-block>
 
     <demo-block title="业务操作">
@@ -309,6 +370,25 @@ import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.v
 
 .cover-badge__value {
   margin-left: 8rpx;
+}
+
+.cover-contract {
+  display: flex;
+  flex-direction: column;
+
+  > :not(:first-child) {
+    margin-top: 24rpx;
+  }
+}
+
+.cover-contract__media {
+  height: 220rpx;
+}
+
+.cover-contract__copy {
+  font-size: 24rpx;
+  line-height: 1.6;
+  color: var(--card-demo-muted);
 }
 
 .card-copy {

--- a/src/uni_modules/lucky-ui/components/lk-card/lk-card.scss
+++ b/src/uni_modules/lucky-ui/components/lk-card/lk-card.scss
@@ -28,11 +28,20 @@
 
   @include e(cover) {
     width: 100%;
-    :deep(image),
+
+    :deep(image) {
+      display: block;
+      width: 100%;
+      object-fit: cover;
+    }
+
+    /* #ifdef H5 */
     :deep(img) {
       display: block;
       width: 100%;
+      object-fit: cover;
     }
+    /* #endif */
   }
 
   @include e(header) {

--- a/tests/unit/component-style-selectors.spec.ts
+++ b/tests/unit/component-style-selectors.spec.ts
@@ -1,8 +1,12 @@
+import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { initPreContext, preCss } from '@dcloudio/uni-cli-shared';
 import * as sass from 'sass';
 import { describe, expect, it } from 'vitest';
 
 const COMPONENT_ROOT = path.join(process.cwd(), 'src/uni_modules/lucky-ui/components');
+const CARD_STYLE = path.join(COMPONENT_ROOT, 'lk-card', 'lk-card.scss');
 
 function compileStyle(component: string): string {
   return sass.compile(path.join(COMPONENT_ROOT, `lk-${component}`, `lk-${component}.scss`), {
@@ -15,6 +19,17 @@ function selectorBlock(css: string, selector: string): string {
   if (start < 0) throw new Error(`Missing selector: ${selector}`);
   const end = css.indexOf('}', start);
   return css.slice(start, end + 1);
+}
+
+function compileCardStyleForPlatform(platform: 'h5' | 'mp-weixin') {
+  initPreContext(platform);
+  const preprocessed = preCss(fs.readFileSync(CARD_STYLE, 'utf8'));
+  const css = sass.compileString(preprocessed, {
+    style: 'expanded',
+    url: pathToFileURL(CARD_STYLE),
+  }).css;
+
+  return { css, preprocessed };
 }
 
 describe('component style selectors', () => {
@@ -83,5 +98,23 @@ describe('component style selectors', () => {
     expect(indicator).toContain('align-items: center');
     expect(indicator).not.toContain('position: absolute');
     expect(indicator).not.toContain('z-index:');
+  });
+
+  it('isolates the native card cover selector through Uni preCss and Sass', () => {
+    const h5 = compileCardStyleForPlatform('h5');
+    const mpWeixin = compileCardStyleForPlatform('mp-weixin');
+    const h5UniImage = selectorBlock(h5.css, '.lk-card__cover :deep(image)');
+    const h5NativeImage = selectorBlock(h5.css, '.lk-card__cover :deep(img)');
+    const mpUniImage = selectorBlock(mpWeixin.css, '.lk-card__cover :deep(image)');
+
+    for (const block of [h5UniImage, h5NativeImage, mpUniImage]) {
+      expect(block).toContain('display: block');
+      expect(block).toContain('width: 100%');
+      expect(block).toContain('object-fit: cover');
+    }
+
+    expect(h5.preprocessed).toContain(':deep(img)');
+    expect(mpWeixin.preprocessed).not.toContain(':deep(img)');
+    expect(mpWeixin.css).not.toContain(':deep(img)');
   });
 });

--- a/tests/unit/lk-card.spec.ts
+++ b/tests/unit/lk-card.spec.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { cardProps } from '../../src/uni_modules/lucky-ui/components/lk-card/card.props';
 import {
   cardShadowMap,
   resolveCardBodyStyle,
@@ -10,13 +11,27 @@ import {
 } from '../../src/uni_modules/lucky-ui/components/lk-card/card.utils';
 
 describe('lk-card display rules', () => {
+  it('exposes the documented interaction and overflow props', () => {
+    expect(cardProps).not.toHaveProperty('hoverable');
+    expect(cardProps.ripple.default).toBe(false);
+    expect(cardProps.overflow.default).toBe('hidden');
+    expect(cardProps.overflow.validator?.('visible')).toBe(true);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(cardProps.overflow.validator?.('clip')).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
   it('builds root classes from border and ripple state', () => {
-    expect(resolveCardClass({
-      customClass: 'custom-card',
-      border: true,
-      ripple: true,
-      rippleActive: true,
-    })).toEqual([
+    expect(
+      resolveCardClass({
+        customClass: 'custom-card',
+        border: true,
+        ripple: true,
+        rippleActive: true,
+      })
+    ).toEqual([
       'lk-card',
       'custom-card',
       {
@@ -26,46 +41,54 @@ describe('lk-card display rules', () => {
       },
     ]);
 
-    expect(resolveCardClass({
-      customClass: '',
-      border: false,
-      ripple: true,
-      rippleActive: false,
-    })[2]).toMatchObject({
+    expect(
+      resolveCardClass({
+        customClass: '',
+        border: false,
+        ripple: true,
+        rippleActive: false,
+      })[2]
+    ).toMatchObject({
       'lk-ripple': true,
       'lk-ripple--active': false,
     });
   });
 
   it('resolves background, overflow and shadow variables', () => {
-    expect(resolveCardStyle({
-      transparent: true,
-      bgColor: '#fff',
-      overflow: 'visible',
-      shadow: 'lg',
-    })).toEqual({
+    expect(
+      resolveCardStyle({
+        transparent: true,
+        bgColor: '#fff',
+        overflow: 'visible',
+        shadow: 'lg',
+      })
+    ).toEqual({
       '--_bg': 'transparent',
       '--_overflow': 'visible',
       '--_shadow': cardShadowMap.lg,
     });
 
-    expect(resolveCardStyle({
-      transparent: false,
-      bgColor: '#101010',
-      overflow: 'hidden',
-      shadow: 'never',
-    })).toEqual({
+    expect(
+      resolveCardStyle({
+        transparent: false,
+        bgColor: '#101010',
+        overflow: 'hidden',
+        shadow: 'never',
+      })
+    ).toEqual({
       '--_bg': '#101010',
       '--_overflow': 'hidden',
       '--_shadow': 'none',
     });
 
-    expect(resolveCardStyle({
-      transparent: false,
-      bgColor: '',
-      overflow: 'hidden',
-      shadow: 'unknown',
-    })).toEqual({
+    expect(
+      resolveCardStyle({
+        transparent: false,
+        bgColor: '',
+        overflow: 'hidden',
+        shadow: 'unknown',
+      })
+    ).toEqual({
       '--_overflow': 'hidden',
     });
   });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(card): isolate native image selector`。
- 保留提交 `720e3bf73188` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。