### PR TITLE
fix(modal): serialize action control flow

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -11,8 +11,8 @@ phone: modal
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const show = ref(false)
+import { ref } from 'vue';
+const show = ref(false);
 </script>
 
 <template>
@@ -32,11 +32,11 @@ const show = ref(false)
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const show = ref(false)
+import { ref } from 'vue';
+const show = ref(false);
 
 function onConfirm() {
-  show.value = false
+  show.value = false;
   // 执行删除逻辑...
 }
 </script>
@@ -61,8 +61,8 @@ function onConfirm() {
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const show = ref(false)
+import { ref } from 'vue';
+const show = ref(false);
 </script>
 
 <template>
@@ -83,9 +83,9 @@ const show = ref(false)
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const show = ref(false)
-const form = ref({ name: '', phone: '' })
+import { ref } from 'vue';
+const show = ref(false);
+const form = ref({ name: '', phone: '' });
 </script>
 
 <template>
@@ -107,6 +107,37 @@ const form = ref({ name: '', phone: '' })
   </lk-modal>
 </template>
 ```
+
+## 异步确认
+
+默认确认按钮需要等待接口、校验或权限判断时，把异步工作放在 `beforeConfirm` 中。返回 `true` 后组件按 `confirm > update:modelValue(false)` 的顺序完成一次确认；返回 `false` 或 Promise reject 时保持打开，也不会触发 `confirm`。
+
+等待期间确认按钮显示 loading，默认确认、取消、右上角关闭与遮罩关闭入口都会禁用，避免重复任务和竞态关闭。
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const show = ref(false);
+
+async function beforeConfirm() {
+  const saved = await saveProfile();
+  return saved;
+}
+
+function onConfirm() {
+  uni.showToast({ title: '保存成功' });
+}
+</script>
+
+<template>
+  <lk-modal v-model="show" title="保存资料" :before-confirm="beforeConfirm" @confirm="onConfirm">
+    <view>确认保存当前资料吗？</view>
+  </lk-modal>
+</template>
+```
+
+`beforeConfirm` 只管理组件默认 footer 的确认动作。使用自定义 `footer` 插槽时，loading、禁用与关闭时机仍由插槽调用方管理。
 
 ## 动画类型
 
@@ -130,39 +161,40 @@ const form = ref({ name: '', phone: '' })
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
-| customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
-| modelValue | 是否显示（v-model） | `boolean` | `false` |
-| zIndex | 层级 | `number` | `1500` |
-| title | 标题文字 | `string` | `''` |
-| width | 弹框宽度 | `string` | `600rpx` |
-| showClose | 显示右上角关闭按钮 | `boolean` | `true` |
-| closeOnOverlay | 点击遮罩关闭 | `boolean` | `true` |
-| showHeader | 是否显示标题栏 | `boolean` | `true` |
-| showFooter | 是否显示底部区域 | `boolean` | `true` |
-| confirmText | 默认确认按钮文字 | `string` | `确定` |
-| cancelText | 默认取消按钮文字 | `string` | `取消` |
-| animation | 动画预设名称 | `keyof ANIMATION_PRESETS` | `scale` |
-| animationType | 内置动画类型，支持全部 `TransitionName` | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined` |
-| duration | 动画持续时间 | `number` | `undefined` |
-| delay | 动画延迟 | `number` | `undefined` |
-| easing | 动画缓动函数 | `TransitionConfig['easing']` | `undefined` |
+| 参数           | 说明                                              | 类型                                                   | 默认值      |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------ | ----------- |
+| customClass    | 组件可视根节点自定义类名                          | `string \| object \| array`                            | `''`        |
+| customStyle    | 组件可视根节点自定义样式                          | `string \| object`                                     | `''`        |
+| modelValue     | 是否显示（v-model）                               | `boolean`                                              | `false`     |
+| zIndex         | 层级                                              | `number`                                               | `1500`      |
+| title          | 标题文字                                          | `string`                                               | `''`        |
+| width          | 弹框宽度                                          | `string`                                               | `600rpx`    |
+| showClose      | 显示右上角关闭按钮                                | `boolean`                                              | `true`      |
+| closeOnOverlay | 点击遮罩关闭                                      | `boolean`                                              | `true`      |
+| showHeader     | 是否显示标题栏                                    | `boolean`                                              | `true`      |
+| showFooter     | 是否显示底部区域                                  | `boolean`                                              | `true`      |
+| confirmText    | 默认确认按钮文字                                  | `string`                                               | `确定`      |
+| beforeConfirm  | 默认确认前拦截；返回 `false` 或 reject 时保持打开 | `() => boolean \| Promise<boolean>`                    | —           |
+| cancelText     | 默认取消按钮文字                                  | `string`                                               | `取消`      |
+| animation      | 动画预设名称                                      | `keyof ANIMATION_PRESETS`                              | `scale`     |
+| animationType  | 内置动画类型，支持全部 `TransitionName`           | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined` |
+| duration       | 动画持续时间                                      | `number`                                               | `undefined` |
+| delay          | 动画延迟                                          | `number`                                               | `undefined` |
+| easing         | 动画缓动函数                                      | `TransitionConfig['easing']`                           | `undefined` |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 显示状态变化 | `(visible: boolean)` |
-| open | 入场动画结束后触发 | `()` |
-| close | 离场动画结束后触发 | `()` |
-| confirm | 点击默认确认按钮时触发 | `()` |
-| cancel | 点击默认取消按钮时触发 | `()` |
-| click-overlay | 点击遮罩时触发 | `()` |
-| click-close | 点击右上角关闭按钮时触发 | `()` |
-| after-enter | 入场动画结束后触发 | `()` |
-| after-leave | 离场动画结束后触发 | `()` |
+| 事件名            | 说明                                    | 回调参数             |
+| ----------------- | --------------------------------------- | -------------------- |
+| update:modelValue | 显示状态变化                            | `(visible: boolean)` |
+| open              | 入场动画结束后触发                      | `()`                 |
+| close             | 离场动画结束后触发                      | `()`                 |
+| confirm           | 默认确认动作通过 `beforeConfirm` 后触发 | `()`                 |
+| cancel            | 点击默认取消按钮时触发                  | `()`                 |
+| click-overlay     | 点击遮罩时触发                          | `()`                 |
+| click-close       | 点击右上角关闭按钮时触发                | `()`                 |
+| after-enter       | 入场动画结束后触发                      | `()`                 |
+| after-leave       | 离场动画结束后触发                      | `()`                 |
 
 ::: warning
 `confirm` 只由默认确认按钮触发；遮罩、右上角关闭按钮和取消按钮不会触发 `confirm`。
@@ -170,11 +202,11 @@ const form = ref({ name: '', phone: '' })
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
-| default | 弹框主体内容 |
-| header | 自定义头部（会覆盖 title） |
-| footer | 自定义底部按钮区域 |
+| 插槽名  | 说明                       |
+| ------- | -------------------------- |
+| default | 弹框主体内容               |
+| header  | 自定义头部（会覆盖 title） |
+| footer  | 自定义底部按钮区域         |
 
 ## 使用建议
 
@@ -184,10 +216,20 @@ const form = ref({ name: '', phone: '' })
 
 ## 发布验收
 
-`lk-modal` 已纳入 needs-hardening showcase 回归，发布前按下面边界验收：
+发布前必须从全新构建进入 Modal Demo，分别执行 H5 与微信小程序 Peekit。下面是待执行的选择器、动作与客观通过条件；构建成功或源码单测不能替代这些运行态证据。
 
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
-| 操作链路 | 人工验收 | `confirm/cancel/click-overlay/click-close` 语义互不串扰 |
-| 弹层表现 | 人工验收 | fixed 遮罩、动画结束事件和异步确认在 H5/App/小程序端稳定 |
+| 场景             | H5 Peekit selector / action                                                                                 | 微信 Peekit selector / action                                                                                       | 客观后置条件                                                                                                                                                                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 遮罩不关闭       | 点击 `#modal-overlay-open-controlled-false`，再点击 `.lk-overlay`                                           | 在 Modal Demo scope 点击打开按钮；进入 Modal 的 Overlay 子组件 scope，对 `.lk-overlay` 执行一次 `tap`               | `.lk-modal__panel` 仍存在；`#modal-overlay-probe-visible` 为 `visible=true`；click 为 1、update 为 0                                                                                                                                                                                      |
+| 遮罩受控关闭     | 点击 `#modal-overlay-open-controlled-true`，再点击 `.lk-overlay`，等待离场时长                              | 同一路径进入 Overlay scope 执行一次 `tap` 并等待离场                                                                | panel 由 1 变 0；visible 为 false；click、update 均严格为 1，lastUpdate 为 false                                                                                                                                                                                                          |
+| 父级仅观察更新   | 点击 `#modal-overlay-open-observe-true`，再点击一次 `.lk-overlay`                                           | 在 Modal Demo scope 打开 observe 场景，再进入 Overlay scope `tap` 遮罩                                              | panel 保持存在且 visible 为 true；click、update 均严格为 1，证明单次关闭请求没有内部双发；最后点击 `#modal-overlay-force-close` 清场                                                                                                                                                      |
+| 异步成功与防重   | 点击 `#modal-async-open-resolve`，对 `.lk-modal__confirm` 在 50ms 内点击两次；分别在 500ms、1200ms 读取状态 | 在 Modal Demo scope 打开 resolve 场景；进入 Modal scope 找到 `.lk-modal__confirm` 子组件，连续 `tap` 两次并分时读取 | 500ms 时 panel 含 `is-confirming`；H5 确认按钮或微信 LkButton scope 内 `.lk-button` 含 `is-loading`、`is-disabled` 且 disabled=true；hook=1、confirm=0、update=0；1200ms 后 visible=false，outcome=resolved，confirm=1、update=1，events 精确为 `before:resolve > confirm > update:false` |
+| 异步失败         | 点击 `#modal-async-open-reject` 与 `.lk-modal__confirm`，等待 1200ms                                        | 在 Modal Demo scope 打开 reject 场景；进入 Modal scope `tap` 确认子组件并等待                                       | panel 仍存在，visible=true，outcome=rejected，hook=1、confirm=0、update=0；`is-confirming` 与按钮 loading/disabled 已移除，可再次操作                                                                                                                                                     |
+| 过期结果竞态     | 打开 resolve 场景并点击确认，500ms 内点击 `#modal-async-race-reopen`，等待旧任务超过 1000ms                 | 同一顺序在 Modal scope 找到内部重开按钮子组件并 `tap`                                                               | 新实例状态保持 visible=true、mode=reject、outcome=idle；hook、confirm、update 均为 0，events=none，旧 Promise 不得关闭重开的 Modal                                                                                                                                                        |
+| 取消与右上角防重 | 分别重新打开异步探针，对 `.lk-modal__cancel` 或 `.lk-modal__close` 在 50ms 内点击两次                       | 分别在 Modal scope 对取消按钮子组件或关闭图标连续两次 `tap`                                                         | 对应 cancel 或 closeClick 计数严格为 1，update 严格为 1；另一个业务计数与 confirm 均为 0                                                                                                                                                                                                  |
+
+微信端先从 `PreviewDemoRenderer` 进入 `modal-demo` 自定义组件 scope，再按表格逐层进入 Modal、Overlay 或 LkButton scope。页面级全局 selector 无法穿透组件边界时不能判为失败；若自定义组件 `tap` 不稳定，可按 Peekit 规范调用对应组件事件方法后读取同一组状态。每个场景开始前都使用对应打开按钮重置计数，不跨场景复用旧状态。
+
+::: warning
+上述表格定义验收方法和通过条件，不表示当前构建已经完成 H5 或微信小程序运行态抓取。实际发布记录必须附本次构建的 selector 读数、事件文本和 console/runtime error 结果。
+:::

--- a/src/components/demos/modal-demo.vue
+++ b/src/components/demos/modal-demo.vue
@@ -11,7 +11,6 @@ import type { SegmentedOption } from '@/uni_modules/lucky-ui/components/lk-segme
 const visible1 = ref(false);
 const visible2 = ref(false);
 const visible3 = ref(false);
-const visible4 = ref(false);
 const visibleScale = ref(false);
 const visibleBounce = ref(false);
 const visibleNoHeader = ref(false);
@@ -40,14 +39,117 @@ const easingOptions: SegmentedOption[] = [
   { label: 'ease-in-out', value: 'ease-in-out' },
 ];
 
-const handleConfirm = () => {
-  return new Promise(resolve => {
+type OverlayProbeMode = 'controlled' | 'observe';
+const overlayProbeVisible = ref(false);
+const overlayProbeMode = ref<OverlayProbeMode>('controlled');
+const overlayProbeCloseOnOverlay = ref(false);
+const overlayProbeClickCount = ref(0);
+const overlayProbeUpdateCount = ref(0);
+const overlayProbeLastUpdate = ref('none');
+
+function openOverlayProbe(closeOnOverlay: boolean, mode: OverlayProbeMode) {
+  overlayProbeVisible.value = true;
+  overlayProbeMode.value = mode;
+  overlayProbeCloseOnOverlay.value = closeOnOverlay;
+  overlayProbeClickCount.value = 0;
+  overlayProbeUpdateCount.value = 0;
+  overlayProbeLastUpdate.value = 'none';
+}
+
+function onOverlayProbeClick() {
+  overlayProbeClickCount.value += 1;
+}
+
+function onOverlayProbeUpdate(value: boolean) {
+  overlayProbeUpdateCount.value += 1;
+  overlayProbeLastUpdate.value = String(value);
+  if (overlayProbeMode.value === 'controlled') {
+    overlayProbeVisible.value = value;
+  }
+}
+
+function closeOverlayProbe() {
+  overlayProbeVisible.value = false;
+}
+
+type AsyncProbeMode = 'resolve' | 'reject';
+const asyncProbeVisible = ref(false);
+const asyncProbeMode = ref<AsyncProbeMode>('resolve');
+const asyncProbeOutcome = ref('idle');
+const asyncProbeHookCount = ref(0);
+const asyncProbeConfirmCount = ref(0);
+const asyncProbeCancelCount = ref(0);
+const asyncProbeCloseClickCount = ref(0);
+const asyncProbeUpdateCount = ref(0);
+const asyncProbeEvents = ref<string[]>([]);
+let asyncProbeSession = 0;
+
+function openAsyncProbe(mode: AsyncProbeMode) {
+  asyncProbeSession += 1;
+  asyncProbeVisible.value = true;
+  asyncProbeMode.value = mode;
+  asyncProbeOutcome.value = 'idle';
+  asyncProbeHookCount.value = 0;
+  asyncProbeConfirmCount.value = 0;
+  asyncProbeCancelCount.value = 0;
+  asyncProbeCloseClickCount.value = 0;
+  asyncProbeUpdateCount.value = 0;
+  asyncProbeEvents.value = [];
+}
+
+function beforeAsyncConfirm() {
+  const session = asyncProbeSession;
+  const mode = asyncProbeMode.value;
+  asyncProbeHookCount.value += 1;
+  asyncProbeOutcome.value = 'pending';
+  asyncProbeEvents.value.push(`before:${mode}`);
+
+  return new Promise<boolean>((resolve, reject) => {
     setTimeout(() => {
-      uni.showToast({ title: '删除成功' });
-      resolve(true);
+      if (session === asyncProbeSession) {
+        asyncProbeOutcome.value = mode === 'resolve' ? 'resolved' : 'rejected';
+      }
+
+      if (mode === 'resolve') {
+        resolve(true);
+      } else {
+        reject(new Error('demo rejection'));
+      }
     }, 1000);
   });
-};
+}
+
+function onAsyncProbeConfirm() {
+  asyncProbeConfirmCount.value += 1;
+  asyncProbeEvents.value.push('confirm');
+}
+
+function onAsyncProbeCancel() {
+  asyncProbeCancelCount.value += 1;
+  asyncProbeEvents.value.push('cancel');
+}
+
+function onAsyncProbeCloseClick() {
+  asyncProbeCloseClickCount.value += 1;
+  asyncProbeEvents.value.push('click-close');
+}
+
+function onAsyncProbeUpdate(value: boolean) {
+  asyncProbeUpdateCount.value += 1;
+  asyncProbeEvents.value.push(`update:${value}`);
+  asyncProbeVisible.value = value;
+}
+
+function reopenAsyncProbeDuringPending() {
+  asyncProbeSession += 1;
+  asyncProbeVisible.value = false;
+  Promise.resolve().then(() => openAsyncProbe('reject'));
+}
+
+function closeAsyncProbe() {
+  asyncProbeSession += 1;
+  asyncProbeVisible.value = false;
+}
 </script>
 
 <template>
@@ -73,13 +175,106 @@ const handleConfirm = () => {
       </lk-space>
     </demo-block>
 
-    <demo-block title="异步确认">
+    <demo-block title="遮罩关闭控制流" desc="稳定计数用于 H5 与微信小程序交互验收">
       <lk-space wrap>
-        <lk-button @click="visible4 = true">异步确认</lk-button>
-        <lk-modal v-model="visible4" animation="quick" @confirm="handleConfirm"
-          >确定删除吗？</lk-modal
+        <lk-button
+          id="modal-overlay-open-controlled-false"
+          @click="openOverlayProbe(false, 'controlled')"
         >
+          受控：遮罩不关闭
+        </lk-button>
+        <lk-button
+          id="modal-overlay-open-controlled-true"
+          @click="openOverlayProbe(true, 'controlled')"
+        >
+          受控：遮罩关闭
+        </lk-button>
+        <lk-button id="modal-overlay-open-observe-true" @click="openOverlayProbe(true, 'observe')">
+          仅观察关闭请求
+        </lk-button>
       </lk-space>
+      <view class="probe-state">
+        <text id="modal-overlay-probe-visible">visible={{ overlayProbeVisible }}</text>
+        <text id="modal-overlay-probe-mode">mode={{ overlayProbeMode }}</text>
+        <text id="modal-overlay-probe-close-on-overlay">
+          closeOnOverlay={{ overlayProbeCloseOnOverlay }}
+        </text>
+        <text id="modal-overlay-probe-click-count">click={{ overlayProbeClickCount }}</text>
+        <text id="modal-overlay-probe-update-count">update={{ overlayProbeUpdateCount }}</text>
+        <text id="modal-overlay-probe-last-update">lastUpdate={{ overlayProbeLastUpdate }}</text>
+      </view>
+      <lk-modal
+        :model-value="overlayProbeVisible"
+        :close-on-overlay="overlayProbeCloseOnOverlay"
+        :show-close="false"
+        :show-footer="false"
+        title="遮罩关闭探针"
+        @click-overlay="onOverlayProbeClick"
+        @update:model-value="onOverlayProbeUpdate"
+      >
+        <view id="modal-overlay-probe-content" class="probe-modal-content">
+          <text>点击遮罩后读取页面上的计数与可见状态。</text>
+          <lk-button id="modal-overlay-force-close" size="sm" @click="closeOverlayProbe">
+            结束探针
+          </lk-button>
+        </view>
+      </lk-modal>
+    </demo-block>
+
+    <demo-block title="异步确认" desc="beforeConfirm 决定关闭，pending 期间默认操作全部禁用">
+      <lk-space wrap>
+        <lk-button id="modal-async-open-resolve" @click="openAsyncProbe('resolve')">
+          异步成功
+        </lk-button>
+        <lk-button id="modal-async-open-reject" @click="openAsyncProbe('reject')">
+          异步失败
+        </lk-button>
+      </lk-space>
+      <view class="probe-state">
+        <text id="modal-async-probe-visible">visible={{ asyncProbeVisible }}</text>
+        <text id="modal-async-probe-mode">mode={{ asyncProbeMode }}</text>
+        <text id="modal-async-probe-outcome">outcome={{ asyncProbeOutcome }}</text>
+        <text id="modal-async-probe-hook-count">hook={{ asyncProbeHookCount }}</text>
+        <text id="modal-async-probe-confirm-count">confirm={{ asyncProbeConfirmCount }}</text>
+        <text id="modal-async-probe-cancel-count">cancel={{ asyncProbeCancelCount }}</text>
+        <text id="modal-async-probe-close-count">closeClick={{ asyncProbeCloseClickCount }}</text>
+        <text id="modal-async-probe-update-count">update={{ asyncProbeUpdateCount }}</text>
+        <text id="modal-async-probe-events"
+          >events={{ asyncProbeEvents.join(' > ') || 'none' }}</text
+        >
+      </view>
+      <lk-modal
+        :model-value="asyncProbeVisible"
+        :before-confirm="beforeAsyncConfirm"
+        animation="quick"
+        title="异步确认探针"
+        @cancel="onAsyncProbeCancel"
+        @click-close="onAsyncProbeCloseClick"
+        @confirm="onAsyncProbeConfirm"
+        @update:model-value="onAsyncProbeUpdate"
+      >
+        <view id="modal-async-probe-content" class="probe-modal-content">
+          <text>确认后等待 1 秒；成功才关闭，失败保持打开。</text>
+          <lk-space wrap>
+            <lk-button
+              id="modal-async-race-reopen"
+              size="sm"
+              variant="soft"
+              @click="reopenAsyncProbeDuringPending"
+            >
+              外部关闭并重开
+            </lk-button>
+            <lk-button
+              id="modal-async-force-close"
+              size="sm"
+              variant="soft"
+              @click="closeAsyncProbe"
+            >
+              结束探针
+            </lk-button>
+          </lk-space>
+        </view>
+      </lk-modal>
     </demo-block>
 
     <demo-block title="更多预设与形态">
@@ -217,5 +412,25 @@ const handleConfirm = () => {
   > :not(:first-child) {
     margin-top: 16rpx;
   }
+}
+
+.probe-state,
+.probe-modal-content {
+  display: flex;
+  flex-direction: column;
+
+  > :not(:first-child) {
+    margin-top: var(--lk-spacing-xs);
+  }
+}
+
+.probe-state {
+  margin-top: var(--lk-spacing-md);
+  color: var(--lk-text-secondary);
+  font-size: var(--lk-font-size-sm);
+}
+
+.probe-modal-content {
+  color: var(--lk-text-primary);
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-modal/lk-modal.scss
+++ b/src/uni_modules/lucky-ui/components/lk-modal/lk-modal.scss
@@ -57,6 +57,11 @@
     &:active {
       background: var(--lk-bg-active);
     }
+
+    &.is-disabled {
+      opacity: 0.55;
+      pointer-events: none;
+    }
   }
 
   @include e(body) {
@@ -93,6 +98,11 @@
           background-color: var(--lk-bg-active);
         }
 
+        &.is-disabled {
+          opacity: 0.55;
+          pointer-events: none;
+        }
+
         @include m(confirm) {
           color: var(--lk-color-primary);
           font-weight: 600;
@@ -112,6 +122,15 @@
           }
         }
       }
+    }
+
+    @include e(confirm-loader) {
+      width: var(--lk-rpx-28);
+      height: var(--lk-rpx-28);
+      border: var(--lk-rpx-4) solid currentColor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      animation: lk-modal-confirm-spin 0.8s linear infinite;
     }
 
     /* 两个按钮左右占比并圆角样式 */
@@ -140,5 +159,11 @@
         }
       }
     }
+  }
+}
+
+@keyframes lk-modal-confirm-spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-modal/lk-modal.vue
+++ b/src/uni_modules/lucky-ui/components/lk-modal/lk-modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue';
+import { computed, onBeforeUnmount, ref, useSlots, watch } from 'vue';
 import type { StyleValue } from 'vue';
 import LkOverlay from '../lk-overlay/lk-overlay.vue';
 import LkIcon from '../lk-icon/lk-icon.vue';
@@ -11,7 +11,7 @@ import {
   type TransitionConfig,
 } from '@/uni_modules/lucky-ui/composables/useTransition';
 import {
-  canTriggerModalAction,
+  createModalActionController,
   resolveModalFooterClass,
   resolveModalHeaderClass,
   resolveModalPanelStyle,
@@ -22,7 +22,6 @@ import {
   resolveModalTransitionDuration,
   resolveModalTransitionEasing,
   resolveModalTransitionName,
-  shouldCloseModalOnOverlay,
   shouldModalHeaderRender,
 } from './modal.utils';
 
@@ -110,39 +109,61 @@ const {
     },
   }
 );
-const panelClass = computed(() => [transitionClasses.value, props.customClass]);
+const confirming = ref(false);
+const closeRequested = ref(false);
+const actionController = createModalActionController({
+  isVisible: () => props.modelValue,
+  isLeaving: () => state.value.leaving,
+  isConfirming: () => confirming.value,
+  setConfirming: value => {
+    confirming.value = value;
+  },
+  isCloseRequested: () => closeRequested.value,
+  setCloseRequested: value => {
+    closeRequested.value = value;
+  },
+  getBeforeConfirm: () => props.beforeConfirm,
+  onUpdateModelValue: value => emit('update:modelValue', value),
+  onConfirm: () => emit('confirm'),
+  onCancel: () => emit('cancel'),
+  onClickOverlay: () => emit('click-overlay'),
+  onClickClose: () => emit('click-close'),
+});
+const actionsDisabled = computed(() => !actionController.canAct());
+const overlayCloseOnClick = computed(() =>
+  actionController.shouldCloseOnOverlay(props.closeOnOverlay)
+);
+const panelClass = computed(() => [
+  transitionClasses.value,
+  props.customClass,
+  { 'is-confirming': confirming.value },
+]);
 
-function close() {
-  // 如果正在离开，直接返回（防止重复触发）
-  if (!canTriggerModalAction(state.value.leaving)) return;
-  emit('update:modelValue', false);
-}
+watch(
+  () => props.modelValue,
+  () => actionController.syncVisibility(),
+  { flush: 'sync' }
+);
+onBeforeUnmount(() => actionController.destroy());
 
 function confirm() {
-  if (!canTriggerModalAction(state.value.leaving)) return;
-  emit('confirm');
-  emit('update:modelValue', false);
+  void actionController.confirm();
 }
 
 function onOverlayClick() {
-  emit('click-overlay');
-  if (
-    shouldCloseModalOnOverlay({
-      leaving: state.value.leaving,
-      closeOnOverlay: props.closeOnOverlay,
-    })
-  )
-    close();
+  actionController.clickOverlay();
+}
+
+function onOverlayModelUpdate(value: boolean) {
+  if (!value) actionController.closeFromOverlay();
 }
 
 function cancel() {
-  emit('cancel');
-  close();
+  actionController.cancel();
 }
 
 function onCloseClick() {
-  emit('click-close');
-  close();
+  actionController.clickClose();
 }
 </script>
 
@@ -151,7 +172,8 @@ function onCloseClick() {
   <lk-overlay
     :model-value="props.modelValue"
     :z-index="zIndex"
-    @update:model-value="close"
+    :close-on-click="overlayCloseOnClick"
+    @update:model-value="onOverlayModelUpdate"
     @click="onOverlayClick"
   />
 
@@ -172,6 +194,8 @@ function onCloseClick() {
           name="x"
           size="48"
           class="lk-modal__close"
+          :class="{ 'is-disabled': actionsDisabled }"
+          :aria-disabled="actionsDisabled"
           @click="onCloseClick"
         />
       </view>
@@ -191,19 +215,22 @@ function onCloseClick() {
           <template v-if="footerType === 'button'">
             <lk-button
               v-if="showCancel"
-              class="lk-modal__footer-btn lk-modal__footer-btn--cancel"
+              class="lk-modal__footer-btn lk-modal__footer-btn--cancel lk-modal__cancel"
               block
               size="md"
               variant="soft"
+              :disabled="actionsDisabled"
               @click="cancel"
             >
               {{ resolvedCancelText }}
             </lk-button>
             <lk-button
-              class="lk-modal__footer-btn"
+              class="lk-modal__footer-btn lk-modal__confirm"
               block
               size="md"
               variant="solid"
+              :loading="confirming"
+              :disabled="actionsDisabled"
               @click="confirm"
             >
               {{ resolvedConfirmText }}
@@ -212,13 +239,21 @@ function onCloseClick() {
           <template v-else>
             <view
               v-if="showCancel"
-              class="lk-modal__text-btn lk-modal__text-btn--cancel"
+              class="lk-modal__text-btn lk-modal__text-btn--cancel lk-modal__cancel"
+              :class="{ 'is-disabled': actionsDisabled }"
+              :aria-disabled="actionsDisabled"
               @tap="cancel"
             >
               {{ resolvedCancelText }}
             </view>
-            <view class="lk-modal__text-btn lk-modal__text-btn--confirm" @tap="confirm">
-              {{ resolvedConfirmText }}
+            <view
+              class="lk-modal__text-btn lk-modal__text-btn--confirm lk-modal__confirm"
+              :class="{ 'is-disabled': actionsDisabled, 'is-loading': confirming }"
+              :aria-disabled="actionsDisabled"
+              @tap="confirm"
+            >
+              <view v-if="confirming" class="lk-modal__confirm-loader" />
+              <text v-else>{{ resolvedConfirmText }}</text>
             </view>
           </template>
         </slot>

--- a/src/uni_modules/lucky-ui/components/lk-modal/modal.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-modal/modal.props.ts
@@ -5,6 +5,8 @@ import type {
   TransitionConfig,
 } from '@/uni_modules/lucky-ui/composables/useTransition';
 
+export type ModalBeforeConfirm = () => boolean | Promise<boolean>;
+
 export const modalProps = {
   ...baseProps,
 
@@ -51,6 +53,12 @@ export const modalProps = {
 
   /** 确认按钮文本 */
   confirmText: LkProp.string(''),
+
+  /** 确认前拦截：返回 false 或 Promise<false> 时保持打开 */
+  beforeConfirm: {
+    type: Function as PropType<ModalBeforeConfirm>,
+    default: null,
+  },
 
   /** 取消按钮文本 */
   cancelText: LkProp.string(''),

--- a/src/uni_modules/lucky-ui/components/lk-modal/modal.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-modal/modal.utils.ts
@@ -4,6 +4,7 @@ import {
   type TransitionConfig,
   type TransitionName,
 } from '@/uni_modules/lucky-ui/composables/useTransition';
+import type { ModalBeforeConfirm } from './modal.props';
 
 export function resolveModalText(options: { value: string; fallback: string }): string {
   return options.value || options.fallback;
@@ -85,13 +86,157 @@ export function resolveModalFooterClass(options: { footerType: string; showCance
   return [`is-footer-${options.footerType}`, { 'has-cancel': options.showCancel }];
 }
 
-export function canTriggerModalAction(leaving: boolean): boolean {
-  return !leaving;
+export interface ModalActionState {
+  visible: boolean;
+  leaving: boolean;
+  confirming: boolean;
+  closeRequested: boolean;
 }
 
-export function shouldCloseModalOnOverlay(options: {
-  leaving: boolean;
-  closeOnOverlay: boolean;
-}): boolean {
-  return !options.leaving && options.closeOnOverlay;
+export function canTriggerModalAction(state: ModalActionState): boolean {
+  return state.visible && !state.leaving && !state.confirming && !state.closeRequested;
+}
+
+export function shouldCloseModalOnOverlay(
+  options: ModalActionState & {
+    closeOnOverlay: boolean;
+  }
+): boolean {
+  return options.closeOnOverlay && canTriggerModalAction(options);
+}
+
+export type ModalConfirmResult = 'confirmed' | 'cancelled' | 'rejected' | 'stale' | 'blocked';
+
+export interface ModalActionControllerOptions {
+  isVisible: () => boolean;
+  isLeaving: () => boolean;
+  isConfirming: () => boolean;
+  setConfirming: (value: boolean) => void;
+  isCloseRequested: () => boolean;
+  setCloseRequested: (value: boolean) => void;
+  getBeforeConfirm: () => ModalBeforeConfirm | null;
+  onUpdateModelValue: (value: boolean) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  onClickOverlay: () => void;
+  onClickClose: () => void;
+}
+
+export interface ModalActionController {
+  canAct: () => boolean;
+  shouldCloseOnOverlay: (closeOnOverlay: boolean) => boolean;
+  clickOverlay: () => boolean;
+  closeFromOverlay: () => boolean;
+  cancel: () => boolean;
+  clickClose: () => boolean;
+  confirm: () => Promise<ModalConfirmResult>;
+  syncVisibility: () => void;
+  destroy: () => void;
+}
+
+export function createModalActionController(
+  options: ModalActionControllerOptions
+): ModalActionController {
+  let confirmAttempt = 0;
+
+  const currentState = (): ModalActionState => ({
+    visible: options.isVisible(),
+    leaving: options.isLeaving(),
+    confirming: options.isConfirming(),
+    closeRequested: options.isCloseRequested(),
+  });
+
+  const canAct = () => canTriggerModalAction(currentState());
+
+  const releaseIgnoredCloseRequest = () => {
+    Promise.resolve().then(() => {
+      if (options.isVisible() && !options.isLeaving()) {
+        options.setCloseRequested(false);
+      }
+    });
+  };
+
+  const requestClose = (beforeUpdate?: () => void): boolean => {
+    if (!canAct()) return false;
+
+    options.setCloseRequested(true);
+    beforeUpdate?.();
+    options.onUpdateModelValue(false);
+    releaseIgnoredCloseRequest();
+    return true;
+  };
+
+  const finishConfirm = (
+    attempt: number,
+    allowed: boolean,
+    rejected: boolean
+  ): ModalConfirmResult => {
+    if (attempt !== confirmAttempt) return 'stale';
+
+    if (!options.isVisible()) {
+      options.setConfirming(false);
+      return 'stale';
+    }
+
+    options.setConfirming(false);
+    if (rejected) return 'rejected';
+    if (!allowed) return 'cancelled';
+
+    return requestClose(options.onConfirm) ? 'confirmed' : 'blocked';
+  };
+
+  const invalidatePendingConfirm = () => {
+    confirmAttempt += 1;
+    options.setConfirming(false);
+    options.setCloseRequested(false);
+  };
+
+  return {
+    canAct,
+    shouldCloseOnOverlay(closeOnOverlay) {
+      return shouldCloseModalOnOverlay({
+        ...currentState(),
+        closeOnOverlay,
+      });
+    },
+    clickOverlay() {
+      if (!canAct()) return false;
+      options.onClickOverlay();
+      return true;
+    },
+    closeFromOverlay() {
+      return requestClose();
+    },
+    cancel() {
+      return requestClose(options.onCancel);
+    },
+    clickClose() {
+      return requestClose(options.onClickClose);
+    },
+    confirm() {
+      if (!canAct()) return Promise.resolve('blocked');
+
+      const beforeConfirm = options.getBeforeConfirm();
+      if (!beforeConfirm) {
+        return Promise.resolve(requestClose(options.onConfirm) ? 'confirmed' : 'blocked');
+      }
+
+      const attempt = ++confirmAttempt;
+      options.setConfirming(true);
+
+      let result: boolean | Promise<boolean>;
+      try {
+        result = beforeConfirm();
+      } catch {
+        return Promise.resolve(finishConfirm(attempt, false, true));
+      }
+
+      return Promise.resolve(result).then(
+        allowed => finishConfirm(attempt, allowed, false),
+        () => finishConfirm(attempt, false, true)
+      );
+    },
+    syncVisibility: invalidatePendingConfirm,
+    destroy: invalidatePendingConfirm,
+  };
 }

--- a/tests/unit/lk-modal.spec.ts
+++ b/tests/unit/lk-modal.spec.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ANIMATION_PRESETS } from '../../src/uni_modules/lucky-ui/composables/useTransition';
+import type { ModalBeforeConfirm } from '../../src/uni_modules/lucky-ui/components/lk-modal/modal.props';
 import {
   canTriggerModalAction,
+  createModalActionController,
   resolveModalFooterClass,
   resolveModalHeaderClass,
   resolveModalPanelStyle,
@@ -16,18 +20,88 @@ import {
   shouldModalHeaderRender,
 } from '../../src/uni_modules/lucky-ui/components/lk-modal/modal.utils';
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createActionHarness(options: { controlled: boolean; beforeConfirm?: ModalBeforeConfirm }) {
+  let visible = true;
+  let leaving = false;
+  let confirming = false;
+  let closeRequested = false;
+  const events: string[] = [];
+
+  const controller = createModalActionController({
+    isVisible: () => visible,
+    isLeaving: () => leaving,
+    isConfirming: () => confirming,
+    setConfirming: value => {
+      confirming = value;
+    },
+    isCloseRequested: () => closeRequested,
+    setCloseRequested: value => {
+      closeRequested = value;
+    },
+    getBeforeConfirm: () => options.beforeConfirm || null,
+    onUpdateModelValue: value => {
+      events.push(`update:${value}`);
+      if (options.controlled) {
+        visible = value;
+        leaving = !value;
+        controller.syncVisibility();
+      }
+    },
+    onConfirm: () => events.push('confirm'),
+    onCancel: () => events.push('cancel'),
+    onClickOverlay: () => events.push('click-overlay'),
+    onClickClose: () => events.push('click-close'),
+  });
+
+  return {
+    controller,
+    events,
+    get visible() {
+      return visible;
+    },
+    get confirming() {
+      return confirming;
+    },
+    get closeRequested() {
+      return closeRequested;
+    },
+    setVisible(value: boolean) {
+      visible = value;
+      leaving = !value;
+      controller.syncVisibility();
+    },
+    tapOverlay(closeOnOverlay: boolean) {
+      const shouldClose = controller.shouldCloseOnOverlay(closeOnOverlay);
+      controller.clickOverlay();
+      if (shouldClose) controller.closeFromOverlay();
+    },
+  };
+}
+
 describe('lk-modal transition and action rules', () => {
   it('resolves locale fallback text and transition config', () => {
     expect(resolveModalText({ value: '', fallback: '确定' })).toBe('确定');
     expect(resolveModalText({ value: '提交', fallback: '确定' })).toBe('提交');
 
-    expect(resolveModalTransitionConfig({
-      animationType: 'fade-up',
-      animation: 'scale',
-      duration: 120,
-      delay: 30,
-      easing: 'linear',
-    })).toEqual({
+    expect(
+      resolveModalTransitionConfig({
+        animationType: 'fade-up',
+        animation: 'scale',
+        duration: 120,
+        delay: 30,
+        easing: 'linear',
+      })
+    ).toEqual({
       name: 'fade-up',
       duration: 120,
       delay: 30,
@@ -57,49 +131,205 @@ describe('lk-modal transition and action rules', () => {
   });
 
   it('builds header/footer classes and styles', () => {
-    expect(shouldModalHeaderRender({
-      showHeader: true,
-      title: '',
-      showClose: false,
-      hasHeaderSlot: true,
-    })).toBe(true);
-    expect(shouldModalHeaderRender({
-      showHeader: false,
-      title: '标题',
-      showClose: true,
-      hasHeaderSlot: true,
-    })).toBe(false);
+    expect(
+      shouldModalHeaderRender({
+        showHeader: true,
+        title: '',
+        showClose: false,
+        hasHeaderSlot: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldModalHeaderRender({
+        showHeader: false,
+        title: '标题',
+        showClose: true,
+        hasHeaderSlot: true,
+      })
+    ).toBe(false);
 
     expect(resolveModalRootStyle(1500)).toEqual({ zIndex: 1501 });
-    expect(resolveModalPanelStyle({
-      transitionStyles: { opacity: 1 },
-      width: '600rpx',
-      customStyle: { transform: 'scale(0.9)' },
-    })).toEqual([
-      { transform: 'scale(0.9)' },
-      { opacity: 1, width: '600rpx' },
-    ]);
+    expect(
+      resolveModalPanelStyle({
+        transitionStyles: { opacity: 1 },
+        width: '600rpx',
+        customStyle: { transform: 'scale(0.9)' },
+      })
+    ).toEqual([{ transform: 'scale(0.9)' }, { opacity: 1, width: '600rpx' }]);
     expect(resolveModalHeaderClass('center')).toEqual(['is-title-center']);
-    expect(resolveModalFooterClass({
-      footerType: 'text',
-      showCancel: true,
-    })).toEqual(['is-footer-text', { 'has-cancel': true }]);
+    expect(
+      resolveModalFooterClass({
+        footerType: 'text',
+        showCancel: true,
+      })
+    ).toEqual(['is-footer-text', { 'has-cancel': true }]);
   });
 
   it('guards actions while leaving and overlay closing by prop', () => {
-    expect(canTriggerModalAction(false)).toBe(true);
-    expect(canTriggerModalAction(true)).toBe(false);
-    expect(shouldCloseModalOnOverlay({
-      leaving: false,
-      closeOnOverlay: true,
-    })).toBe(true);
-    expect(shouldCloseModalOnOverlay({
-      leaving: true,
-      closeOnOverlay: true,
-    })).toBe(false);
-    expect(shouldCloseModalOnOverlay({
-      leaving: false,
-      closeOnOverlay: false,
-    })).toBe(false);
+    expect(
+      canTriggerModalAction({
+        visible: true,
+        leaving: false,
+        confirming: false,
+        closeRequested: false,
+      })
+    ).toBe(true);
+    expect(
+      canTriggerModalAction({
+        visible: true,
+        leaving: true,
+        confirming: false,
+        closeRequested: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldCloseModalOnOverlay({
+        visible: true,
+        leaving: false,
+        confirming: false,
+        closeRequested: false,
+        closeOnOverlay: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldCloseModalOnOverlay({
+        visible: true,
+        leaving: true,
+        confirming: false,
+        closeRequested: false,
+        closeOnOverlay: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldCloseModalOnOverlay({
+        visible: true,
+        leaving: false,
+        confirming: false,
+        closeRequested: false,
+        closeOnOverlay: false,
+      })
+    ).toBe(false);
+  });
+
+  it.each([true, false])(
+    'emits one overlay event and no close when closeOnOverlay=false (controlled=%s)',
+    controlled => {
+      const harness = createActionHarness({ controlled });
+
+      harness.tapOverlay(false);
+
+      expect(harness.events).toEqual(['click-overlay']);
+      expect(harness.visible).toBe(true);
+    }
+  );
+
+  it.each([true, false])(
+    'emits exactly one close request when closeOnOverlay=true (controlled=%s)',
+    async controlled => {
+      const harness = createActionHarness({ controlled });
+
+      harness.tapOverlay(true);
+      harness.controller.closeFromOverlay();
+
+      expect(harness.events).toEqual(['click-overlay', 'update:false']);
+      expect(harness.visible).toBe(!controlled);
+
+      await Promise.resolve();
+      if (!controlled) expect(harness.closeRequested).toBe(false);
+    }
+  );
+
+  it('awaits a successful beforeConfirm and blocks concurrent actions', async () => {
+    const deferred = createDeferred<boolean>();
+    let beforeConfirmCount = 0;
+    const harness = createActionHarness({
+      controlled: true,
+      beforeConfirm: () => {
+        beforeConfirmCount += 1;
+        return deferred.promise;
+      },
+    });
+
+    const first = harness.controller.confirm();
+    const second = harness.controller.confirm();
+
+    expect(beforeConfirmCount).toBe(1);
+    expect(harness.confirming).toBe(true);
+    expect(harness.controller.canAct()).toBe(false);
+    expect(harness.controller.shouldCloseOnOverlay(true)).toBe(false);
+    expect(harness.controller.cancel()).toBe(false);
+    expect(harness.controller.clickClose()).toBe(false);
+    expect(await second).toBe('blocked');
+    expect(harness.events).toEqual([]);
+
+    deferred.resolve(true);
+
+    expect(await first).toBe('confirmed');
+    expect(harness.confirming).toBe(false);
+    expect(harness.events).toEqual(['confirm', 'update:false']);
+  });
+
+  it('keeps the modal open when beforeConfirm resolves false or rejects', async () => {
+    const denied = createActionHarness({
+      controlled: true,
+      beforeConfirm: () => Promise.resolve(false),
+    });
+    expect(await denied.controller.confirm()).toBe('cancelled');
+    expect(denied.confirming).toBe(false);
+    expect(denied.visible).toBe(true);
+    expect(denied.events).toEqual([]);
+
+    const rejected = createActionHarness({
+      controlled: true,
+      beforeConfirm: () => Promise.reject(new Error('request failed')),
+    });
+    expect(await rejected.controller.confirm()).toBe('rejected');
+    expect(rejected.confirming).toBe(false);
+    expect(rejected.visible).toBe(true);
+    expect(rejected.events).toEqual([]);
+  });
+
+  it('ignores a stale confirm result after an external close and reopen', async () => {
+    const deferred = createDeferred<boolean>();
+    const harness = createActionHarness({
+      controlled: true,
+      beforeConfirm: () => deferred.promise,
+    });
+
+    const pending = harness.controller.confirm();
+    harness.setVisible(false);
+    harness.setVisible(true);
+    deferred.resolve(true);
+
+    expect(await pending).toBe('stale');
+    expect(harness.visible).toBe(true);
+    expect(harness.confirming).toBe(false);
+    expect(harness.events).toEqual([]);
+  });
+
+  it('guards cancel and close events before the parent transition starts', () => {
+    const cancelHarness = createActionHarness({ controlled: false });
+    expect(cancelHarness.controller.cancel()).toBe(true);
+    expect(cancelHarness.controller.cancel()).toBe(false);
+    expect(cancelHarness.events).toEqual(['cancel', 'update:false']);
+
+    const closeHarness = createActionHarness({ controlled: false });
+    expect(closeHarness.controller.clickClose()).toBe(true);
+    expect(closeHarness.controller.clickClose()).toBe(false);
+    expect(closeHarness.events).toEqual(['click-close', 'update:false']);
+  });
+
+  it('wires overlay ownership and loading/disabled state into the template', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/uni_modules/lucky-ui/components/lk-modal/lk-modal.vue'),
+      'utf8'
+    );
+
+    expect(source).toContain(':close-on-click="overlayCloseOnClick"');
+    expect(source).toContain('@update:model-value="onOverlayModelUpdate"');
+    expect(source).toContain('class="lk-modal__footer-btn lk-modal__confirm"');
+    expect(source).toContain(':loading="confirming"');
+    expect(source).toContain(':disabled="actionsDisabled"');
+    expect(source).toContain("'is-loading': confirming");
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(modal): serialize action control flow`。
- 保留提交 `6d83b815bfcf` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。