### PR TITLE
fix(overlay): preserve shared scroll lock

### DIFF
--- a/docs/components/overlay.md
+++ b/docs/components/overlay.md
@@ -11,9 +11,9 @@ phone: overlay
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const show = ref(false)
+const show = ref(false);
 </script>
 
 <template>
@@ -51,13 +51,17 @@ const show = ref(false)
 </template>
 ```
 
+当多个开启 `lockScroll` 的 Overlay 同时显示时，背景会持续锁定，直到最后一个 Overlay
+关闭或关闭自身的 `lockScroll`。运行时切换 `visible` 或 `lockScroll` 均会同步锁状态；H5
+会在最后一把锁释放时恢复 `body` 原有的内联 `overflow` 值。
+
 ## 推荐示例
 
 ### 1) 直接复用项目 Demo（推荐）
 
 ```vue
 <script setup lang="ts">
-import OverlayDemo from '@/components/demos/overlay-demo.vue'
+import OverlayDemo from '@/components/demos/overlay-demo.vue';
 </script>
 
 <template>
@@ -79,35 +83,35 @@ import OverlayDemo from '@/components/demos/overlay-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| modelValue | 是否显示（v-model） | `boolean` | `false` |
-| zIndex | 层级 | `number` | `900` |
-| opacity | 遮罩透明度 | `number` | `0.55` |
-| background | 自定义背景色；传入后优先于 `opacity` | `string` | `''` |
-| closeOnClick | 点击遮罩是否关闭 | `boolean` | `true` |
-| lockScroll | 是否锁定背景滚动 | `boolean` | `true` |
-| duration | 动画持续时间（毫秒） | `number` | `240` |
-| id | 根节点 id | `string` | `''` |
-| customClass | 根节点自定义类名 | `string \| object \| array` | — |
-| customStyle | 根节点自定义样式 | `string \| object` | — |
+| 参数         | 说明                                 | 类型                        | 默认值  |
+| ------------ | ------------------------------------ | --------------------------- | ------- |
+| modelValue   | 是否显示（v-model）                  | `boolean`                   | `false` |
+| zIndex       | 层级                                 | `number`                    | `900`   |
+| opacity      | 遮罩透明度                           | `number`                    | `0.55`  |
+| background   | 自定义背景色；传入后优先于 `opacity` | `string`                    | `''`    |
+| closeOnClick | 点击遮罩是否关闭                     | `boolean`                   | `true`  |
+| lockScroll   | 是否锁定背景滚动                     | `boolean`                   | `true`  |
+| duration     | 动画持续时间（毫秒）                 | `number`                    | `240`   |
+| id           | 根节点 id                            | `string`                    | `''`    |
+| customClass  | 根节点自定义类名                     | `string \| object \| array` | —       |
+| customStyle  | 根节点自定义样式                     | `string \| object`          | —       |
 
 ### Events
 
-| 事件名 | 说明 | 参数 |
-|--------|------|------|
-| click | 点击遮罩时触发 | `(event?: Event) => void` |
-| open | 遮罩开始打开时触发 | `() => void` |
-| close | 点击遮罩并触发关闭时触发 | `(event?: Event) => void` |
-| update:modelValue | v-model 状态更新 | `(value: boolean) => void` |
-| after-enter | 入场动画结束 | `() => void` |
-| after-leave | 离场动画结束 | `() => void` |
-| touchmove | 触摸移动时触发，锁滚动时会阻止默认行为 | `(event?: Event) => void` |
+| 事件名            | 说明                                   | 参数                       |
+| ----------------- | -------------------------------------- | -------------------------- |
+| click             | 点击遮罩时触发                         | `(event?: Event) => void`  |
+| open              | 遮罩开始打开时触发                     | `() => void`               |
+| close             | 点击遮罩并触发关闭时触发               | `(event?: Event) => void`  |
+| update:modelValue | v-model 状态更新                       | `(value: boolean) => void` |
+| after-enter       | 入场动画结束                           | `() => void`               |
+| after-leave       | 离场动画结束                           | `() => void`               |
+| touchmove         | 触摸移动时触发，锁滚动时会阻止默认行为 | `(event?: Event) => void`  |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
+| 插槽名  | 说明           |
+| ------- | -------------- |
 | default | 遮罩层中的内容 |
 
 ## 使用建议
@@ -118,6 +122,17 @@ import OverlayDemo from '@/components/demos/overlay-demo.vue'
 
 ## 发布验收
 
+- 稳定定位：Overlay 根节点提供 `[data-testid="lk-overlay"]` 与
+  `data-scroll-locked="true|false"`。回归 Demo 还提供
+  `#overlay-scroll-lock-primary`、`#overlay-scroll-lock-secondary` 和
+  `#overlay-scroll-unlocked`。
+- H5 Peekit：进入 Overlay Demo，点击 `#overlay-scroll-lock-open`，断言主遮罩
+  `data-scroll-locked=true` 且 `body` 的 `overflow` 为 `hidden`；打开第二层后关闭第二层，
+  主遮罩仍应为 `true` 且 `body` 仍为 `hidden`；切换主遮罩滚动锁为关闭后，两者分别为
+  `false` 和打开前的 `overflow`；再次开启并关闭演练后，`body` 必须再次恢复打开前的值。
+- 微信 Peekit：同一演练中，锁开启时在遮罩上纵向滑动，背景滚动位置不得变化；切换为
+  `lockScroll=false` 后执行相同滑动，背景滚动位置必须变化。构建产物还应客观确认锁定分支为
+  `catchtouchmove`、未锁分支为 `bindtouchmove`，不能把“事件已触发”等同于滚动已被阻止。
 - H5：打开内容遮罩后，内容区点击不应冒泡关闭；点击关闭按钮后遮罩应离场且不残留锁滚动。
 - App：重点复核 fixed 遮罩层级、软键盘弹出后的覆盖范围和页面滚动锁定。
 - 小程序：重点复核 `touchmove` 阻止默认行为、点击穿透和自定义内容内按钮事件。

--- a/src/components/demos/overlay-demo.vue
+++ b/src/components/demos/overlay-demo.vue
@@ -10,6 +10,9 @@ const visible2 = ref(false);
 const visible3 = ref(false);
 const visible5 = ref(false);
 const visible6 = ref(false);
+const visibleLockPrimary = ref(false);
+const visibleLockSecondary = ref(false);
+const runtimeLockScroll = ref(true);
 
 const showOverlay1 = () => {
   visible1.value = true;
@@ -21,6 +24,17 @@ const showOverlay2 = () => {
 
 const showOverlay3 = () => {
   visible3.value = true;
+};
+
+const showScrollLockFixture = () => {
+  runtimeLockScroll.value = true;
+  visibleLockSecondary.value = false;
+  visibleLockPrimary.value = true;
+};
+
+const closeScrollLockFixture = () => {
+  visibleLockSecondary.value = false;
+  visibleLockPrimary.value = false;
 };
 </script>
 
@@ -54,7 +68,55 @@ const showOverlay3 = () => {
         <lk-button @click="visible6 = true">允许滚动</lk-button>
       </lk-space>
       <lk-overlay v-model="visible5" :close-on-click="false" />
-      <lk-overlay v-model="visible6" :lock-scroll="false" />
+      <lk-overlay id="overlay-scroll-unlocked" v-model="visible6" :lock-scroll="false" />
+    </demo-block>
+
+    <demo-block title="滚动锁回归演练">
+      <lk-button id="overlay-scroll-lock-open" type="primary" @click="showScrollLockFixture">
+        打开滚动锁演练
+      </lk-button>
+      <lk-overlay
+        id="overlay-scroll-lock-primary"
+        v-model="visibleLockPrimary"
+        :close-on-click="false"
+        :lock-scroll="runtimeLockScroll"
+        :z-index="910"
+      >
+        <view class="overlay-content" @click.stop>
+          <text id="overlay-scroll-lock-state" class="overlay-text">
+            主遮罩：{{ visibleLockPrimary ? '打开' : '关闭' }}；滚动锁：{{
+              runtimeLockScroll ? '开启' : '关闭'
+            }}
+          </text>
+          <lk-space wrap>
+            <lk-button
+              id="overlay-scroll-lock-toggle"
+              @click="runtimeLockScroll = !runtimeLockScroll"
+            >
+              切换滚动锁
+            </lk-button>
+            <lk-button id="overlay-scroll-lock-open-secondary" @click="visibleLockSecondary = true">
+              打开第二层
+            </lk-button>
+            <lk-button id="overlay-scroll-lock-close-primary" @click="closeScrollLockFixture">
+              关闭演练
+            </lk-button>
+          </lk-space>
+        </view>
+      </lk-overlay>
+      <lk-overlay
+        id="overlay-scroll-lock-secondary"
+        v-model="visibleLockSecondary"
+        :close-on-click="false"
+        :z-index="920"
+      >
+        <view class="overlay-content" @click.stop>
+          <text class="overlay-text">第二层遮罩已打开</text>
+          <lk-button id="overlay-scroll-lock-close-secondary" @click="visibleLockSecondary = false">
+            关闭第二层
+          </lk-button>
+        </view>
+      </lk-overlay>
     </demo-block>
   </view>
 </template>

--- a/src/uni_modules/lucky-ui/components/lk-overlay/lk-overlay.vue
+++ b/src/uni_modules/lucky-ui/components/lk-overlay/lk-overlay.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { overlayProps, overlayEmits } from './overlay.props';
 import { useTransition } from '../../composables/useTransition';
+import { createBodyScrollLock } from '../../utils/scroll-lock';
 import {
   resolveOverlayStyle,
   resolveOverlayVisible,
+  preventOverlayTouchMove,
   shouldCloseOverlayOnClick,
   shouldLockOverlayScroll,
-  shouldPreventOverlayTouchMove,
+  useOverlayScrollLock,
 } from './overlay.utils';
 
 defineOptions({ name: 'LkOverlay' });
@@ -55,64 +57,89 @@ function onClick(event?: unknown) {
   }
 }
 
-function lock() {
-  if (
-    !shouldLockOverlayScroll({
-      visible: externalShow.value,
-      lockScroll: props.lockScroll,
-    })
-  )
-    return;
-  // #ifdef H5
-  document.body.style.overflow = 'hidden';
-  // #endif
-}
-function unlock() {
-  if (!props.lockScroll) return;
-  // #ifdef H5
-  document.body.style.overflow = '';
-  // #endif
+const bodyScrollLock = createBodyScrollLock();
+
+function resolveShouldLockScroll(): boolean {
+  return shouldLockOverlayScroll({
+    visible: externalShow.value,
+    lockScroll: props.lockScroll,
+  });
 }
 
-// 滚动锁定逻辑随外部显示状态切换
+const scrollLocked = useOverlayScrollLock(resolveShouldLockScroll, {
+  sync(shouldLock) {
+    let locked = shouldLock;
+    // #ifdef H5
+    locked = bodyScrollLock.sync(shouldLock);
+    // #endif
+    return locked;
+  },
+  release() {
+    bodyScrollLock.release();
+  },
+});
+
 watch(
   externalShow,
-  v => {
-    if (v) {
-      emit('open');
-      lock();
-    } else {
-      unlock();
-    }
+  visible => {
+    if (visible) emit('open');
   },
   { immediate: true }
 );
 
-onMounted(() => {
-  if (externalShow.value) lock();
-});
-onBeforeUnmount(unlock);
-
 function onTouchMove(e: TouchEvent) {
   emit('touchmove', e);
-  if (shouldPreventOverlayTouchMove(props.lockScroll)) {
-    e.preventDefault();
-  }
+  // #ifdef H5
+  preventOverlayTouchMove(e, scrollLocked.value);
+  // #endif
 }
 </script>
 
 <template>
+  <!-- #ifdef MP-WEIXIN -->
+  <view
+    v-if="display && scrollLocked"
+    :id="id"
+    class="lk-overlay"
+    :class="[customClass, transitionClasses]"
+    :style="overlayStyle"
+    data-testid="lk-overlay"
+    data-scroll-locked="true"
+    @tap="onClick"
+    @touchmove.stop.prevent="onTouchMove"
+  >
+    <slot />
+  </view>
+  <view
+    v-else-if="display"
+    :id="id"
+    class="lk-overlay"
+    :class="[customClass, transitionClasses]"
+    :style="overlayStyle"
+    data-testid="lk-overlay"
+    data-scroll-locked="false"
+    @tap="onClick"
+    @touchmove="onTouchMove"
+  >
+    <slot />
+  </view>
+  <!-- #endif -->
+
+  <!-- #ifndef MP-WEIXIN -->
   <view
     v-if="display"
     :id="id"
     class="lk-overlay"
     :class="[customClass, transitionClasses]"
     :style="overlayStyle"
+    data-testid="lk-overlay"
+    :data-scroll-locked="scrollLocked ? 'true' : 'false'"
     @tap="onClick"
     @touchmove="onTouchMove"
   >
     <slot />
   </view>
+  <!-- #endif -->
 </template>
 
 <style lang="scss">

--- a/src/uni_modules/lucky-ui/components/lk-overlay/overlay.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-overlay/overlay.utils.ts
@@ -1,4 +1,10 @@
-import type { StyleValue } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import type { Ref, StyleValue } from 'vue';
+
+export interface OverlayScrollLockController {
+  sync(shouldLock: boolean): boolean;
+  release(): void;
+}
 
 export function resolveOverlayVisible(options: { modelValue: boolean }): boolean {
   return options.modelValue;
@@ -40,6 +46,28 @@ export function shouldLockOverlayScroll(options: {
   return options.visible && options.lockScroll;
 }
 
-export function shouldPreventOverlayTouchMove(lockScroll: boolean): boolean {
-  return lockScroll;
+export function useOverlayScrollLock(
+  shouldLock: () => boolean,
+  controller: OverlayScrollLockController
+): Ref<boolean> {
+  const scrollLocked = ref(false);
+  const sync = () => {
+    scrollLocked.value = controller.sync(shouldLock());
+  };
+
+  watch(shouldLock, sync, { immediate: true });
+  onMounted(sync);
+  onBeforeUnmount(() => {
+    controller.release();
+    scrollLocked.value = false;
+  });
+
+  return scrollLocked;
+}
+
+export function preventOverlayTouchMove(
+  event: Pick<TouchEvent, 'preventDefault'>,
+  scrollLocked: boolean
+): void {
+  if (scrollLocked) event.preventDefault();
 }

--- a/src/uni_modules/lucky-ui/utils/scroll-lock.ts
+++ b/src/uni_modules/lucky-ui/utils/scroll-lock.ts
@@ -1,0 +1,63 @@
+export interface ScrollLockStyle {
+  overflow: string;
+}
+
+export type ScrollLockTargetResolver = () => ScrollLockStyle | null;
+
+const activeOwners = new Set<object>();
+let activeStyle: ScrollLockStyle | null = null;
+let ownedOverflow = '';
+
+function resolveBodyStyle(): ScrollLockStyle | null {
+  let style: ScrollLockStyle | null = null;
+  // #ifdef H5
+  if (typeof document !== 'undefined' && document.body) style = document.body.style;
+  // #endif
+  return style;
+}
+
+function acquire(owner: object, style: ScrollLockStyle): boolean {
+  if (activeOwners.has(owner)) return true;
+
+  if (activeOwners.size === 0) {
+    activeStyle = style;
+    ownedOverflow = style.overflow;
+    style.overflow = 'hidden';
+  } else if (activeStyle !== style) {
+    return false;
+  }
+
+  activeOwners.add(owner);
+  return true;
+}
+
+function release(owner: object): void {
+  if (!activeOwners.delete(owner) || activeOwners.size > 0) return;
+
+  if (activeStyle?.overflow === 'hidden') activeStyle.overflow = ownedOverflow;
+  activeStyle = null;
+  ownedOverflow = '';
+}
+
+export function createBodyScrollLock(resolveTarget: ScrollLockTargetResolver = resolveBodyStyle) {
+  const owner = {};
+
+  return {
+    sync(shouldLock: boolean): boolean {
+      if (!shouldLock) {
+        release(owner);
+        return false;
+      }
+
+      if (activeOwners.has(owner)) return true;
+      const target = resolveTarget();
+      return target ? acquire(owner, target) : false;
+    },
+    release(): void {
+      release(owner);
+    },
+    isLocked(): boolean {
+      return activeOwners.has(owner);
+    },
+  };
+}

--- a/tests/unit/lk-overlay.spec.ts
+++ b/tests/unit/lk-overlay.spec.ts
@@ -1,39 +1,87 @@
-import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { createRenderer, defineComponent, nextTick, ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  preventOverlayTouchMove,
   resolveOverlayBackground,
   resolveOverlayBaseStyle,
   resolveOverlayStyle,
   resolveOverlayVisible,
   shouldCloseOverlayOnClick,
   shouldLockOverlayScroll,
-  shouldPreventOverlayTouchMove,
+  useOverlayScrollLock,
 } from '../../src/uni_modules/lucky-ui/components/lk-overlay/overlay.utils';
+import {
+  createBodyScrollLock,
+  type ScrollLockStyle,
+} from '../../src/uni_modules/lucky-ui/utils/scroll-lock';
+
+type TestNode = Record<string, unknown>;
+type TestElement = TestNode;
+
+const nodeRequire = createRequire(import.meta.url);
+const testRenderer = createRenderer<TestNode, TestElement>({
+  patchProp() {},
+  insert() {},
+  remove() {},
+  createElement() {
+    return {};
+  },
+  createText() {
+    return {};
+  },
+  createComment() {
+    return {};
+  },
+  setText() {},
+  setElementText() {},
+  parentNode() {
+    return null;
+  },
+  nextSibling() {
+    return null;
+  },
+});
 
 describe('lk-overlay visibility and interaction rules', () => {
   it('resolves visibility from modelValue', () => {
-    expect(resolveOverlayVisible({
-      modelValue: true,
-    })).toBe(true);
-    expect(resolveOverlayVisible({
-      modelValue: false,
-    })).toBe(false);
+    expect(
+      resolveOverlayVisible({
+        modelValue: true,
+      })
+    ).toBe(true);
+    expect(
+      resolveOverlayVisible({
+        modelValue: false,
+      })
+    ).toBe(false);
   });
 
   it('builds background and style from opacity or explicit background', () => {
-    expect(resolveOverlayBackground({
-      background: '',
-      opacity: 0.42,
-    })).toBe('rgba(0,0,0,0.42)');
-    expect(resolveOverlayBackground({
-      background: 'rgba(255,0,0,0.3)',
-      opacity: 0.42,
-    })).toBe('rgba(255,0,0,0.3)');
+    expect(
+      resolveOverlayBackground({
+        background: '',
+        opacity: 0.42,
+      })
+    ).toBe('rgba(0,0,0,0.42)');
+    expect(
+      resolveOverlayBackground({
+        background: 'rgba(255,0,0,0.3)',
+        opacity: 0.42,
+      })
+    ).toBe('rgba(255,0,0,0.3)');
 
-    expect(resolveOverlayBaseStyle({
-      zIndex: 1200,
-      background: '',
-      opacity: 0.5,
-    })).toEqual({
+    expect(
+      resolveOverlayBaseStyle({
+        zIndex: 1200,
+        background: '',
+        opacity: 0.5,
+      })
+    ).toEqual({
       zIndex: 1200,
       '--lk-overlay-bg': 'rgba(0,0,0,0.5)',
     });
@@ -43,13 +91,15 @@ describe('lk-overlay visibility and interaction rules', () => {
     const transitionStyles = { opacity: 1 };
     const customStyle = { backdropFilter: 'blur(8px)' };
 
-    expect(resolveOverlayStyle({
-      zIndex: 900,
-      background: '#000',
-      opacity: 0.55,
-      transitionStyles,
-      customStyle,
-    })).toEqual([
+    expect(
+      resolveOverlayStyle({
+        zIndex: 900,
+        background: '#000',
+        opacity: 0.55,
+        transitionStyles,
+        customStyle,
+      })
+    ).toEqual([
       {
         zIndex: 900,
         '--lk-overlay-bg': '#000',
@@ -62,19 +112,194 @@ describe('lk-overlay visibility and interaction rules', () => {
   it('resolves click close and scroll lock guards', () => {
     expect(shouldCloseOverlayOnClick(true)).toBe(true);
     expect(shouldCloseOverlayOnClick(false)).toBe(false);
-    expect(shouldLockOverlayScroll({
-      visible: true,
-      lockScroll: true,
-    })).toBe(true);
-    expect(shouldLockOverlayScroll({
-      visible: false,
-      lockScroll: true,
-    })).toBe(false);
-    expect(shouldLockOverlayScroll({
-      visible: true,
-      lockScroll: false,
-    })).toBe(false);
-    expect(shouldPreventOverlayTouchMove(true)).toBe(true);
-    expect(shouldPreventOverlayTouchMove(false)).toBe(false);
+    expect(
+      shouldLockOverlayScroll({
+        visible: true,
+        lockScroll: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldLockOverlayScroll({
+        visible: false,
+        lockScroll: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldLockOverlayScroll({
+        visible: true,
+        lockScroll: false,
+      })
+    ).toBe(false);
   });
+
+  it('keeps the body locked until every overlay owner releases it', () => {
+    const style: ScrollLockStyle = { overflow: 'auto' };
+    const first = createBodyScrollLock(() => style);
+    const second = createBodyScrollLock(() => style);
+
+    expect(first.sync(true)).toBe(true);
+    expect(first.sync(true)).toBe(true);
+    expect(second.sync(true)).toBe(true);
+    expect(style.overflow).toBe('hidden');
+
+    expect(first.sync(false)).toBe(false);
+    expect(first.isLocked()).toBe(false);
+    expect(second.isLocked()).toBe(true);
+    expect(style.overflow).toBe('hidden');
+
+    second.release();
+    expect(second.isLocked()).toBe(false);
+    expect(style.overflow).toBe('auto');
+  });
+
+  it('tracks runtime lock toggles and restores the exact prior overflow', () => {
+    const style: ScrollLockStyle = { overflow: 'clip' };
+    const lock = createBodyScrollLock(() => style);
+
+    expect(lock.sync(false)).toBe(false);
+    expect(style.overflow).toBe('clip');
+    expect(lock.sync(true)).toBe(true);
+    expect(style.overflow).toBe('hidden');
+    expect(lock.sync(false)).toBe(false);
+    expect(style.overflow).toBe('clip');
+    expect(lock.sync(true)).toBe(true);
+    expect(style.overflow).toBe('hidden');
+
+    lock.release();
+    expect(style.overflow).toBe('clip');
+  });
+
+  it('can retry after the H5 body target becomes available', () => {
+    const style: ScrollLockStyle = { overflow: '' };
+    let target: ScrollLockStyle | null = null;
+    const lock = createBodyScrollLock(() => target);
+
+    expect(lock.sync(true)).toBe(false);
+    target = style;
+    expect(lock.sync(true)).toBe(true);
+    expect(style.overflow).toBe('hidden');
+
+    lock.release();
+    expect(style.overflow).toBe('');
+  });
+
+  it('does not overwrite a newer external body overflow change when releasing', () => {
+    const style: ScrollLockStyle = { overflow: 'auto' };
+    const lock = createBodyScrollLock(() => style);
+
+    expect(lock.sync(true)).toBe(true);
+    style.overflow = 'clip';
+    lock.release();
+
+    expect(style.overflow).toBe('clip');
+    expect(lock.isLocked()).toBe(false);
+  });
+
+  it('syncs mounted overlays across runtime toggles and releases on unmount', async () => {
+    const style: ScrollLockStyle = { overflow: 'auto' };
+    const firstVisible = ref(true);
+    const firstLockScroll = ref(true);
+    const secondVisible = ref(true);
+    const firstController = createBodyScrollLock(() => style);
+    const secondController = createBodyScrollLock(() => style);
+
+    const FirstOverlay = defineComponent({
+      setup() {
+        useOverlayScrollLock(() => firstVisible.value && firstLockScroll.value, firstController);
+        return () => null;
+      },
+    });
+    const SecondOverlay = defineComponent({
+      setup() {
+        useOverlayScrollLock(() => secondVisible.value, secondController);
+        return () => null;
+      },
+    });
+    const firstApp = testRenderer.createApp(FirstOverlay);
+    const secondApp = testRenderer.createApp(SecondOverlay);
+
+    firstApp.mount({});
+    secondApp.mount({});
+    await nextTick();
+    expect(style.overflow).toBe('hidden');
+
+    firstLockScroll.value = false;
+    await nextTick();
+    expect(firstController.isLocked()).toBe(false);
+    expect(secondController.isLocked()).toBe(true);
+    expect(style.overflow).toBe('hidden');
+
+    firstLockScroll.value = true;
+    await nextTick();
+    expect(firstController.isLocked()).toBe(true);
+
+    firstApp.unmount();
+    expect(firstController.isLocked()).toBe(false);
+    expect(style.overflow).toBe('hidden');
+
+    secondVisible.value = false;
+    await nextTick();
+    expect(style.overflow).toBe('auto');
+
+    secondVisible.value = true;
+    await nextTick();
+    expect(style.overflow).toBe('hidden');
+    secondApp.unmount();
+    expect(secondController.isLocked()).toBe(false);
+    expect(style.overflow).toBe('auto');
+  });
+
+  it('prevents H5 touchmove only while scroll locking is active', () => {
+    const preventDefault = vi.fn();
+
+    preventOverlayTouchMove({ preventDefault }, false);
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    preventOverlayTouchMove({ preventDefault }, true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('compiles a conditional catch binding only for locked WeChat overlays', () => {
+    const uniBin = nodeRequire.resolve('@dcloudio/vite-plugin-uni/bin/uni.js');
+    const temporaryParent = resolve(tmpdir());
+    const outputDirectory = mkdtempSync(join(temporaryParent, 'lucky-ui-overlay-mp-'));
+    const outputPath = join(
+      outputDirectory,
+      'uni_modules/lucky-ui/components/lk-overlay/lk-overlay.wxml'
+    );
+    const buildStartedAt = Date.now();
+
+    expect(dirname(outputDirectory)).toBe(temporaryParent);
+    expect(existsSync(outputPath)).toBe(false);
+
+    try {
+      execFileSync(process.execPath, [uniBin, 'build', '-p', 'mp-weixin'], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          UNI_OUTPUT_DIR: outputDirectory,
+        },
+        stdio: 'pipe',
+      });
+
+      expect(existsSync(outputPath)).toBe(true);
+      expect(statSync(outputPath).mtimeMs).toBeGreaterThanOrEqual(buildStartedAt - 1_000);
+      const output = readFileSync(outputPath, 'utf8');
+
+      expect(output).toMatch(
+        /data-testid="lk-overlay" data-scroll-locked="true"[^>]*catchtouchmove=/
+      );
+      expect(output).toMatch(
+        /data-testid="lk-overlay" data-scroll-locked="false"[^>]*bindtouchmove=/
+      );
+      expect(output).not.toMatch(
+        /data-scroll-locked="true"[^>]*bindtouchmove=|data-scroll-locked="false"[^>]*catchtouchmove=/
+      );
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+
+    expect(existsSync(outputDirectory)).toBe(false);
+  }, 60_000);
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(overlay): preserve shared scroll lock`。
- 保留提交 `4b72359d4358` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。