### PR TITLE
fix(tabbar): isolate container instances

### DIFF
--- a/src/uni_modules/lucky-ui/components/lk-tabbar-container/lk-tabbar-container.vue
+++ b/src/uni_modules/lucky-ui/components/lk-tabbar-container/lk-tabbar-container.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, watch, type StyleValue } from 'vue';
+import { computed, onBeforeUnmount, onMounted, watch, type StyleValue } from 'vue';
 import LkLoading from '../lk-loading/lk-loading.vue';
 import LkIcon from '../lk-icon/lk-icon.vue';
 import { useLocale } from '../../composables/useLocale';
-import {
-  useTabbarContainer,
-  initTabbarContainer,
-  setTabbarDebug,
-} from '../../core/src/tabbar-container';
+import { createTabbarContainer } from '../../core/src/tabbar-container';
 import {
   TabbarContainerMode,
   TabbarContainerRenderMode,
@@ -16,6 +12,7 @@ import {
   type TabConfig,
 } from './tabbar-container.props';
 import {
+  createTabbarContainerChangeController,
   getTabbarContainerPreloadIds,
   isTabbarContainerSlidingMode,
   resolveTabbarContainerActiveBgStyle,
@@ -25,7 +22,6 @@ import {
   resolveTabbarContainerIcon,
   resolveTabbarContainerSafeAreaBottom,
   resolveTabbarContainerStyle,
-  shouldChangeTabbarContainerTab,
   shouldShowTabbarContainerBadge,
 } from './tabbar-container.utils';
 
@@ -56,7 +52,16 @@ preferRuntimeSafeArea = true;
 
 const safeAreaBottom = resolveTabbarContainerSafeAreaBottom(systemInfo);
 
-const { activeId, switchTab, preloadTabs, getTabInstance, isVisited } = useTabbarContainer();
+const tabbarContainer = createTabbarContainer();
+const { activeId, switchTab, preloadTabs, getTabInstance, isVisited, init, reset, setDebug } =
+  tabbarContainer;
+const changeController = createTabbarContainerChangeController({
+  getActiveId: () => activeId.value,
+  switchTab,
+  onBeforeChange: (tabId, oldTabId) => emit('beforeChange', tabId, oldTabId),
+  onChange: tabId => emit('change', tabId),
+});
+let preloadTimer: ReturnType<typeof setTimeout> | undefined;
 
 const TABBAR_ICON_SIZE = 40;
 
@@ -148,19 +153,7 @@ function shouldRenderFallbackSlot(tabId: string) {
 }
 
 async function handleTabClick(tab: TabConfig) {
-  if (
-    !shouldChangeTabbarContainerTab({
-      nextTabId: tab.id,
-      activeId: activeId.value,
-    })
-  )
-    return;
-
-  const oldTabId = activeId.value;
-  emit('beforeChange', tab.id, oldTabId);
-
-  await switchTab(tab.id);
-  emit('change', tab.id);
+  await changeController.switchTo(tab.id);
 }
 
 async function retryLoad(tabId: string) {
@@ -173,14 +166,12 @@ async function retryLoad(tabId: string) {
 }
 
 onMounted(() => {
-  if (props.debug) {
-    setTabbarDebug(true);
-  }
+  setDebug(props.debug);
 
-  initTabbarContainer(runtimeTabs.value, props.defaultTab || runtimeTabs.value[0]?.id);
+  init(runtimeTabs.value, props.defaultTab || runtimeTabs.value[0]?.id);
 
   if (props.preloadAll) {
-    setTimeout(() => {
+    preloadTimer = setTimeout(() => {
       preloadTabs(
         getTabbarContainerPreloadIds({
           tabs: runtimeTabs.value,
@@ -194,10 +185,20 @@ onMounted(() => {
 watch(
   () => [runtimeTabs.value, props.defaultTab] as const,
   ([newTabs]) => {
-    initTabbarContainer(newTabs, activeId.value || props.defaultTab);
+    changeController.invalidate();
+    init(newTabs, activeId.value || props.defaultTab);
   },
   { deep: true }
 );
+
+onBeforeUnmount(() => {
+  changeController.invalidate();
+  if (preloadTimer !== undefined) {
+    clearTimeout(preloadTimer);
+    preloadTimer = undefined;
+  }
+  reset();
+});
 </script>
 
 <template>

--- a/src/uni_modules/lucky-ui/components/lk-tabbar-container/tabbar-container.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-tabbar-container/tabbar-container.utils.ts
@@ -151,3 +151,50 @@ export function resolveTabbarContainerBadgeText(badge: number | undefined): stri
   if (typeof badge !== 'number' || badge <= 0) return '';
   return badge > 99 ? '99+' : String(badge);
 }
+
+export interface TabbarContainerChangeController {
+  switchTo: (tabId: string) => Promise<boolean>;
+  invalidate: () => void;
+}
+
+/**
+ * 为单个组件实例串联切换意图与事件。
+ * 相同目标只接受一次；不同目标采用 latest-wins，失效操作不得补发 change。
+ */
+export function createTabbarContainerChangeController(options: {
+  getActiveId: () => string;
+  switchTab: (tabId: string) => Promise<boolean>;
+  onBeforeChange: (tabId: string, oldTabId: string) => void;
+  onChange: (tabId: string) => void;
+}): TabbarContainerChangeController {
+  let generation = 0;
+  const pendingTargets = new Map<string, number>();
+
+  async function switchTo(tabId: string): Promise<boolean> {
+    const oldTabId = options.getActiveId();
+    if (tabId === oldTabId || pendingTargets.has(tabId)) return false;
+
+    const currentGeneration = ++generation;
+    pendingTargets.clear();
+    pendingTargets.set(tabId, currentGeneration);
+    options.onBeforeChange(tabId, oldTabId);
+
+    try {
+      const changed = await options.switchTab(tabId);
+      if (!changed || generation !== currentGeneration) return false;
+      options.onChange(tabId);
+      return true;
+    } finally {
+      if (pendingTargets.get(tabId) === currentGeneration) {
+        pendingTargets.delete(tabId);
+      }
+    }
+  }
+
+  function invalidate(): void {
+    generation += 1;
+    pendingTargets.clear();
+  }
+
+  return { switchTo, invalidate };
+}

--- a/src/uni_modules/lucky-ui/core/src/tabbar-container/index.ts
+++ b/src/uni_modules/lucky-ui/core/src/tabbar-container/index.ts
@@ -8,8 +8,7 @@
  * 4. 支持懒加载：首次切换到某个 Tab 时才加载其内容
  */
 
-import { ref, computed, markRaw, type ComputedRef } from 'vue';
-import type { Component } from 'vue';
+import { computed, markRaw, ref, type Component, type ComputedRef, type Ref } from 'vue';
 
 /** Tab 配置项 */
 export interface TabConfig {
@@ -34,7 +33,7 @@ export interface TabConfig {
 }
 
 /** Tab 实例状态 */
-interface TabInstance {
+export interface TabInstance {
   /** 组件引用 */
   component: Component | null;
   /** 是否已加载 */
@@ -46,7 +45,7 @@ interface TabInstance {
 }
 
 /** Tabbar 容器状态 */
-interface TabbarContainerState {
+export interface TabbarContainerState {
   /** 当前激活的 Tab ID */
   activeId: string;
   /** Tab 配置列表 */
@@ -57,234 +56,432 @@ interface TabbarContainerState {
   visitedTabs: Set<string>;
 }
 
+/** 兼容旧的全局 composable 返回值 */
 export interface UseTabbarContainerReturn {
   activeId: ComputedRef<string>;
   tabs: ComputedRef<TabConfig[]>;
   visitedTabs: ComputedRef<Set<string>>;
-  switchTab: typeof switchTab;
-  preloadTab: typeof preloadTab;
-  preloadTabs: typeof preloadTabs;
-  getTabInstance: typeof getTabInstance;
-  updateBadge: typeof updateTabBadge;
-  isVisited: typeof isTabVisited;
+  switchTab: (tabId: string) => Promise<void>;
+  preloadTab: (tabId: string) => Promise<void>;
+  preloadTabs: (tabIds: string[]) => Promise<void>;
+  getTabInstance: (tabId: string) => TabInstance | undefined;
+  updateBadge: (tabId: string, badge?: number, dot?: boolean) => void;
+  isVisited: (tabId: string) => boolean;
 }
 
-/** 全局状态 */
-const state = ref<TabbarContainerState>({
-  activeId: '',
-  tabs: [],
-  instances: new Map(),
-  visitedTabs: new Set(),
-});
-
-/** 调试模式 */
-let debugMode = false;
-
-/** 日志 */
-function log(...args: unknown[]): void {
-  if (debugMode) {
-    console.log('[TabbarContainer]', ...args);
-  }
+/** 每个 Tabbar 容器独占的状态与行为 owner */
+export interface TabbarContainerOwner {
+  activeId: ComputedRef<string>;
+  tabs: ComputedRef<TabConfig[]>;
+  visitedTabs: ComputedRef<Set<string>>;
+  init: (tabs: TabConfig[], defaultTabId?: string) => void;
+  switchTab: (tabId: string) => Promise<boolean>;
+  preloadTab: (tabId: string) => Promise<void>;
+  preloadTabs: (tabIds: string[]) => Promise<void>;
+  getActiveTabId: () => string;
+  getTabs: () => TabConfig[];
+  getTabInstance: (tabId: string) => TabInstance | undefined;
+  isVisited: (tabId: string) => boolean;
+  updateBadge: (tabId: string, badge?: number, dot?: boolean) => void;
+  setDebug: (enabled: boolean) => void;
+  reset: () => void;
 }
 
-/**
- * 初始化 Tabbar 容器
- */
-export function initTabbarContainer(tabs: TabConfig[], defaultTabId?: string): void {
-  state.value.tabs = tabs;
-  state.value.instances.clear();
-  state.value.visitedTabs.clear();
+interface ActiveSwitch {
+  tabId: string;
+  lifecycle: number;
+  generation: number;
+  instance: TabInstance;
+  promise: Promise<boolean>;
+}
 
-  tabs.forEach(tab => {
-    state.value.instances.set(tab.id, {
-      component: null,
-      loaded: false,
-      loading: false,
-      error: null,
-    });
+function createTabbarState(): Ref<TabbarContainerState> {
+  return ref({
+    activeId: '',
+    tabs: [],
+    instances: new Map(),
+    visitedTabs: new Set(),
   });
-
-  const initialTab = defaultTabId || tabs[0]?.id || '';
-  if (initialTab) {
-    switchTab(initialTab);
-  }
-
-  log(
-    'Container initialized with tabs:',
-    tabs.map(t => t.id)
-  );
 }
 
-/**
- * 切换 Tab
- */
-export async function switchTab(tabId: string): Promise<void> {
-  const tab = state.value.tabs.find(t => t.id === tabId);
-  if (!tab) {
-    console.warn(`[TabbarContainer] Tab not found: ${tabId}`);
-    return;
+function createTabbarOwner(
+  state: Ref<TabbarContainerState>,
+  isolateTabConfigs: boolean
+): TabbarContainerOwner {
+  let debugMode = false;
+  let lifecycleGeneration = 0;
+  let switchGeneration = 0;
+  let activeSwitch: ActiveSwitch | undefined;
+  const switchLoadPromises = new Map<TabInstance, Promise<Component>>();
+
+  const activeId = computed(() => state.value.activeId);
+  const tabs = computed(() => state.value.tabs);
+  const visitedTabs = computed(() => state.value.visitedTabs);
+
+  function log(...args: unknown[]): void {
+    if (debugMode) {
+      console.log('[TabbarContainer]', ...args);
+    }
   }
 
-  const instance = state.value.instances.get(tabId);
-  if (!instance) {
-    return;
+  function isCurrentInstance(lifecycle: number, tabId: string, instance: TabInstance): boolean {
+    return lifecycleGeneration === lifecycle && state.value.instances.get(tabId) === instance;
   }
 
-  if (!instance.loaded && !instance.loading) {
+  function isCurrentSwitch(
+    lifecycle: number,
+    generation: number,
+    tabId: string,
+    instance: TabInstance
+  ): boolean {
+    return switchGeneration === generation && isCurrentInstance(lifecycle, tabId, instance);
+  }
+
+  function invalidateLifecycle(): void {
+    lifecycleGeneration += 1;
+    switchGeneration += 1;
+    state.value.instances.forEach(instance => {
+      instance.loading = false;
+    });
+    activeSwitch = undefined;
+    switchLoadPromises.clear();
+  }
+
+  function loadSwitchComponent(
+    tab: TabConfig,
+    instance: TabInstance
+  ): Component | Promise<Component> {
+    if (typeof tab.component !== 'function') {
+      return tab.component as Component;
+    }
+
+    const pendingLoad = switchLoadPromises.get(instance);
+    if (pendingLoad) return pendingLoad;
+
+    let loadPromise: Promise<Component>;
+    try {
+      loadPromise = Promise.resolve(
+        (tab.component as () => Promise<{ default: Component }>)()
+      ).then(module => module.default);
+    } catch (error) {
+      loadPromise = Promise.reject(error);
+    }
+    switchLoadPromises.set(instance, loadPromise);
+    void loadPromise.then(
+      () => {
+        if (switchLoadPromises.get(instance) === loadPromise) {
+          switchLoadPromises.delete(instance);
+        }
+      },
+      () => {
+        if (switchLoadPromises.get(instance) === loadPromise) {
+          switchLoadPromises.delete(instance);
+        }
+      }
+    );
+    return loadPromise;
+  }
+
+  async function executeSwitch(
+    tab: TabConfig,
+    instance: TabInstance,
+    lifecycle: number,
+    generation: number
+  ): Promise<boolean> {
+    if (!instance.loaded && !instance.loading) {
+      instance.loading = true;
+      log('Loading tab component:', tab.id);
+
+      try {
+        if (!tab.component) {
+          if (!isCurrentSwitch(lifecycle, generation, tab.id, instance)) return false;
+          instance.component = null;
+          instance.loaded = true;
+          instance.error = null;
+          log('Tab component skipped (no component):', tab.id);
+        } else if (typeof tab.component === 'function') {
+          const component = await loadSwitchComponent(tab, instance);
+          if (!isCurrentSwitch(lifecycle, generation, tab.id, instance)) return false;
+          instance.component = markRaw(component);
+          instance.loaded = true;
+          instance.error = null;
+          log('Tab component loaded:', tab.id);
+        } else {
+          if (!isCurrentSwitch(lifecycle, generation, tab.id, instance)) return false;
+          instance.component = markRaw(tab.component);
+          instance.loaded = true;
+          instance.error = null;
+          log('Tab component loaded:', tab.id);
+        }
+      } catch (error) {
+        if (!isCurrentSwitch(lifecycle, generation, tab.id, instance)) return false;
+        instance.error = error as Error;
+        console.error(`[TabbarContainer] Failed to load tab: ${tab.id}`, error);
+      } finally {
+        if (isCurrentSwitch(lifecycle, generation, tab.id, instance)) {
+          instance.loading = false;
+        }
+      }
+    }
+
+    if (!isCurrentSwitch(lifecycle, generation, tab.id, instance)) return false;
+
+    state.value.activeId = tab.id;
+    state.value.visitedTabs.add(tab.id);
+    log('Switched to tab:', tab.id);
+    return true;
+  }
+
+  async function switchTab(tabId: string): Promise<boolean> {
+    const tab = state.value.tabs.find(item => item.id === tabId);
+    if (!tab) {
+      console.warn(`[TabbarContainer] Tab not found: ${tabId}`);
+      return false;
+    }
+
+    const instance = state.value.instances.get(tabId);
+    if (!instance) return false;
+
+    if (state.value.activeId === tabId && (instance.loaded || instance.loading)) {
+      return false;
+    }
+
+    const pendingSwitch = activeSwitch;
+    if (
+      pendingSwitch?.tabId === tabId &&
+      isCurrentInstance(pendingSwitch.lifecycle, tabId, pendingSwitch.instance)
+    ) {
+      await pendingSwitch.promise;
+      return false;
+    }
+
+    const generation = ++switchGeneration;
+    if (
+      pendingSwitch &&
+      isCurrentInstance(pendingSwitch.lifecycle, pendingSwitch.tabId, pendingSwitch.instance)
+    ) {
+      pendingSwitch.instance.loading = false;
+    }
+
+    const lifecycle = lifecycleGeneration;
+    let resolveSwitch!: (changed: boolean) => void;
+    let rejectSwitch!: (reason?: unknown) => void;
+    const promise = new Promise<boolean>((resolve, reject) => {
+      resolveSwitch = resolve;
+      rejectSwitch = reject;
+    });
+    const currentSwitch: ActiveSwitch = {
+      tabId,
+      lifecycle,
+      generation,
+      instance,
+      promise,
+    };
+    activeSwitch = currentSwitch;
+    void executeSwitch(tab, instance, lifecycle, generation).then(resolveSwitch, rejectSwitch);
+
+    try {
+      return await promise;
+    } finally {
+      if (activeSwitch === currentSwitch) {
+        activeSwitch = undefined;
+      }
+    }
+  }
+
+  function init(tabsConfig: TabConfig[], defaultTabId?: string): void {
+    invalidateLifecycle();
+    const ownedTabs = isolateTabConfigs ? tabsConfig.map(tab => ({ ...tab })) : tabsConfig;
+    state.value.tabs = ownedTabs;
+    state.value.instances.clear();
+    state.value.visitedTabs.clear();
+    state.value.activeId = '';
+
+    ownedTabs.forEach(tab => {
+      state.value.instances.set(tab.id, {
+        component: null,
+        loaded: false,
+        loading: false,
+        error: null,
+      });
+    });
+
+    const initialTab = ownedTabs.some(tab => tab.id === defaultTabId)
+      ? defaultTabId!
+      : ownedTabs[0]?.id || '';
+    if (initialTab) {
+      void switchTab(initialTab);
+    }
+
+    log(
+      'Container initialized with tabs:',
+      ownedTabs.map(tab => tab.id)
+    );
+  }
+
+  function getActiveTabId(): string {
+    return state.value.activeId;
+  }
+
+  function getTabs(): TabConfig[] {
+    return state.value.tabs;
+  }
+
+  function getTabInstance(tabId: string): TabInstance | undefined {
+    return state.value.instances.get(tabId);
+  }
+
+  function isVisited(tabId: string): boolean {
+    return state.value.visitedTabs.has(tabId);
+  }
+
+  async function preloadTab(tabId: string): Promise<void> {
+    const tab = state.value.tabs.find(item => item.id === tabId);
+    const instance = state.value.instances.get(tabId);
+
+    if (!tab || !instance || instance.loaded || instance.loading) return;
+
+    const lifecycle = lifecycleGeneration;
     instance.loading = true;
-    log('Loading tab component:', tabId);
+    log('Preloading tab:', tabId);
 
     try {
       if (!tab.component) {
+        if (!isCurrentInstance(lifecycle, tabId, instance)) return;
         instance.component = null;
         instance.loaded = true;
-        instance.error = null;
-        log('Tab component skipped (no component):', tabId);
+        log('Tab preload skipped (no component):', tabId);
       } else if (typeof tab.component === 'function') {
         const module = await (tab.component as () => Promise<{ default: Component }>)();
+        if (!isCurrentInstance(lifecycle, tabId, instance)) return;
         instance.component = markRaw(module.default);
+        instance.loaded = true;
+        log('Tab preloaded:', tabId);
       } else {
+        if (!isCurrentInstance(lifecycle, tabId, instance)) return;
         instance.component = markRaw(tab.component);
+        instance.loaded = true;
+        log('Tab preloaded:', tabId);
       }
-      instance.loaded = true;
-      instance.error = null;
-      log('Tab component loaded:', tabId);
     } catch (error) {
+      if (!isCurrentInstance(lifecycle, tabId, instance)) return;
       instance.error = error as Error;
-      console.error(`[TabbarContainer] Failed to load tab: ${tabId}`, error);
+      console.error(`[TabbarContainer] Failed to preload tab: ${tabId}`, error);
     } finally {
-      instance.loading = false;
+      if (isCurrentInstance(lifecycle, tabId, instance)) {
+        instance.loading = false;
+      }
     }
   }
 
-  state.value.activeId = tabId;
-  state.value.visitedTabs.add(tabId);
-  log('Switched to tab:', tabId);
-}
-
-/**
- * 获取当前激活的 Tab ID
- */
-export function getActiveTabId(): string {
-  return state.value.activeId;
-}
-
-/**
- * 获取 Tab 配置列表
- */
-export function getTabs(): TabConfig[] {
-  return state.value.tabs;
-}
-
-/**
- * 获取 Tab 实例
- */
-export function getTabInstance(tabId: string): TabInstance | undefined {
-  return state.value.instances.get(tabId);
-}
-
-/**
- * 检查 Tab 是否已访问
- */
-export function isTabVisited(tabId: string): boolean {
-  return state.value.visitedTabs.has(tabId);
-}
-
-/**
- * 预加载 Tab 组件
- */
-export async function preloadTab(tabId: string): Promise<void> {
-  const tab = state.value.tabs.find(t => t.id === tabId);
-  const instance = state.value.instances.get(tabId);
-
-  if (!tab || !instance || instance.loaded || instance.loading) {
-    return;
+  async function preloadTabs(tabIds: string[]): Promise<void> {
+    await Promise.all(tabIds.map(tabId => preloadTab(tabId)));
   }
 
-  instance.loading = true;
-  log('Preloading tab:', tabId);
-
-  try {
-    if (!tab.component) {
-      instance.component = null;
-      instance.loaded = true;
-      log('Tab preload skipped (no component):', tabId);
-    } else if (typeof tab.component === 'function') {
-      const module = await (tab.component as () => Promise<{ default: Component }>)();
-      instance.component = markRaw(module.default);
-    } else {
-      instance.component = markRaw(tab.component);
-    }
-    instance.loaded = true;
-    log('Tab preloaded:', tabId);
-  } catch (error) {
-    instance.error = error as Error;
-    console.error(`[TabbarContainer] Failed to preload tab: ${tabId}`, error);
-  } finally {
-    instance.loading = false;
-  }
-}
-
-/**
- * 批量预加载 Tab 组件
- */
-export async function preloadTabs(tabIds: string[]): Promise<void> {
-  await Promise.all(tabIds.map(id => preloadTab(id)));
-}
-
-/**
- * 更新 Tab 徽标
- */
-export function updateTabBadge(tabId: string, badge?: number, dot?: boolean): void {
-  const tab = state.value.tabs.find(t => t.id === tabId);
-  if (tab) {
+  function updateBadge(tabId: string, badge?: number, dot?: boolean): void {
+    const tab = state.value.tabs.find(item => item.id === tabId);
+    if (!tab) return;
     if (badge !== undefined) tab.badge = badge;
     if (dot !== undefined) tab.dot = dot;
   }
+
+  function setDebug(enabled: boolean): void {
+    debugMode = enabled;
+  }
+
+  function reset(): void {
+    invalidateLifecycle();
+    state.value.activeId = '';
+    state.value.tabs = [];
+    state.value.instances.clear();
+    state.value.visitedTabs.clear();
+    log('Container reset');
+  }
+
+  return {
+    activeId,
+    tabs,
+    visitedTabs,
+    init,
+    switchTab,
+    preloadTab,
+    preloadTabs,
+    getActiveTabId,
+    getTabs,
+    getTabInstance,
+    isVisited,
+    updateBadge,
+    setDebug,
+    reset,
+  };
 }
 
-/**
- * 设置调试模式
- */
+/** 创建完全独立的 Tabbar 容器 owner */
+export function createTabbarContainer(): TabbarContainerOwner {
+  return createTabbarOwner(createTabbarState(), true);
+}
+
+/** 旧函数 API 继续绑定同一个默认 owner，以保持兼容 */
+const defaultState = createTabbarState();
+const defaultOwner = createTabbarOwner(defaultState, false);
+
+export function initTabbarContainer(tabs: TabConfig[], defaultTabId?: string): void {
+  defaultOwner.init(tabs, defaultTabId);
+}
+
+export async function switchTab(tabId: string): Promise<void> {
+  await defaultOwner.switchTab(tabId);
+}
+
+export function getActiveTabId(): string {
+  return defaultOwner.getActiveTabId();
+}
+
+export function getTabs(): TabConfig[] {
+  return defaultOwner.getTabs();
+}
+
+export function getTabInstance(tabId: string): TabInstance | undefined {
+  return defaultOwner.getTabInstance(tabId);
+}
+
+export function isTabVisited(tabId: string): boolean {
+  return defaultOwner.isVisited(tabId);
+}
+
+export async function preloadTab(tabId: string): Promise<void> {
+  await defaultOwner.preloadTab(tabId);
+}
+
+export async function preloadTabs(tabIds: string[]): Promise<void> {
+  await defaultOwner.preloadTabs(tabIds);
+}
+
+export function updateTabBadge(tabId: string, badge?: number, dot?: boolean): void {
+  defaultOwner.updateBadge(tabId, badge, dot);
+}
+
 export function setTabbarDebug(enabled: boolean): void {
-  debugMode = enabled;
+  defaultOwner.setDebug(enabled);
 }
 
-/**
- * 重置容器状态
- */
 export function resetTabbarContainer(): void {
-  state.value.activeId = '';
-  state.value.tabs = [];
-  state.value.instances.clear();
-  state.value.visitedTabs.clear();
-  log('Container reset');
+  defaultOwner.reset();
 }
 
-/**
- * Tabbar 容器 Hook
- */
+/** 兼容旧的全局单例 composable；多实例组件应使用 createTabbarContainer */
 export function useTabbarContainer(): UseTabbarContainerReturn {
   return {
-    /** 当前激活的 Tab ID */
-    activeId: computed(() => state.value.activeId),
-    /** Tab 配置列表 */
-    tabs: computed(() => state.value.tabs),
-    /** 已访问的 Tab 集合 */
-    visitedTabs: computed(() => state.value.visitedTabs),
-    /** 切换 Tab */
+    activeId: defaultOwner.activeId,
+    tabs: defaultOwner.tabs,
+    visitedTabs: defaultOwner.visitedTabs,
     switchTab,
-    /** 预加载 Tab */
     preloadTab,
-    /** 预加载多个 Tab */
     preloadTabs,
-    /** 获取 Tab 实例 */
     getTabInstance,
-    /** 更新徽标 */
     updateBadge: updateTabBadge,
-    /** 检查是否已访问 */
     isVisited: isTabVisited,
   };
 }
 
-export { state as tabbarState };
+export const tabbarState = defaultState;

--- a/tests/unit/lk-tabbar-container.spec.ts
+++ b/tests/unit/lk-tabbar-container.spec.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { Component } from 'vue';
 import {
+  createTabbarContainer,
+  getActiveTabId,
+  getTabs as getLegacyTabs,
+  initTabbarContainer,
+  resetTabbarContainer,
+  switchTab as switchLegacyTab,
+  type TabConfig,
+  updateTabBadge,
+} from '../../src/uni_modules/lucky-ui/core/src/tabbar-container';
+import {
+  createTabbarContainerChangeController,
   getTabbarContainerPreloadIds,
   isTabbarContainerSlidingMode,
   resolveTabbarContainerActiveBgStyle,
@@ -14,6 +26,34 @@ import {
   shouldShowTabbarContainerBadge,
 } from '../../src/uni_modules/lucky-ui/components/lk-tabbar-container/tabbar-container.utils';
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function createTab(id: string, component?: TabConfig['component']): TabConfig {
+  return { id, label: id, icon: id, component };
+}
+
+function createDeferredLoader() {
+  const result = deferred<{ default: Component }>();
+  return {
+    ...result,
+    loader: vi.fn(() => result.promise),
+  };
+}
+
 describe('lk-tabbar-container layout and navigation rules', () => {
   const tabs = [
     { id: 'home', label: '首页', icon: 'house' },
@@ -22,27 +62,35 @@ describe('lk-tabbar-container layout and navigation rules', () => {
   ];
 
   it('resolves safe area, mode class and copy fallback', () => {
-    expect(resolveTabbarContainerSafeAreaBottom({
-      safeAreaInsets: { bottom: 20 },
-    })).toBe(20);
-    expect(resolveTabbarContainerSafeAreaBottom({
-      screenHeight: 812,
-      safeArea: { bottom: 778 },
-    })).toBe(34);
+    expect(
+      resolveTabbarContainerSafeAreaBottom({
+        safeAreaInsets: { bottom: 20 },
+      })
+    ).toBe(20);
+    expect(
+      resolveTabbarContainerSafeAreaBottom({
+        screenHeight: 812,
+        safeArea: { bottom: 778 },
+      })
+    ).toBe(34);
 
     expect(isTabbarContainerSlidingMode('block')).toBe(true);
     expect(isTabbarContainerSlidingMode('float')).toBe(false);
-    expect(resolveTabbarContainerCopyText({
-      value: '',
-      fallback: '加载中',
-    })).toBe('加载中');
-    expect(resolveTabbarContainerClass({
-      mode: 'ripple',
-      fixed: true,
-      safeMode: false,
-      renderMode: 'auto',
-      customClass: 'custom',
-    })).toEqual([
+    expect(
+      resolveTabbarContainerCopyText({
+        value: '',
+        fallback: '加载中',
+      })
+    ).toBe('加载中');
+    expect(
+      resolveTabbarContainerClass({
+        mode: 'ripple',
+        fixed: true,
+        safeMode: false,
+        renderMode: 'auto',
+        customClass: 'custom',
+      })
+    ).toEqual([
       'lk-tabbar-container',
       'lk-tabbar-container--ripple',
       'lk-tabbar-container--render-auto',
@@ -56,63 +104,409 @@ describe('lk-tabbar-container layout and navigation rules', () => {
   });
 
   it('builds container style and active indicator geometry', () => {
-    expect(resolveTabbarContainerStyle({
-      preferRuntimeSafeArea: false,
-      safeAreaBottom: 34,
-      customStyle: { background: '#fff' },
-    })).toEqual({
+    expect(
+      resolveTabbarContainerStyle({
+        preferRuntimeSafeArea: false,
+        safeAreaBottom: 34,
+        customStyle: { background: '#fff' },
+      })
+    ).toEqual({
       '--lk-tabbar-container-safe-area-bottom': '34px',
       background: '#fff',
     });
-    expect(resolveTabbarContainerActiveBgStyle({
-      count: 4,
-      activeIndex: 2,
-    })).toEqual({
+    expect(
+      resolveTabbarContainerActiveBgStyle({
+        count: 4,
+        activeIndex: 2,
+      })
+    ).toEqual({
       '--item-width': '25%',
       '--item-left': '50%',
       '--item-count': 4,
       '--active-index': 2,
       '--active-center': '62.5%',
     });
-    expect(resolveTabbarContainerActiveBgStyle({
-      count: 0,
-      activeIndex: -1,
-    })).toEqual({ display: 'none' });
+    expect(
+      resolveTabbarContainerActiveBgStyle({
+        count: 0,
+        activeIndex: -1,
+      })
+    ).toEqual({ display: 'none' });
   });
 
   it('resolves active icons and preload ids', () => {
     expect(resolveTabbarContainerFillIconName('cart')).toBe('cart-fill');
     expect(resolveTabbarContainerFillIconName('cart-fill')).toBe('cart-fill');
-    expect(resolveTabbarContainerIcon({
-      tab: tabs[1],
-      activeId: 'cart',
-    })).toBe('cart-fill');
-    expect(resolveTabbarContainerIcon({
-      tab: tabs[2],
-      activeId: 'mine',
-    })).toBe('user-selected');
-    expect(resolveTabbarContainerIcon({
-      tab: tabs[0],
-      activeId: 'cart',
-    })).toBe('house');
-    expect(getTabbarContainerPreloadIds({
-      tabs,
-      activeId: 'cart',
-    })).toEqual(['home', 'mine']);
+    expect(
+      resolveTabbarContainerIcon({
+        tab: tabs[1],
+        activeId: 'cart',
+      })
+    ).toBe('cart-fill');
+    expect(
+      resolveTabbarContainerIcon({
+        tab: tabs[2],
+        activeId: 'mine',
+      })
+    ).toBe('user-selected');
+    expect(
+      resolveTabbarContainerIcon({
+        tab: tabs[0],
+        activeId: 'cart',
+      })
+    ).toBe('house');
+    expect(
+      getTabbarContainerPreloadIds({
+        tabs,
+        activeId: 'cart',
+      })
+    ).toEqual(['home', 'mine']);
   });
 
   it('guards tab changes and badge display', () => {
-    expect(shouldChangeTabbarContainerTab({
-      nextTabId: 'cart',
-      activeId: 'home',
-    })).toBe(true);
-    expect(shouldChangeTabbarContainerTab({
-      nextTabId: 'home',
-      activeId: 'home',
-    })).toBe(false);
+    expect(
+      shouldChangeTabbarContainerTab({
+        nextTabId: 'cart',
+        activeId: 'home',
+      })
+    ).toBe(true);
+    expect(
+      shouldChangeTabbarContainerTab({
+        nextTabId: 'home',
+        activeId: 'home',
+      })
+    ).toBe(false);
     expect(shouldShowTabbarContainerBadge(1)).toBe(true);
     expect(shouldShowTabbarContainerBadge(0)).toBe(false);
     expect(resolveTabbarContainerBadgeText(120)).toBe('99+');
     expect(resolveTabbarContainerBadgeText(undefined)).toBe('');
+  });
+});
+
+describe('tabbar-container instance ownership', () => {
+  it('keeps the legacy singleton function API compatible', async () => {
+    const legacyTabs = [createTab('first'), createTab('second')];
+    resetTabbarContainer();
+    initTabbarContainer(legacyTabs, 'first');
+
+    expect(getActiveTabId()).toBe('first');
+    await expect(switchLegacyTab('second')).resolves.toBeUndefined();
+    expect(getActiveTabId()).toBe('second');
+    updateTabBadge('first', 2, true);
+    expect(legacyTabs[0]).toMatchObject({ badge: 2, dot: true });
+    legacyTabs[0].label = 'updated';
+    expect(getLegacyTabs()[0].label).toBe('updated');
+
+    resetTabbarContainer();
+    expect(getActiveTabId()).toBe('');
+  });
+
+  it('keeps two initialized owners isolated even when tab ids overlap', async () => {
+    const homeA = createDeferredLoader();
+    const homeB = createDeferredLoader();
+    const ownerA = createTabbarContainer();
+    const ownerB = createTabbarContainer();
+
+    ownerA.init([createTab('home', homeA.loader), createTab('a-only')], 'home');
+    ownerB.init([createTab('home', homeB.loader), createTab('b-only')], 'home');
+    const waitForA = ownerA.switchTab('home');
+    const waitForB = ownerB.switchTab('home');
+
+    expect(ownerA.getTabs().map(tab => tab.id)).toEqual(['home', 'a-only']);
+    expect(ownerB.getTabs().map(tab => tab.id)).toEqual(['home', 'b-only']);
+    expect(ownerA.getTabInstance('home')?.loading).toBe(true);
+    expect(ownerB.getTabInstance('home')?.loading).toBe(true);
+    expect(ownerA.getActiveTabId()).toBe('');
+    expect(ownerB.getActiveTabId()).toBe('');
+
+    homeB.resolve({ default: { name: 'HomeB' } as Component });
+    await expect(waitForB).resolves.toBe(false);
+    expect(ownerB.getActiveTabId()).toBe('home');
+    expect(ownerA.getActiveTabId()).toBe('');
+
+    homeA.resolve({ default: { name: 'HomeA' } as Component });
+    await expect(waitForA).resolves.toBe(false);
+    expect(ownerA.getActiveTabId()).toBe('home');
+
+    await expect(ownerA.switchTab('a-only')).resolves.toBe(true);
+    expect(ownerA.getActiveTabId()).toBe('a-only');
+    expect(ownerB.getActiveTabId()).toBe('home');
+    expect(ownerB.getTabInstance('b-only')).toBeDefined();
+
+    ownerA.reset();
+    expect(ownerA.getTabs()).toEqual([]);
+    expect(ownerB.getTabs().map(tab => tab.id)).toEqual(['home', 'b-only']);
+    expect(ownerB.getActiveTabId()).toBe('home');
+  });
+
+  it('owns copied tab configs when two owners receive the same input array', () => {
+    const sharedTabs = [createTab('home'), createTab('mine')];
+    const ownerA = createTabbarContainer();
+    const ownerB = createTabbarContainer();
+
+    ownerA.init(sharedTabs, 'home');
+    ownerB.init(sharedTabs, 'home');
+    ownerA.updateBadge('home', 3, true);
+
+    expect(ownerA.getTabs()[0]).toMatchObject({ badge: 3, dot: true });
+    expect(ownerB.getTabs()[0]).not.toHaveProperty('badge');
+    expect(ownerB.getTabs()[0]).not.toHaveProperty('dot');
+    expect(sharedTabs[0]).not.toHaveProperty('badge');
+    expect(ownerA.getTabs()).not.toBe(ownerB.getTabs());
+    expect(ownerA.getTabs()[0]).not.toBe(ownerB.getTabs()[0]);
+  });
+
+  it('lets only the latest slow-to-fast switch resolve into state', async () => {
+    const slow = createDeferredLoader();
+    const fast = createDeferredLoader();
+    const slowComponent = { name: 'SlowPane' } as Component;
+    const fastComponent = { name: 'FastPane' } as Component;
+    const owner = createTabbarContainer();
+    owner.init(
+      [createTab('base'), createTab('slow', slow.loader), createTab('fast', fast.loader)],
+      'base'
+    );
+
+    const slowSwitch = owner.switchTab('slow');
+    const slowInstance = owner.getTabInstance('slow')!;
+    expect(slowInstance.loading).toBe(true);
+
+    const fastSwitch = owner.switchTab('fast');
+    const fastInstance = owner.getTabInstance('fast')!;
+    expect(slowInstance.loading).toBe(false);
+    expect(fastInstance.loading).toBe(true);
+
+    fast.resolve({ default: fastComponent });
+    await expect(fastSwitch).resolves.toBe(true);
+    expect(owner.getActiveTabId()).toBe('fast');
+    expect(fastInstance.component).toBe(fastComponent);
+    expect(fastInstance.loading).toBe(false);
+
+    slow.resolve({ default: slowComponent });
+    await expect(slowSwitch).resolves.toBe(false);
+    expect(owner.getActiveTabId()).toBe('fast');
+    expect(slowInstance).toMatchObject({
+      component: null,
+      loaded: false,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('ignores a stale rejection while the latest rejection owns the error state', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const slow = createDeferredLoader();
+    const fast = createDeferredLoader();
+    const slowError = new Error('stale slow failure');
+    const fastError = new Error('latest fast failure');
+    const owner = createTabbarContainer();
+    owner.init(
+      [createTab('base'), createTab('slow', slow.loader), createTab('fast', fast.loader)],
+      'base'
+    );
+
+    const slowSwitch = owner.switchTab('slow');
+    const slowInstance = owner.getTabInstance('slow')!;
+    const fastSwitch = owner.switchTab('fast');
+    const fastInstance = owner.getTabInstance('fast')!;
+
+    fast.reject(fastError);
+    await expect(fastSwitch).resolves.toBe(true);
+    expect(owner.getActiveTabId()).toBe('fast');
+    expect(fastInstance).toMatchObject({ loading: false, error: fastError });
+
+    slow.reject(slowError);
+    await expect(slowSwitch).resolves.toBe(false);
+    expect(owner.getActiveTabId()).toBe('fast');
+    expect(slowInstance).toMatchObject({ loading: false, error: null });
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      '[TabbarContainer] Failed to load tab: fast',
+      fastError
+    );
+    consoleError.mockRestore();
+  });
+
+  it('invalidates a pending switch on reset without allowing late writes', async () => {
+    const slow = createDeferredLoader();
+    const slowComponent = { name: 'SlowPane' } as Component;
+    const owner = createTabbarContainer();
+    owner.init([createTab('base'), createTab('slow', slow.loader)], 'base');
+
+    const slowSwitch = owner.switchTab('slow');
+    const staleInstance = owner.getTabInstance('slow')!;
+    expect(staleInstance.loading).toBe(true);
+
+    owner.reset();
+    expect(staleInstance.loading).toBe(false);
+    expect(owner.getActiveTabId()).toBe('');
+    expect(owner.getTabs()).toEqual([]);
+
+    slow.resolve({ default: slowComponent });
+    await expect(slowSwitch).resolves.toBe(false);
+    expect(staleInstance).toMatchObject({
+      component: null,
+      loaded: false,
+      loading: false,
+      error: null,
+    });
+    expect(owner.getActiveTabId()).toBe('');
+  });
+
+  it('keeps a re-initialized same-id instance safe from an old promise', async () => {
+    const oldLoader = createDeferredLoader();
+    const oldComponent = { name: 'OldPane' } as Component;
+    const replacementComponent = { name: 'ReplacementPane' } as Component;
+    const owner = createTabbarContainer();
+    owner.init([createTab('base'), createTab('shared', oldLoader.loader)], 'base');
+
+    const oldSwitch = owner.switchTab('shared');
+    const oldInstance = owner.getTabInstance('shared')!;
+    owner.init([createTab('shared', replacementComponent)], 'shared');
+    const replacementInstance = owner.getTabInstance('shared')!;
+
+    expect(replacementInstance).not.toBe(oldInstance);
+    expect(owner.getActiveTabId()).toBe('shared');
+    expect(replacementInstance.component).toMatchObject({ name: 'ReplacementPane' });
+    expect(replacementInstance.loaded).toBe(true);
+
+    oldLoader.resolve({ default: oldComponent });
+    await expect(oldSwitch).resolves.toBe(false);
+    expect(replacementInstance.component).toMatchObject({ name: 'ReplacementPane' });
+    expect(replacementInstance).toMatchObject({ loaded: true, loading: false, error: null });
+    expect(oldInstance).toMatchObject({
+      component: null,
+      loaded: false,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('falls back to the first tab when re-init removes the requested default', () => {
+    const owner = createTabbarContainer();
+    owner.init([createTab('first'), createTab('removed')], 'removed');
+    expect(owner.getActiveTabId()).toBe('removed');
+
+    owner.init([createTab('first')], 'removed');
+
+    expect(owner.getActiveTabId()).toBe('first');
+    expect(owner.isVisited('first')).toBe(true);
+  });
+
+  it('deduplicates the same pending target and ignores the current active target', async () => {
+    const target = createDeferredLoader();
+    const targetComponent = { name: 'TargetPane' } as Component;
+    const owner = createTabbarContainer();
+    owner.init([createTab('base'), createTab('target', target.loader)], 'base');
+
+    const firstSwitch = owner.switchTab('target');
+    const duplicateSwitch = owner.switchTab('target');
+    expect(target.loader).toHaveBeenCalledTimes(1);
+
+    target.resolve({ default: targetComponent });
+    await expect(firstSwitch).resolves.toBe(true);
+    await expect(duplicateSwitch).resolves.toBe(false);
+    expect(owner.getActiveTabId()).toBe('target');
+    await expect(owner.switchTab('target')).resolves.toBe(false);
+    expect(target.loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses an in-flight loader when the latest intent returns to the same tab', async () => {
+    const slow = createDeferredLoader();
+    const fast = createDeferredLoader();
+    const owner = createTabbarContainer();
+    owner.init(
+      [createTab('base'), createTab('slow', slow.loader), createTab('fast', fast.loader)],
+      'base'
+    );
+
+    const firstSlowSwitch = owner.switchTab('slow');
+    const fastSwitch = owner.switchTab('fast');
+    const latestSlowSwitch = owner.switchTab('slow');
+
+    expect(slow.loader).toHaveBeenCalledTimes(1);
+    expect(owner.getTabInstance('slow')?.loading).toBe(true);
+
+    slow.resolve({ default: { name: 'SlowPane' } as Component });
+    await expect(firstSlowSwitch).resolves.toBe(false);
+    await expect(latestSlowSwitch).resolves.toBe(true);
+    expect(owner.getActiveTabId()).toBe('slow');
+    expect(owner.getTabInstance('slow')).toMatchObject({
+      loaded: true,
+      loading: false,
+      error: null,
+    });
+
+    fast.resolve({ default: { name: 'FastPane' } as Component });
+    await expect(fastSwitch).resolves.toBe(false);
+    expect(owner.getActiveTabId()).toBe('slow');
+    expect(owner.getTabInstance('fast')).toMatchObject({
+      component: null,
+      loaded: false,
+      loading: false,
+      error: null,
+    });
+  });
+});
+
+describe('tabbar-container change event ownership', () => {
+  it('emits each accepted intent once and only emits change for the latest result', async () => {
+    const slow = createDeferredLoader();
+    const fast = createDeferredLoader();
+    const owner = createTabbarContainer();
+    owner.init(
+      [createTab('base'), createTab('slow', slow.loader), createTab('fast', fast.loader)],
+      'base'
+    );
+    const beforeChange = vi.fn();
+    const change = vi.fn();
+    const controller = createTabbarContainerChangeController({
+      getActiveId: owner.getActiveTabId,
+      switchTab: owner.switchTab,
+      onBeforeChange: beforeChange,
+      onChange: change,
+    });
+
+    const slowClick = controller.switchTo('slow');
+    await expect(controller.switchTo('slow')).resolves.toBe(false);
+    const fastClick = controller.switchTo('fast');
+
+    expect(beforeChange.mock.calls).toEqual([
+      ['slow', 'base'],
+      ['fast', 'base'],
+    ]);
+    fast.resolve({ default: { name: 'FastPane' } as Component });
+    await expect(fastClick).resolves.toBe(true);
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(change).toHaveBeenLastCalledWith('fast');
+
+    slow.resolve({ default: { name: 'SlowPane' } as Component });
+    await expect(slowClick).resolves.toBe(false);
+    await expect(controller.switchTo('fast')).resolves.toBe(false);
+    expect(beforeChange).toHaveBeenCalledTimes(2);
+    expect(change).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit change after controller invalidation and owner reset', async () => {
+    const slow = createDeferredLoader();
+    const owner = createTabbarContainer();
+    owner.init([createTab('base'), createTab('slow', slow.loader)], 'base');
+    const beforeChange = vi.fn();
+    const change = vi.fn();
+    const controller = createTabbarContainerChangeController({
+      getActiveId: owner.getActiveTabId,
+      switchTab: owner.switchTab,
+      onBeforeChange: beforeChange,
+      onChange: change,
+    });
+
+    const pendingClick = controller.switchTo('slow');
+    controller.invalidate();
+    owner.reset();
+    slow.resolve({ default: { name: 'SlowPane' } as Component });
+
+    await expect(pendingClick).resolves.toBe(false);
+    expect(beforeChange).toHaveBeenCalledTimes(1);
+    expect(change).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(tabbar): isolate container instances`。
- 保留提交 `d35c8451fa7a` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。