### PR TITLE
fix(request): isolate cancellation generations

### DIFF
--- a/src/uni_modules/lucky-ui/core/src/utils/request.ts
+++ b/src/uni_modules/lucky-ui/core/src/utils/request.ts
@@ -126,40 +126,171 @@ class InterceptorManager<T> {
 /**
  * 请求任务管理器
  */
+interface RequestGeneration {
+  key: string;
+  generation: number;
+  cancelled: boolean;
+  cancellationError: RequestError;
+  cancellation: Promise<never>;
+  rejectCancellation: (reason: RequestError) => void;
+  task?: UniApp.RequestTask;
+  retryTimer?: ReturnType<typeof setTimeout>;
+}
+
 class RequestTaskManager {
-  private tasks = new Map<string, UniApp.RequestTask>();
+  private generations = new Map<string, RequestGeneration>();
+  private generation = 0;
 
   /**
-   * 添加任务
+   * 开始一个逻辑请求，并让同 key 的旧 generation 失效
    */
-  add(key: string, task: UniApp.RequestTask): void {
-    this.tasks.set(key, task);
+  start(key: string, cancellationError: RequestError): RequestGeneration {
+    let rejectCancellation!: (reason: RequestError) => void;
+    const cancellation = new Promise<never>((_, reject) => {
+      rejectCancellation = reject;
+    });
+
+    // cancellation 还会参与具体的 race；这里的兜底处理确保即使初始化流程意外中断，
+    // 后续取消也不会产生未处理的 Promise 拒绝。
+    void cancellation.catch(() => undefined);
+
+    const generation: RequestGeneration = {
+      key,
+      generation: ++this.generation,
+      cancelled: false,
+      cancellationError,
+      cancellation,
+      rejectCancellation,
+    };
+    const previous = this.generations.get(key);
+
+    // 先提交新 generation，再中止旧任务；即使 abort 同步触发旧回调，
+    // 旧回调也无法删除或提交到新 generation。
+    this.generations.set(key, generation);
+    if (previous) {
+      this.cancelGeneration(previous);
+    }
+
+    return generation;
+  }
+
+  /**
+   * 将单次请求任务挂到所属逻辑请求
+   */
+  attach(generation: RequestGeneration, task: UniApp.RequestTask): boolean {
+    if (!this.isLatest(generation)) {
+      this.abortTask(task);
+      return false;
+    }
+    generation.task = task;
+    return true;
+  }
+
+  /**
+   * 单次尝试结束时只释放自己挂接的任务
+   */
+  release(generation: RequestGeneration, task: UniApp.RequestTask): void {
+    if (generation.task === task) {
+      generation.task = undefined;
+    }
+  }
+
+  /**
+   * 判断是否仍为该 key 的最新逻辑请求
+   */
+  isLatest(generation: RequestGeneration): boolean {
+    return !generation.cancelled && this.generations.get(generation.key) === generation;
+  }
+
+  /**
+   * 判断逻辑请求是否已被显式取消或替换
+   */
+  isCancelled(generation: RequestGeneration): boolean {
+    return generation.cancelled;
+  }
+
+  /**
+   * 保存重试等待计时器；generation 失效时立即清理
+   */
+  attachRetryTimer(generation: RequestGeneration, timer: ReturnType<typeof setTimeout>): boolean {
+    if (!this.isLatest(generation)) {
+      clearTimeout(timer);
+      return false;
+    }
+
+    this.clearRetryTimer(generation);
+    generation.retryTimer = timer;
+    return true;
+  }
+
+  /**
+   * 计时器自然到期时只释放自身句柄
+   */
+  releaseRetryTimer(generation: RequestGeneration, timer: ReturnType<typeof setTimeout>): void {
+    if (generation.retryTimer === timer) {
+      generation.retryTimer = undefined;
+    }
   }
 
   /**
    * 取消任务
    */
   cancel(key: string): void {
-    const task = this.tasks.get(key);
-    if (task) {
-      task.abort();
-      this.tasks.delete(key);
-    }
+    const generation = this.generations.get(key);
+    if (!generation) return;
+
+    this.generations.delete(key);
+    this.cancelGeneration(generation);
   }
 
   /**
    * 取消所有任务
    */
   cancelAll(): void {
-    this.tasks.forEach(task => task.abort());
-    this.tasks.clear();
+    const generations = [...this.generations.values()];
+    this.generations.clear();
+    generations.forEach(generation => {
+      this.cancelGeneration(generation);
+    });
   }
 
   /**
-   * 移除任务
+   * 逻辑请求结束；旧 generation 不得清理新 generation
    */
-  remove(key: string): void {
-    this.tasks.delete(key);
+  finish(generation: RequestGeneration): void {
+    generation.task = undefined;
+    this.clearRetryTimer(generation);
+    if (this.generations.get(generation.key) === generation) {
+      this.generations.delete(generation.key);
+    }
+  }
+
+  private cancelGeneration(generation: RequestGeneration): void {
+    if (generation.cancelled) return;
+
+    generation.cancelled = true;
+    const task = generation.task;
+    generation.task = undefined;
+    this.clearRetryTimer(generation);
+    generation.rejectCancellation(generation.cancellationError);
+    this.abortTask(task);
+  }
+
+  private clearRetryTimer(generation: RequestGeneration): void {
+    if (generation.retryTimer !== undefined) {
+      clearTimeout(generation.retryTimer);
+      generation.retryTimer = undefined;
+    }
+  }
+
+  private abortTask(task?: UniApp.RequestTask): void {
+    if (!task) return;
+
+    try {
+      task.abort();
+    } catch {
+      // abort 是尽力清理；底层异常不得改变已经提交的取消终态。
+    }
   }
 }
 
@@ -306,75 +437,176 @@ export class Request {
   /**
    * 延迟函数
    */
-  private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  private delay(ms: number, generation: RequestGeneration): Promise<void> {
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        this.taskManager.releaseRetryTimer(generation, timer);
+        resolve();
+      }, ms);
+
+      if (!this.taskManager.attachRetryTimer(generation, timer)) {
+        resolve();
+      }
+    });
+  }
+
+  /**
+   * 创建与 uni.request abort 语义一致的取消错误
+   */
+  private createCancellationError(config: RequestConfig): RequestError {
+    return {
+      errMsg: 'request:fail abort',
+      config,
+    };
+  }
+
+  /**
+   * 执行单次请求尝试
+   */
+  private performRequestAttempt<T>(
+    config: RequestConfig,
+    generation: RequestGeneration,
+    terminalOnFailure: boolean
+  ): Promise<RequestResponse<T>> {
+    return new Promise((resolve, reject) => {
+      const taskRef: { current?: UniApp.RequestTask } = {};
+      let settled = false;
+
+      const settle = (handler: () => void): void => {
+        if (settled) return;
+        settled = true;
+        if (taskRef.current) {
+          this.taskManager.release(generation, taskRef.current);
+        }
+        handler();
+      };
+
+      let task: UniApp.RequestTask;
+      try {
+        task = uni.request({
+          ...config,
+          method: config.method as UniApp.RequestOptions['method'],
+          success: (res: UniApp.RequestSuccessCallbackResult) => {
+            if (!this.taskManager.isLatest(generation)) {
+              settle(() => reject(this.createCancellationError(config)));
+              return;
+            }
+
+            const response: RequestResponse<T> = {
+              data: res.data as T,
+              statusCode: res.statusCode,
+              header: res.header,
+              cookies: res.cookies,
+              profile: res.profile,
+            };
+            settle(() => {
+              this.taskManager.finish(generation);
+              resolve(response);
+            });
+          },
+          fail: (
+            err: UniApp.GeneralCallbackResult & {
+              statusCode?: number;
+              data?: unknown;
+            }
+          ) => {
+            if (!this.taskManager.isLatest(generation)) {
+              settle(() => reject(this.createCancellationError(config)));
+              return;
+            }
+
+            const error: RequestError = {
+              errMsg: err.errMsg,
+              statusCode: err.statusCode,
+              data: err.data,
+              config,
+            };
+            settle(() => {
+              if (terminalOnFailure) {
+                this.taskManager.finish(generation);
+              }
+              reject(error);
+            });
+          },
+        });
+      } catch (error) {
+        if (settled) return;
+        if (!this.taskManager.isLatest(generation)) {
+          settle(() => reject(this.createCancellationError(config)));
+          return;
+        }
+
+        settle(() => {
+          if (terminalOnFailure) {
+            this.taskManager.finish(generation);
+          }
+          reject(error);
+        });
+        return;
+      }
+      taskRef.current = task;
+
+      if (settled) return;
+      if (!this.taskManager.attach(generation, task)) {
+        settle(() => reject(this.createCancellationError(config)));
+      }
+    });
   }
 
   /**
    * 执行请求（支持重试）
    */
-  private async performRequest<T>(
-    config: RequestConfig,
-    attempt: number = 0
-  ): Promise<RequestResponse<T>> {
-    return new Promise((resolve, reject) => {
-      const requestId = this.generateRequestId(config);
+  private async performRequest<T>(config: RequestConfig): Promise<RequestResponse<T>> {
+    const requestId = this.generateRequestId(config);
+    const cancellationError = this.createCancellationError(config);
+    const generation = this.taskManager.start(requestId, cancellationError);
+    const maxRetries = config.retry || 0;
 
-      // 取消同一个requestId的之前请求
-      if (config.requestId) {
-        this.taskManager.cancel(config.requestId);
+    const attempts = async (): Promise<RequestResponse<T>> => {
+      let attempt = 0;
+      let firstError: unknown;
+      let hasFirstError = false;
+
+      while (true) {
+        if (!this.taskManager.isLatest(generation)) {
+          throw cancellationError;
+        }
+
+        const canRetry = attempt < maxRetries;
+        try {
+          return await this.performRequestAttempt<T>(config, generation, !canRetry);
+        } catch (error) {
+          if (this.taskManager.isCancelled(generation)) {
+            throw cancellationError;
+          }
+
+          if (!hasFirstError) {
+            firstError = error;
+            hasFirstError = true;
+          }
+          if (!canRetry) {
+            throw firstError;
+          }
+
+          if (config.retryDelay) {
+            await Promise.race([
+              this.delay(config.retryDelay, generation),
+              generation.cancellation,
+            ]);
+          }
+          if (!this.taskManager.isLatest(generation)) {
+            throw cancellationError;
+          }
+          attempt += 1;
+        }
       }
+    };
 
-      const task = uni.request({
-        ...config,
-        method: config.method as UniApp.RequestOptions['method'],
-        success: (res: UniApp.RequestSuccessCallbackResult) => {
-          this.taskManager.remove(requestId);
-          const response: RequestResponse<T> = {
-            data: res.data as T,
-            statusCode: res.statusCode,
-            header: res.header,
-            cookies: res.cookies,
-            profile: res.profile,
-          };
-          resolve(response);
-        },
-        fail: async (
-          err: UniApp.GeneralCallbackResult & {
-            statusCode?: number;
-            data?: unknown;
-          }
-        ) => {
-          this.taskManager.remove(requestId);
-
-          // 重试逻辑
-          const maxRetries = config.retry || 0;
-          if (attempt < maxRetries) {
-            if (config.retryDelay) {
-              await this.delay(config.retryDelay);
-            }
-            try {
-              const result = await this.performRequest<T>(config, attempt + 1);
-              resolve(result);
-              return;
-            } catch {
-              // 重试失败，继续走原来的错误处理逻辑
-            }
-          }
-
-          const error: RequestError = {
-            errMsg: err.errMsg,
-            statusCode: err.statusCode,
-            data: err.data,
-            config,
-          };
-          reject(error);
-        },
-      });
-
-      // 保存任务
-      this.taskManager.add(requestId, task);
-    });
+    try {
+      return await Promise.race([attempts(), generation.cancellation]);
+    } finally {
+      this.taskManager.finish(generation);
+    }
   }
 
   /**
@@ -384,6 +616,7 @@ export class Request {
     const mergedConfig = this.mergeConfig(config);
     // 用于在 finally 块中访问最终配置，以判断是否需要隐藏 loading
     let finalConfig: RequestConfig = mergedConfig;
+    let loadingAcquired = false;
 
     // Promise 链，初始值为已合并的配置
     type RequestChainFn = (value: unknown) => unknown | Promise<unknown>;
@@ -394,6 +627,7 @@ export class Request {
       finalConfig = config;
       if (finalConfig.loading) {
         this.showLoading(finalConfig.loadingText);
+        loadingAcquired = true;
       }
       return this.performRequest<T>(finalConfig);
     };
@@ -425,7 +659,7 @@ export class Request {
     try {
       return (await promise) as RequestResponse<T>;
     } finally {
-      if (finalConfig.loading) {
+      if (loadingAcquired) {
         this.hideLoading();
       }
     }

--- a/tests/unit/request.spec.ts
+++ b/tests/unit/request.spec.ts
@@ -1,0 +1,384 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRequest,
+  type RequestResponse,
+} from '../../src/uni_modules/lucky-ui/core/src/utils/request';
+
+interface ControlledRequest {
+  options: UniApp.RequestOptions;
+  task: UniApp.RequestTask;
+  abort: ReturnType<typeof vi.fn>;
+  fail: (error?: UniApp.GeneralCallbackResult & { statusCode?: number; data?: unknown }) => void;
+  succeed: (data?: unknown) => void;
+}
+
+interface ControlledUniOptions {
+  beforeCreate?: (index: number) => void;
+  afterCreate?: (request: ControlledRequest, index: number) => void;
+  onAbort?: (index: number) => void;
+}
+
+type Settled<T> = { status: 'fulfilled'; value: T } | { status: 'rejected'; reason: unknown };
+
+function capture<T>(promise: Promise<T>): Promise<Settled<T>> {
+  return promise.then(
+    value => ({ status: 'fulfilled', value }),
+    reason => ({ status: 'rejected', reason })
+  );
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 6; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function installControlledUni(behavior: ControlledUniOptions = {}) {
+  const requests: ControlledRequest[] = [];
+  let invocationCount = 0;
+  const request = vi.fn((options: UniApp.RequestOptions): UniApp.RequestTask => {
+    const index = invocationCount;
+    invocationCount += 1;
+    behavior.beforeCreate?.(index);
+
+    let settled = false;
+    const fail: ControlledRequest['fail'] = (error = { errMsg: 'request:fail network' }) => {
+      if (settled) return;
+      settled = true;
+      options.fail?.(error);
+    };
+    const succeed: ControlledRequest['succeed'] = (data = { ok: true }) => {
+      if (settled) return;
+      settled = true;
+      options.success?.({
+        data: data as UniApp.RequestSuccessCallbackResult['data'],
+        statusCode: 200,
+        header: {},
+        cookies: [],
+      });
+    };
+    const abort = vi.fn(() => {
+      behavior.onAbort?.(index);
+      fail({ errMsg: 'request:fail abort' });
+    });
+    const task = {
+      abort,
+      onHeadersReceived: vi.fn(),
+      offHeadersReceived: vi.fn(),
+    } as unknown as UniApp.RequestTask;
+
+    const controlledRequest = { options, task, abort, fail, succeed };
+    requests.push(controlledRequest);
+    behavior.afterCreate?.(controlledRequest, index);
+    return task;
+  });
+
+  const showLoading = vi.fn();
+  const hideLoading = vi.fn();
+
+  vi.stubGlobal('uni', {
+    request,
+    showLoading,
+    hideLoading,
+    getLocale: vi.fn(() => 'zh-Hans'),
+  });
+
+  return { request, requests, showLoading, hideLoading };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('request cancellation generations', () => {
+  it('keeps a newer same-id request alive when an older retry delay is released', async () => {
+    vi.useFakeTimers();
+    const controller = installControlledUni();
+    const api = createRequest();
+    const first = capture(api.get('/first', { requestId: 'shared', retry: 1, retryDelay: 100 }));
+
+    await flushMicrotasks();
+    controller.requests[0].fail({ errMsg: 'request:fail offline' });
+    await flushMicrotasks();
+    expect(vi.getTimerCount()).toBe(1);
+
+    const secondPromise = api.get<{ owner: string }>('/second', { requestId: 'shared' });
+    await flushMicrotasks();
+
+    expect(controller.requests).toHaveLength(2);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(controller.requests).toHaveLength(2);
+    expect(controller.requests[1].abort).not.toHaveBeenCalled();
+    await expect(first).resolves.toMatchObject({
+      status: 'rejected',
+      reason: {
+        errMsg: 'request:fail abort',
+        config: { url: '/first', requestId: 'shared' },
+      },
+    });
+
+    controller.requests[1].succeed({ owner: 'second' });
+    await expect(secondPromise).resolves.toMatchObject({ data: { owner: 'second' } });
+  });
+
+  it('never retries a directly cancelled logical request', async () => {
+    vi.useFakeTimers();
+    const controller = installControlledUni();
+    const api = createRequest();
+    const result = capture(
+      api.get('/cancel-me', { requestId: 'cancel-me', retry: 2, retryDelay: 100 })
+    );
+
+    await flushMicrotasks();
+    api.cancel('cancel-me');
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(controller.request).toHaveBeenCalledTimes(1);
+    expect(controller.requests[0].abort).toHaveBeenCalledTimes(1);
+    await expect(result).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail abort' },
+    });
+  });
+
+  it('cancels a logical request while it is waiting to retry', async () => {
+    vi.useFakeTimers();
+    const controller = installControlledUni();
+    const api = createRequest();
+    const result = capture(
+      api.get('/cancel-delay', { requestId: 'cancel-delay', retry: 2, retryDelay: 100 })
+    );
+
+    await flushMicrotasks();
+    controller.requests[0].fail({ errMsg: 'request:fail offline' });
+    await flushMicrotasks();
+    expect(vi.getTimerCount()).toBe(1);
+    api.cancel('cancel-delay');
+    await flushMicrotasks();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(controller.request).toHaveBeenCalledTimes(1);
+    await expect(result).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail abort' },
+    });
+  });
+
+  it('does not let an older finally remove the newer request generation', async () => {
+    const controller = installControlledUni();
+    const api = createRequest();
+    const first = capture(api.get('/first', { requestId: 'shared' }));
+
+    await flushMicrotasks();
+    const second = capture(api.get('/second', { requestId: 'shared' }));
+    await flushMicrotasks();
+
+    expect(controller.requests[0].abort).toHaveBeenCalledTimes(1);
+    await expect(first).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail abort' },
+    });
+
+    api.cancel('shared');
+    await flushMicrotasks();
+
+    expect(controller.requests[1].abort).toHaveBeenCalledTimes(1);
+    await expect(second).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail abort' },
+    });
+  });
+
+  it('preserves a normal retry when the generation remains current', async () => {
+    vi.useFakeTimers();
+    const controller = installControlledUni();
+    const api = createRequest();
+    const result: Promise<RequestResponse<{ attempt: number }>> = api.get('/retry', {
+      requestId: 'retry',
+      retry: 1,
+      retryDelay: 100,
+    });
+
+    await flushMicrotasks();
+    controller.requests[0].fail({ errMsg: 'request:fail offline' });
+    await flushMicrotasks();
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(controller.requests).toHaveLength(2);
+    controller.requests[1].succeed({ attempt: 2 });
+    await expect(result).resolves.toMatchObject({ data: { attempt: 2 } });
+  });
+});
+
+describe('request terminal ownership', () => {
+  it('commits a synchronous success before a same-id replacement starts', async () => {
+    const controller = installControlledUni({
+      afterCreate: (request, index) => {
+        if (index === 0) {
+          request.succeed({ owner: 'first' });
+        }
+      },
+    });
+    const api = createRequest();
+    const first = capture(api.get<{ owner: string }>('/first', { requestId: 'shared' }));
+    const second = capture(api.get<{ owner: string }>('/second', { requestId: 'shared' }));
+
+    await flushMicrotasks();
+
+    expect(controller.requests).toHaveLength(2);
+    await expect(first).resolves.toMatchObject({
+      status: 'fulfilled',
+      value: { data: { owner: 'first' } },
+    });
+
+    controller.requests[1].succeed({ owner: 'second' });
+    await expect(second).resolves.toMatchObject({
+      status: 'fulfilled',
+      value: { data: { owner: 'second' } },
+    });
+  });
+
+  it('commits a synchronous terminal failure before a same-id replacement starts', async () => {
+    const controller = installControlledUni({
+      afterCreate: (request, index) => {
+        if (index === 0) {
+          request.fail({ errMsg: 'request:fail first-terminal' });
+        }
+      },
+    });
+    const api = createRequest();
+    const first = capture(api.get('/first', { requestId: 'shared' }));
+    const second = capture(api.get<{ owner: string }>('/second', { requestId: 'shared' }));
+
+    await flushMicrotasks();
+
+    expect(controller.requests).toHaveLength(2);
+    await expect(first).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail first-terminal' },
+    });
+
+    controller.requests[1].succeed({ owner: 'second' });
+    await expect(second).resolves.toMatchObject({
+      status: 'fulfilled',
+      value: { data: { owner: 'second' } },
+    });
+  });
+
+  it.each([undefined, null])(
+    'preserves a %s first synchronous error after retries are exhausted',
+    async firstError => {
+      const finalError = new Error('final error');
+      const controller = installControlledUni({
+        beforeCreate: index => {
+          if (index === 0) {
+            throw firstError;
+          }
+          throw finalError;
+        },
+      });
+      const api = createRequest();
+      const settled = await capture(
+        api.get('/sync-throw', { requestId: 'sync-throw', retry: 1, retryDelay: 0 })
+      );
+
+      expect(controller.request).toHaveBeenCalledTimes(2);
+      expect(settled).toEqual({ status: 'rejected', reason: firstError });
+    }
+  );
+
+  it('uses retry as the number of extra attempts and returns the first ordinary error', async () => {
+    const controller = installControlledUni();
+    const api = createRequest();
+    const result = capture(
+      api.get('/retry-exhausted', {
+        requestId: 'retry-exhausted',
+        retry: 2,
+        retryDelay: 0,
+      })
+    );
+
+    await flushMicrotasks();
+    controller.requests[0].fail({ errMsg: 'request:fail first' });
+    await flushMicrotasks();
+    controller.requests[1].fail({ errMsg: 'request:fail second' });
+    await flushMicrotasks();
+    controller.requests[2].fail({ errMsg: 'request:fail third' });
+
+    expect(controller.request).toHaveBeenCalledTimes(3);
+    await expect(result).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail first' },
+    });
+  });
+});
+
+describe('request cleanup ownership', () => {
+  it('does not hide loading for a request rejected before dispatch', async () => {
+    const controller = installControlledUni();
+    const api = createRequest({ loading: true });
+    const active = capture(api.get('/active'));
+
+    await flushMicrotasks();
+    expect(controller.showLoading).toHaveBeenCalledTimes(1);
+    expect(controller.hideLoading).not.toHaveBeenCalled();
+
+    const interceptorError = new Error('blocked before dispatch');
+    api.interceptors.request.use(() => {
+      throw interceptorError;
+    });
+    const blocked = capture(api.get('/blocked'));
+    await expect(blocked).resolves.toEqual({
+      status: 'rejected',
+      reason: interceptorError,
+    });
+
+    expect(controller.hideLoading).not.toHaveBeenCalled();
+    controller.requests[0].succeed();
+    await expect(active).resolves.toMatchObject({ status: 'fulfilled' });
+    expect(controller.hideLoading).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps replacement usable when abort cleanup throws synchronously', async () => {
+    const abortError = new Error('abort cleanup failed');
+    const controller = installControlledUni({
+      onAbort: index => {
+        if (index === 0) {
+          throw abortError;
+        }
+      },
+    });
+    const api = createRequest();
+    const first = capture(api.get('/first', { requestId: 'shared' }));
+
+    await flushMicrotasks();
+    const second = capture(api.get<{ owner: string }>('/second', { requestId: 'shared' }));
+    await flushMicrotasks();
+
+    expect(controller.requests[0].abort).toHaveBeenCalledTimes(1);
+    expect(controller.requests).toHaveLength(2);
+    await expect(first).resolves.toMatchObject({
+      status: 'rejected',
+      reason: { errMsg: 'request:fail abort' },
+    });
+
+    controller.requests[1].succeed({ owner: 'second' });
+    await expect(second).resolves.toMatchObject({
+      status: 'fulfilled',
+      value: { data: { owner: 'second' } },
+    });
+
+    expect(() => api.cancel('shared')).not.toThrow();
+    expect(controller.requests[1].abort).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(request): isolate cancellation generations`。
- 保留提交 `3ba112fbbd2d` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。