### PR TITLE
fix(curtain): correct back navigation protocol

### DIFF
--- a/docs/components/curtain.md
+++ b/docs/components/curtain.md
@@ -11,18 +11,15 @@ phone: curtain
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const show = ref(false)
+const show = ref(false);
 </script>
 
 <template>
   <lk-button @click="show = true">显示幕帘</lk-button>
 
-  <lk-curtain
-    v-model="show"
-    image-url="https://img.yzcdn.cn/vant/apple-1.jpg"
-  />
+  <lk-curtain v-model="show" image-url="https://img.yzcdn.cn/vant/apple-1.jpg" />
 </template>
 ```
 
@@ -41,11 +38,7 @@ const show = ref(false)
 ## 点击遮罩关闭
 
 ```vue
-<lk-curtain
-  v-model="show"
-  image-url="https://img.yzcdn.cn/vant/apple-3.jpg"
-  close-on-overlay
-/>
+<lk-curtain v-model="show" image-url="https://img.yzcdn.cn/vant/apple-3.jpg" close-on-overlay />
 ```
 
 ## 自定义内容
@@ -53,12 +46,7 @@ const show = ref(false)
 如果要做优惠券、活动卡片、复杂营销布局，推荐直接使用默认插槽。
 
 ```vue
-<lk-curtain
-  v-model="show"
-  width="580rpx"
-  height="800rpx"
-  close-position="bottom"
->
+<lk-curtain v-model="show" width="580rpx" height="800rpx" close-position="bottom">
   <view style="width:100%;height:100%;background:linear-gradient(180deg,#ff4444 0%,#ff8855 100%);border-radius:32rpx">
     <view style="padding:48rpx;color:#fff;font-size:40rpx;font-weight:700">新人专享礼</view>
   </view>
@@ -78,13 +66,21 @@ const show = ref(false)
 
 当 `link` 是 http 地址时，H5 会直接跳转，App 会尝试外部打开，小程序端会复制链接。
 
+返回上一页时不需要传 `link`，通过 `backDelta` 指定返回层数：
+
+```vue
+<lk-curtain v-model="show" link-type="navigateBack" :back-delta="2">
+  <view>返回两页</view>
+</lk-curtain>
+```
+
 ## 推荐示例
 
 ### 1) 直接复用项目 Demo（推荐）
 
 ```vue
 <script setup lang="ts">
-import CurtainDemo from '@/components/demos/curtain-demo.vue'
+import CurtainDemo from '@/components/demos/curtain-demo.vue';
 </script>
 
 <template>
@@ -106,34 +102,35 @@ import CurtainDemo from '@/components/demos/curtain-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| zIndex | 层级 | `number` | `1500` |
-| modelValue | 是否显示，支持 `v-model` | `boolean` | `false` |
-| imageUrl | 幕帘图片地址 | `string` | `''` |
-| imageMode | 图片裁剪模式 | `CurtainImageMode` | `widthFix` |
-| width | 幕帘宽度 | `string \| number` | `'600rpx'` |
-| height | 幕帘高度 | `string \| number` | `''` |
-| closePosition | 关闭按钮位置 | `top-left \| top-right \| bottom-left \| bottom-right \| bottom` | `bottom` |
-| closeOffset | 角位关闭按钮偏移。正值代表内侧（浮在图片上），负值代表外侧（完全脱离图片，且水平对齐边缘不超出）。支持 `rpx` 或 `px` 变量 | `string \| number` | `'24rpx'` |
-| closeOffsetBottom | 底部关闭按钮偏移。自动转为负值偏移（偏离到图片底部下方） | `string \| number` | `'80rpx'` |
-| closeOnOverlay | 点击遮罩是否关闭 | `boolean` | `false` |
-| link | 点击内容后的跳转地址 | `string` | `''` |
-| linkType | 跳转方式 | `navigateTo \| redirectTo \| reLaunch \| switchTab \| navigateBack` | `navigateTo` |
+| 参数              | 说明                                                                                                                      | 类型                                                                | 默认值       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------ |
+| zIndex            | 层级                                                                                                                      | `number`                                                            | `1500`       |
+| modelValue        | 是否显示，支持 `v-model`                                                                                                  | `boolean`                                                           | `false`      |
+| imageUrl          | 幕帘图片地址                                                                                                              | `string`                                                            | `''`         |
+| imageMode         | 图片裁剪模式                                                                                                              | `CurtainImageMode`                                                  | `widthFix`   |
+| width             | 幕帘宽度                                                                                                                  | `string \| number`                                                  | `'600rpx'`   |
+| height            | 幕帘高度                                                                                                                  | `string \| number`                                                  | `''`         |
+| closePosition     | 关闭按钮位置                                                                                                              | `top-left \| top-right \| bottom-left \| bottom-right \| bottom`    | `bottom`     |
+| closeOffset       | 角位关闭按钮偏移。正值代表内侧（浮在图片上），负值代表外侧（完全脱离图片，且水平对齐边缘不超出）。支持 `rpx` 或 `px` 变量 | `string \| number`                                                  | `'24rpx'`    |
+| closeOffsetBottom | 底部关闭按钮偏移。自动转为负值偏移（偏离到图片底部下方）                                                                  | `string \| number`                                                  | `'80rpx'`    |
+| closeOnOverlay    | 点击遮罩是否关闭                                                                                                          | `boolean`                                                           | `false`      |
+| link              | 点击内容后的跳转地址                                                                                                      | `string`                                                            | `''`         |
+| linkType          | 跳转方式                                                                                                                  | `navigateTo \| redirectTo \| reLaunch \| switchTab \| navigateBack` | `navigateTo` |
+| backDelta         | 返回页面层数，仅在 `linkType="navigateBack"` 时生效，必须为正整数                                                         | `number`                                                            | `1`          |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 显示状态变化 | `(show: boolean)` |
-| close | 点击关闭按钮时触发 | `()` |
-| click | 点击幕帘内容时触发 | `()` |
-| click-overlay | 点击遮罩层时触发 | `()` |
+| 事件名            | 说明               | 回调参数          |
+| ----------------- | ------------------ | ----------------- |
+| update:modelValue | 显示状态变化       | `(show: boolean)` |
+| close             | 点击关闭按钮时触发 | `()`              |
+| click             | 点击幕帘内容时触发 | `()`              |
+| click-overlay     | 点击遮罩层时触发   | `()`              |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
+| 插槽名  | 说明                                                 |
+| ------- | ---------------------------------------------------- |
 | default | 自定义幕帘内容；存在插槽时将不再渲染 `imageUrl` 图片 |
 
 ## 使用建议
@@ -146,8 +143,11 @@ import CurtainDemo from '@/components/demos/curtain-demo.vue'
 
 `lk-curtain` 已纳入 needs-hardening showcase 回归，发布前按下面边界验收：
 
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
-| 浮层关闭 | 人工验收 | 关闭按钮位置、遮罩点击和 `update:modelValue` 在目标端一致 |
-| 外链跳转 | 人工验收 | H5 直接跳转、App 外部打开、小程序复制链接的端差说明可追溯 |
+| 场景       | 验收方式    | 要点                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 展示台基线 | 自动回归    | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记                                                                                                                                                                                                                                                                                                       |
+| 浮层关闭   | 人工验收    | 关闭按钮位置、遮罩点击和 `update:modelValue` 在目标端一致                                                                                                                                                                                                                                                                                                                                     |
+| 外链跳转   | 人工验收    | H5 直接跳转、App 外部打开、小程序复制链接的端差说明可追溯                                                                                                                                                                                                                                                                                                                                     |
+| 返回导航   | H5 Peekit   | 首页进入 Curtain 后先点 `#curtain-prepare-navigation-stack`，形成“首页 → Curtain → Curtain”三层栈；顶层依次点 `#curtain-open-navigation`、`#curtain-navigate-back-target`，必须一次返回首页。重新进入 Curtain，断言 `#curtain-navigation-probe` 的调用记录精确为一次 `{ type: 'navigateBack', options: { delta: 2 } }`，不存在 `url`。两层栈不足以区分错误的 `delta=1/2/99`，不得作为通过证据 |
+| 前进导航   | H5 Peekit   | 在上述重新进入的 Curtain 中依次点 `#curtain-open-forward-navigation`、`#curtain-navigate-forward-target`，必须进入 Button；返回 Curtain 后，调用记录必须在上一条之后仅新增 `{ type: 'navigateTo', options: { url: '/pages_sub/component-detail/index?name=button' } }`，总调用数严格为 2                                                                                                      |
+| 返回导航   | 微信 Peekit | 用真实开发者工具重放同一三层栈；断言页面栈从 3 直接变为 1，并在重新进入后读取同一调用记录。必须同时满足调用次数、完整参数、页面栈与 errors 为空；Uni 构建或幕帘消失都不能替代运行态证据                                                                                                                                                                                                       |

--- a/src/components/demos/curtain-demo.vue
+++ b/src/components/demos/curtain-demo.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed, provide, ref } from 'vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 import LkChoice from '@/uni_modules/lucky-ui/components/lk-choice/lk-choice.vue';
 import type { CurtainClosePosition } from '@/uni_modules/lucky-ui/components/lk-curtain/curtain.props';
+import {
+  curtainNavigationDispatchObserverKey,
+  type CurtainNavigationAction,
+} from '@/uni_modules/lucky-ui/components/lk-curtain/curtain.utils';
 
 // 基础展示
 const showBasic = ref(false);
@@ -26,6 +30,49 @@ const showOverlayClose = ref(false);
 
 // 自定义内容 (插槽)
 const showCustom = ref(false);
+
+// 返回导航协议探针
+const showNavigateBack = ref(false);
+const showNavigateForward = ref(false);
+const navigationClickCount = ref(0);
+const navigationProbeStorageKey = 'lucky-ui:curtain-navigation-probe';
+
+interface CurtainNavigationProbe {
+  calls: CurtainNavigationAction[];
+}
+
+function readNavigationProbe(): CurtainNavigationProbe {
+  const stored = uni.getStorageSync(navigationProbeStorageKey) as
+    | CurtainNavigationProbe
+    | undefined;
+  return stored && Array.isArray(stored.calls) ? stored : { calls: [] };
+}
+
+const navigationProbe = ref<CurtainNavigationProbe>(readNavigationProbe());
+const navigationCallsJson = computed(() => JSON.stringify(navigationProbe.value.calls));
+
+provide(curtainNavigationDispatchObserverKey, action => {
+  const current = readNavigationProbe();
+  const next: CurtainNavigationProbe = {
+    calls: [...current.calls, action],
+  };
+  uni.setStorageSync(navigationProbeStorageKey, next);
+  navigationProbe.value = next;
+});
+
+function prepareNavigationStack() {
+  const emptyProbe: CurtainNavigationProbe = { calls: [] };
+  uni.setStorageSync(navigationProbeStorageKey, emptyProbe);
+  navigationProbe.value = emptyProbe;
+  navigationClickCount.value = 0;
+  uni.navigateTo({
+    url: '/pages_sub/component-detail/index?name=curtain&curtainNavigationDepth=2',
+  });
+}
+
+const onNavigateBackClick = () => {
+  navigationClickCount.value += 1;
+};
 
 /**
  * 这里的点击事件在小程序端需要注意：
@@ -105,6 +152,46 @@ const onReceive = () => {
         />
       </demo-block>
 
+      <demo-block title="返回导航">
+        <view
+          id="curtain-navigation-probe"
+          class="demo-p"
+          :data-click-count="String(navigationClickCount)"
+          :data-navigation-call-count="String(navigationProbe.calls.length)"
+          :data-navigation-calls="navigationCallsJson"
+        >
+          三层页面栈中，返回幕帘应只调用一次 navigateBack({ delta: 2 })；普通前进跳转仍应只传 url。
+        </view>
+        <lk-button id="curtain-prepare-navigation-stack" block @click="prepareNavigationStack">
+          准备三层页面栈
+        </lk-button>
+        <lk-button id="curtain-open-navigation" block @click="showNavigateBack = true">
+          显示返回幕帘
+        </lk-button>
+        <lk-curtain
+          v-model="showNavigateBack"
+          link-type="navigateBack"
+          :back-delta="2"
+          width="520rpx"
+          height="320rpx"
+          @click="onNavigateBackClick"
+        >
+          <view id="curtain-navigate-back-target" class="navigation-card">返回上一页</view>
+        </lk-curtain>
+        <lk-button id="curtain-open-forward-navigation" block @click="showNavigateForward = true">
+          显示前进幕帘
+        </lk-button>
+        <lk-curtain
+          v-model="showNavigateForward"
+          link="/pages_sub/component-detail/index?name=button"
+          link-type="navigateTo"
+          width="520rpx"
+          height="320rpx"
+        >
+          <view id="curtain-navigate-forward-target" class="navigation-card">前往 Button</view>
+        </lk-curtain>
+      </demo-block>
+
       <!-- 自定义内容 -->
       <demo-block title="自定义插槽内容">
         <view class="demo-p">使用默认插槽实现高度自定义的营销弹窗。</view>
@@ -168,6 +255,17 @@ const onReceive = () => {
   font-size: 26rpx;
   color: test.$test-text-secondary;
   margin-bottom: 20rpx;
+}
+
+.navigation-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--lk-color-white);
+  background: var(--lk-brand-600);
+  border-radius: var(--lk-radius-lg);
 }
 
 /* 自定义优惠券卡片样式 */

--- a/src/uni_modules/lucky-ui/components/lk-curtain/curtain.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-curtain/curtain.props.ts
@@ -101,6 +101,14 @@ export const curtainProps = {
    */
   link: LkProp.string(''),
   /**
+   * 返回页面层数，仅在 linkType="navigateBack" 时生效
+   */
+  backDelta: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => Number.isInteger(value) && value > 0,
+  },
+  /**
    * 小程序端复制链接成功提示
    */
   copySuccessText: LkProp.string(''),

--- a/src/uni_modules/lucky-ui/components/lk-curtain/curtain.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-curtain/curtain.utils.ts
@@ -1,7 +1,32 @@
-import type { StyleValue } from 'vue';
+import type { InjectionKey, StyleValue } from 'vue';
 import type { TransitionConfig } from '@/uni_modules/lucky-ui/composables/useTransition';
 import { addUnit } from '../../core/src/utils/unit';
-import type { CurtainClosePosition } from './curtain.props';
+import type { CurtainClosePosition, CurtainLinkType } from './curtain.props';
+
+type CurtainForwardLinkType = Exclude<CurtainLinkType, 'navigateBack'>;
+
+export type CurtainNavigationAction =
+  | {
+      type: CurtainForwardLinkType;
+      options: { url: string };
+    }
+  | {
+      type: 'navigateBack';
+      options: { delta: number };
+    };
+
+export type CurtainNavigationRuntime = {
+  navigateTo?: (options: { url: string }) => unknown;
+  redirectTo?: (options: { url: string }) => unknown;
+  reLaunch?: (options: { url: string }) => unknown;
+  switchTab?: (options: { url: string }) => unknown;
+  navigateBack?: (options: { delta: number }) => unknown;
+};
+
+export type CurtainNavigationDispatchObserver = (action: CurtainNavigationAction) => void;
+
+export const curtainNavigationDispatchObserverKey: InjectionKey<CurtainNavigationDispatchObserver> =
+  Symbol('LkCurtainNavigationDispatchObserver');
 
 export function resolveCurtainWidth(width: string | number): string {
   return addUnit(width) || '';
@@ -119,6 +144,50 @@ export function shouldCloseCurtainOnOverlay(closeOnOverlay: boolean): boolean {
 
 export function shouldNavigateCurtainLink(link: string): boolean {
   return link.length > 0;
+}
+
+export function normalizeCurtainBackDelta(backDelta: number): number {
+  return Number.isInteger(backDelta) && backDelta > 0 ? backDelta : 1;
+}
+
+export function resolveCurtainNavigationAction(options: {
+  linkType: CurtainLinkType;
+  link: string;
+  backDelta: number;
+}): CurtainNavigationAction | null {
+  if (options.linkType === 'navigateBack') {
+    return {
+      type: 'navigateBack',
+      options: { delta: normalizeCurtainBackDelta(options.backDelta) },
+    };
+  }
+
+  if (!shouldNavigateCurtainLink(options.link)) return null;
+
+  return {
+    type: options.linkType,
+    options: { url: options.link },
+  };
+}
+
+export function executeCurtainNavigation(
+  action: CurtainNavigationAction,
+  runtime: CurtainNavigationRuntime,
+  observer?: CurtainNavigationDispatchObserver
+): boolean {
+  if (action.type === 'navigateBack') {
+    const navigation = runtime.navigateBack;
+    if (typeof navigation !== 'function') return false;
+    navigation.call(runtime, action.options);
+    observer?.(action);
+    return true;
+  }
+
+  const navigation = runtime[action.type];
+  if (typeof navigation !== 'function') return false;
+  navigation.call(runtime, action.options);
+  observer?.(action);
+  return true;
 }
 
 export function isCurtainHttpLink(link: string): boolean {

--- a/src/uni_modules/lucky-ui/components/lk-curtain/lk-curtain.vue
+++ b/src/uni_modules/lucky-ui/components/lk-curtain/lk-curtain.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, useSlots } from 'vue';
+import { computed, inject, useSlots } from 'vue';
 
 import LkOverlay from '../lk-overlay/lk-overlay.vue';
 import LkIcon from '../lk-icon/lk-icon.vue';
@@ -9,7 +9,11 @@ import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition'
 import { useLocale } from '../../composables/useLocale';
 import { curtainProps, curtainEmits } from './curtain.props';
 import {
+  type CurtainNavigationRuntime,
+  curtainNavigationDispatchObserverKey,
   isCurtainHttpLink,
+  executeCurtainNavigation,
+  resolveCurtainNavigationAction,
   resolveCurtainCloseStyle,
   resolveCurtainContentStyle,
   resolveCurtainCopySuccessText,
@@ -18,7 +22,6 @@ import {
   resolveCurtainTransitionConfig,
   resolveCurtainWidth,
   shouldCloseCurtainOnOverlay,
-  shouldNavigateCurtainLink,
 } from './curtain.utils';
 
 defineOptions({ name: 'LkCurtain' });
@@ -28,6 +31,15 @@ const emit = defineEmits(curtainEmits);
 const { t } = useLocale('curtain');
 
 const slots = useSlots();
+const navigationDispatchObserver = inject(curtainNavigationDispatchObserverKey, undefined);
+
+const navigationRuntime: CurtainNavigationRuntime = {
+  navigateTo: options => uni.navigateTo(options),
+  redirectTo: options => uni.redirectTo(options),
+  reLaunch: options => uni.reLaunch(options),
+  switchTab: options => uni.switchTab(options),
+  navigateBack: options => uni.navigateBack(options),
+};
 
 const widthStr = computed(() => resolveCurtainWidth(props.width));
 const heightStr = computed(() => resolveCurtainHeight(props.height));
@@ -84,13 +96,23 @@ function onClose() {
 
 function onClick() {
   emit('click');
-  if (!shouldNavigateCurtainLink(props.link)) return;
+  const navigation = resolveCurtainNavigationAction({
+    linkType: props.linkType,
+    link: props.link,
+    backDelta: props.backDelta,
+  });
+  if (!navigation) return;
 
-  const isHttp = isCurtainHttpLink(props.link);
+  if (navigation.type === 'navigateBack') {
+    executeCurtainNavigation(navigation, navigationRuntime, navigationDispatchObserver);
+    return;
+  }
+
+  const isHttp = isCurtainHttpLink(navigation.options.url);
 
   // #ifdef H5
   if (isHttp) {
-    window.location.href = props.link;
+    window.location.href = navigation.options.url;
     return;
   }
   // #endif
@@ -100,7 +122,7 @@ function onClick() {
     const runtime = (globalThis as { plus?: { runtime?: { openURL?: (url: string) => void } } })
       .plus?.runtime;
     if (runtime && typeof runtime.openURL === 'function') {
-      runtime.openURL(props.link);
+      runtime.openURL(navigation.options.url);
       return;
     }
   }
@@ -108,18 +130,13 @@ function onClick() {
 
   // #ifdef MP
   if (isHttp) {
-    uni.setClipboardData({ data: props.link });
+    uni.setClipboardData({ data: navigation.options.url });
     uni.showToast({ title: resolvedCopySuccessText.value, icon: 'none' });
     return;
   }
   // #endif
 
-  const navFn = (uni as unknown as Record<string, (...args: unknown[]) => unknown>)[props.linkType];
-  if (typeof navFn === 'function') {
-    navFn({
-      url: props.link,
-    });
-  }
+  executeCurtainNavigation(navigation, navigationRuntime, navigationDispatchObserver);
 }
 </script>
 

--- a/tests/unit/lk-curtain.spec.ts
+++ b/tests/unit/lk-curtain.spec.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { curtainProps } from '../../src/uni_modules/lucky-ui/components/lk-curtain/curtain.props';
 import {
+  type CurtainNavigationAction,
   ensureCurtainNegativeOffset,
+  executeCurtainNavigation,
   isCurtainHttpLink,
+  normalizeCurtainBackDelta,
   resolveCurtainCloseOffset,
   resolveCurtainCloseStyle,
   resolveCurtainContentStyle,
   resolveCurtainCopySuccessText,
   resolveCurtainHeight,
   resolveCurtainRootStyle,
+  resolveCurtainNavigationAction,
   resolveCurtainTransitionConfig,
   resolveCurtainWidth,
   shouldCloseCurtainOnOverlay,
@@ -23,45 +27,55 @@ describe('lk-curtain layout and link rules', () => {
   it('normalizes width, height and copy text fallback', () => {
     expect(resolveCurtainWidth(600)).toBe('600rpx');
     expect(resolveCurtainHeight('80vh')).toBe('80vh');
-    expect(resolveCurtainCopySuccessText({
-      copySuccessText: '',
-      fallback: '复制成功',
-    })).toBe('复制成功');
-    expect(resolveCurtainCopySuccessText({
-      copySuccessText: '链接已复制',
-      fallback: '复制成功',
-    })).toBe('链接已复制');
+    expect(
+      resolveCurtainCopySuccessText({
+        copySuccessText: '',
+        fallback: '复制成功',
+      })
+    ).toBe('复制成功');
+    expect(
+      resolveCurtainCopySuccessText({
+        copySuccessText: '链接已复制',
+        fallback: '复制成功',
+      })
+    ).toBe('链接已复制');
   });
 
   it('builds root and content style layers', () => {
     const customStyle = { marginTop: '24rpx' };
-    expect(resolveCurtainRootStyle({
-      customStyle,
-      zIndex: 10090,
-      show: true,
-    })).toEqual([
+    expect(
+      resolveCurtainRootStyle({
+        customStyle,
+        zIndex: 10090,
+        show: true,
+      })
+    ).toEqual([
       customStyle,
       {
         zIndex: 10090,
         pointerEvents: 'auto',
       },
     ]);
-    expect(resolveCurtainRootStyle({
-      customStyle: '',
-      zIndex: 10090,
-      show: false,
-    })).toEqual([
+    expect(
+      resolveCurtainRootStyle({
+        customStyle: '',
+        zIndex: 10090,
+        show: false,
+      })
+    ).toEqual([
       '',
       {
         zIndex: 10090,
         pointerEvents: 'none',
       },
     ]);
-    expect(resolveCurtainContentStyle({
-      zIndex: 10091,
-      width: '600rpx',
-      height: '800rpx',
-    })).toEqual({
+    expect(
+      resolveCurtainContentStyle({
+        zIndex: 10091,
+        width: '600rpx',
+        height: '800rpx',
+      })
+    ).toEqual({
       zIndex: 10091,
       width: '600rpx',
       height: '800rpx',
@@ -71,32 +85,40 @@ describe('lk-curtain layout and link rules', () => {
   it('resolves close button negative offsets by position', () => {
     expect(ensureCurtainNegativeOffset('24rpx')).toBe('-24rpx');
     expect(ensureCurtainNegativeOffset('-18px')).toBe('-18px');
-    expect(resolveCurtainCloseOffset({
-      closePosition: 'bottom',
-      closeOffset: 24,
-      closeOffsetBottom: 36,
-    })).toBe('-36rpx');
-    expect(resolveCurtainCloseStyle({
-      closePosition: 'top-right',
-      closeOffset: 24,
-      closeOffsetBottom: 36,
-    })).toEqual({
+    expect(
+      resolveCurtainCloseOffset({
+        closePosition: 'bottom',
+        closeOffset: 24,
+        closeOffsetBottom: 36,
+      })
+    ).toBe('-36rpx');
+    expect(
+      resolveCurtainCloseStyle({
+        closePosition: 'top-right',
+        closeOffset: 24,
+        closeOffsetBottom: 36,
+      })
+    ).toEqual({
       top: '24rpx',
       right: '24rpx',
     });
-    expect(resolveCurtainCloseStyle({
-      closePosition: 'top-right',
-      closeOffset: -24,
-      closeOffsetBottom: 36,
-    })).toEqual({
+    expect(
+      resolveCurtainCloseStyle({
+        closePosition: 'top-right',
+        closeOffset: -24,
+        closeOffsetBottom: 36,
+      })
+    ).toEqual({
       top: 'calc(-24rpx - var(--lk-rpx-72))',
       right: '0',
     });
-    expect(resolveCurtainCloseStyle({
-      closePosition: 'bottom',
-      closeOffset: 24,
-      closeOffsetBottom: 'var(--lk-rpx-36)',
-    })).toEqual({
+    expect(
+      resolveCurtainCloseStyle({
+        closePosition: 'bottom',
+        closeOffset: 24,
+        closeOffsetBottom: 'var(--lk-rpx-36)',
+      })
+    ).toEqual({
       bottom: 'calc(var(--lk-rpx-36) * -1)',
     });
   });
@@ -113,5 +135,112 @@ describe('lk-curtain layout and link rules', () => {
     expect(shouldNavigateCurtainLink('/pages/home/index')).toBe(true);
     expect(isCurtainHttpLink('https://example.com')).toBe(true);
     expect(isCurtainHttpLink('/pages/home/index')).toBe(false);
+  });
+
+  it('creates a URL request only for forward navigation', () => {
+    expect(
+      resolveCurtainNavigationAction({
+        linkType: 'navigateTo',
+        link: '/pages/home/index',
+        backDelta: 4,
+      })
+    ).toEqual({
+      type: 'navigateTo',
+      options: { url: '/pages/home/index' },
+    });
+    expect(
+      resolveCurtainNavigationAction({
+        linkType: 'navigateTo',
+        link: '',
+        backDelta: 1,
+      })
+    ).toBeNull();
+  });
+
+  it('creates a delta-only navigateBack request without requiring a link', () => {
+    expect(curtainProps.backDelta.default).toBe(1);
+    expect(curtainProps.backDelta.validator(2)).toBe(true);
+    expect(curtainProps.backDelta.validator(0)).toBe(false);
+    expect(curtainProps.backDelta.validator(1.5)).toBe(false);
+    expect(normalizeCurtainBackDelta(3)).toBe(3);
+    expect(normalizeCurtainBackDelta(0)).toBe(1);
+    expect(normalizeCurtainBackDelta(Number.NaN)).toBe(1);
+    expect(
+      resolveCurtainNavigationAction({
+        linkType: 'navigateBack',
+        link: '',
+        backDelta: 2,
+      })
+    ).toEqual({
+      type: 'navigateBack',
+      options: { delta: 2 },
+    });
+    expect(
+      resolveCurtainNavigationAction({
+        linkType: 'navigateBack',
+        link: '/ignored',
+        backDelta: -2,
+      })
+    ).toEqual({
+      type: 'navigateBack',
+      options: { delta: 1 },
+    });
+  });
+
+  it('executes each navigation protocol with its exact option shape', () => {
+    const calls: Array<{ type: string; options: unknown }> = [];
+    const observed: CurtainNavigationAction[] = [];
+    const receivers: boolean[] = [];
+    const runtime = {
+      navigateTo(options: { url: string }) {
+        receivers.push(this === runtime);
+        calls.push({ type: 'navigateTo', options });
+      },
+      navigateBack(options: { delta: number }) {
+        receivers.push(this === runtime);
+        calls.push({ type: 'navigateBack', options });
+      },
+    };
+
+    expect(
+      executeCurtainNavigation(
+        {
+          type: 'navigateTo',
+          options: { url: '/pages/home/index' },
+        },
+        runtime,
+        action => observed.push(action)
+      )
+    ).toBe(true);
+    expect(
+      executeCurtainNavigation(
+        {
+          type: 'navigateBack',
+          options: { delta: 2 },
+        },
+        runtime,
+        action => observed.push(action)
+      )
+    ).toBe(true);
+    expect(calls).toEqual([
+      { type: 'navigateTo', options: { url: '/pages/home/index' } },
+      { type: 'navigateBack', options: { delta: 2 } },
+    ]);
+    expect(receivers).toEqual([true, true]);
+    expect(observed).toEqual([
+      { type: 'navigateTo', options: { url: '/pages/home/index' } },
+      { type: 'navigateBack', options: { delta: 2 } },
+    ]);
+    expect(
+      executeCurtainNavigation(
+        {
+          type: 'switchTab',
+          options: { url: '/pages/home/index' },
+        },
+        {},
+        action => observed.push(action)
+      )
+    ).toBe(false);
+    expect(observed).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(curtain): correct back navigation protocol`。
- 保留提交 `7b2ca1a12b9e` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。