### PR TITLE
fix(popup): refresh transition props

### DIFF
--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -82,9 +82,7 @@ const pos = ref<'top' | 'bottom' | 'left' | 'right' | ''>('');
 ```vue
 <template>
   <lk-popup v-model="show" position="bottom" draggable>
-    <view v-for="i in 30" :key="i" style="padding: 28rpx 40rpx">
-      列表项 {{ i }}
-    </view>
+    <view v-for="i in 30" :key="i" style="padding: 28rpx 40rpx"> 列表项 {{ i }} </view>
   </lk-popup>
 </template>
 ```
@@ -116,6 +114,21 @@ const pos = ref<'top' | 'bottom' | 'left' | 'right' | ''>('');
   <view style="padding:32rpx">自定义动画</view>
 </lk-popup>
 ```
+
+`position`、`draggable`、`animation`、`animationType`、`duration`、`delay` 和 `easing` 都是响应式配置。弹层关闭后修改任一配置，下一次打开会按最新的优先级、类名、时长、延迟与缓动执行，无需重新挂载组件。
+
+### 响应式配置验收探针
+
+组件演示页提供一组跨端稳定选择器，用于客观验证运行时配置没有冻结：
+
+| 选择器                              | 用途                              |
+| ----------------------------------- | --------------------------------- |
+| `#popup-reactive-transition-probe`  | 读取当前七项输入、模式和显隐状态  |
+| `#popup-reactive-transition-next`   | 仅在弹层关闭时切换下一组配置      |
+| `#popup-reactive-transition-open`   | 使用当前配置打开同一个 Popup 实例 |
+| `.popup-reactive-transition-target` | 读取真实面板的过渡类名与计算样式  |
+
+Peekit 基准流程固定为：在 `bottom-default` 模式打开并记录 `slide-up / 180ms`；关闭后点击一次“下一组配置”，确认探针为 `right-700`；再次打开同一实例，面板必须变为 `slide-right / 700ms / 80ms / linear`。继续切换还可分别验证 draggable 的 `fade`、`bounce` 预设和显式 `fade-left` 类型。每一步都必须同时记录探针属性、面板 class、计算样式、截图及控制台/运行时错误；仅构建成功或仅看到弹层出现不能作为通过依据。H5 与微信小程序使用同一套选择器和断言。
 
 ## 圆角弹框
 
@@ -150,34 +163,34 @@ const pos = ref<'top' | 'bottom' | 'left' | 'right' | ''>('');
 
 ### Props
 
-| 参数                  | 说明                                                       | 类型                                       | 默认值       |
-| --------------------- | ---------------------------------------------------------- | ------------------------------------------ | ------------ |
-| customClass           | 组件可视根节点自定义类名                                   | `string \| object \| array`                | `''`         |
-| customStyle           | 组件可视根节点自定义样式                                   | `string \| object`                         | `''`         |
-| modelValue            | 是否显示（v-model）                                        | `boolean`                                  | `false`      |
-| zIndex                | 弹层层级                                                   | `number`                                   | `1000`       |
-| position              | 弹出位置                                                   | `top \| bottom \| left \| right \| center` | `center`     |
-| round                 | 是否圆角                                                   | `boolean`                                  | `true`       |
-| radius                | 圆角大小                                                   | `string`                                   | `32rpx`      |
-| draggable             | 是否开启拖拽，仅底部模式有效                               | `boolean`                                  | `false`      |
-| snapPoints            | 底部拖拽吸附点，值为 translateY 占窗口高度比例             | `number[]`                                 | `[0.5, 0.1]` |
-| dragDamping           | 越界拖拽阻尼系数，越小越克制                               | `number`                                   | `0.18`       |
-| dragEasing            | 拖拽吸附动画曲线                                           | `string`                                   | `cubic-bezier(0.18, 0.89, 0.32, 1.08)` |
-| title                 | 标题                                                       | `string`                                   | `''`         |
-| closable              | 是否显示关闭图标                                           | `boolean`                                  | `false`      |
-| closeIcon             | 关闭图标名称                                               | `string`                                   | `x-lg`       |
-| closeIconPosition     | 关闭图标位置                                               | `top-right \| top-left`                    | `top-right`  |
-| overlay               | 是否显示遮罩                                               | `boolean`                                  | `true`       |
-| closeOnOverlay        | 点击遮罩关闭                                               | `boolean`                                  | `true`       |
-| lockScroll            | 锁定背景滚动                                               | `boolean`                                  | `true`       |
-| safeArea              | 底部是否适配安全区                                         | `boolean`                                  | `true`       |
-| height                | 弹层高度；draggable bottom 模式下由 `snapPoints` 接管可见高度 | `string \| number`                         | `''`         |
-| width                 | 弹层宽度                                                   | `string \| number`                         | `''`         |
-| animation             | 动画预设名称                                               | `keyof ANIMATION_PRESETS`                  | `undefined`  |
-| animationType         | 内置动画类型，支持全部 `TransitionName`                     | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined`  |
-| duration              | 动画持续时间                                               | `number`                                   | `undefined`  |
-| delay                 | 动画延迟                                                   | `number`                                   | `undefined`  |
-| easing                | 动画缓动函数                                               | `TransitionConfig['easing']`               | `undefined`  |
+| 参数              | 说明                                                          | 类型                                                   | 默认值                                 |
+| ----------------- | ------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------- |
+| customClass       | 组件可视根节点自定义类名                                      | `string \| object \| array`                            | `''`                                   |
+| customStyle       | 组件可视根节点自定义样式                                      | `string \| object`                                     | `''`                                   |
+| modelValue        | 是否显示（v-model）                                           | `boolean`                                              | `false`                                |
+| zIndex            | 弹层层级                                                      | `number`                                               | `1000`                                 |
+| position          | 弹出位置                                                      | `top \| bottom \| left \| right \| center`             | `center`                               |
+| round             | 是否圆角                                                      | `boolean`                                              | `true`                                 |
+| radius            | 圆角大小                                                      | `string`                                               | `32rpx`                                |
+| draggable         | 是否开启拖拽，仅底部模式有效                                  | `boolean`                                              | `false`                                |
+| snapPoints        | 底部拖拽吸附点，值为 translateY 占窗口高度比例                | `number[]`                                             | `[0.5, 0.1]`                           |
+| dragDamping       | 越界拖拽阻尼系数，越小越克制                                  | `number`                                               | `0.18`                                 |
+| dragEasing        | 拖拽吸附动画曲线                                              | `string`                                               | `cubic-bezier(0.18, 0.89, 0.32, 1.08)` |
+| title             | 标题                                                          | `string`                                               | `''`                                   |
+| closable          | 是否显示关闭图标                                              | `boolean`                                              | `false`                                |
+| closeIcon         | 关闭图标名称                                                  | `string`                                               | `x-lg`                                 |
+| closeIconPosition | 关闭图标位置                                                  | `top-right \| top-left`                                | `top-right`                            |
+| overlay           | 是否显示遮罩                                                  | `boolean`                                              | `true`                                 |
+| closeOnOverlay    | 点击遮罩关闭                                                  | `boolean`                                              | `true`                                 |
+| lockScroll        | 锁定背景滚动                                                  | `boolean`                                              | `true`                                 |
+| safeArea          | 底部是否适配安全区                                            | `boolean`                                              | `true`                                 |
+| height            | 弹层高度；draggable bottom 模式下由 `snapPoints` 接管可见高度 | `string \| number`                                     | `''`                                   |
+| width             | 弹层宽度                                                      | `string \| number`                                     | `''`                                   |
+| animation         | 动画预设名称                                                  | `keyof ANIMATION_PRESETS`                              | `undefined`                            |
+| animationType     | 内置动画类型，支持全部 `TransitionName`                       | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined`                            |
+| duration          | 动画持续时间                                                  | `number`                                               | `undefined`                            |
+| delay             | 动画延迟                                                      | `number`                                               | `undefined`                            |
+| easing            | 动画缓动函数                                                  | `TransitionConfig['easing']`                           | `undefined`                            |
 
 ### Events
 
@@ -213,3 +226,4 @@ const pos = ref<'top' | 'bottom' | 'left' | 'right' | ''>('');
 | 展示台基线 | 自动回归 | `tests/visual/needs-hardening-showcase.spec.ts` 校验组件路由、verified 状态与中风险标记 |
 | 弹出方向   | 人工验收 | `top/bottom/left/right/center` 尺寸、圆角和安全区表现稳定                               |
 | 交互关闭   | 人工验收 | 遮罩关闭、拖拽关闭、锁滚动与动画结束事件在目标端一致                                    |
+| 响应式动画 | Peekit   | 关闭时从 `bottom / 180ms` 切到 `right / 700ms`，重开同一实例后类名与计算样式同步更新    |

--- a/src/components/demos/popup-demo.vue
+++ b/src/components/demos/popup-demo.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkPopup from '@/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+import type { TransitionName } from '@/uni_modules/lucky-ui/composables/useTransition';
 
 const visible1 = ref(false);
 const visible2 = ref(false);
@@ -21,6 +22,78 @@ const visibleWithTitle = ref(false);
 const visibleWithClose = ref(false);
 const visibleWithBoth = ref(false);
 const visibleCustomTitle = ref(false);
+const reactiveTransitionVisible = ref(false);
+
+type ReactiveTransitionProbeConfig = {
+  key: string;
+  position: 'bottom' | 'right' | 'center';
+  draggable: boolean;
+  animation?: 'bounce';
+  animationType?: TransitionName;
+  duration: number;
+  delay: number;
+  easing: string;
+};
+
+const reactiveTransitionConfigs: ReactiveTransitionProbeConfig[] = [
+  {
+    key: 'bottom-default',
+    position: 'bottom',
+    draggable: false,
+    duration: 180,
+    delay: 0,
+    easing: 'ease-out',
+  },
+  {
+    key: 'right-700',
+    position: 'right',
+    draggable: false,
+    duration: 700,
+    delay: 80,
+    easing: 'linear',
+  },
+  {
+    key: 'bottom-draggable',
+    position: 'bottom',
+    draggable: true,
+    duration: 360,
+    delay: 20,
+    easing: 'ease-in',
+  },
+  {
+    key: 'bounce-preset',
+    position: 'center',
+    draggable: false,
+    animation: 'bounce',
+    duration: 420,
+    delay: 30,
+    easing: 'ease-in-out',
+  },
+  {
+    key: 'fade-left-type',
+    position: 'center',
+    draggable: false,
+    animationType: 'fade-left',
+    duration: 500,
+    delay: 40,
+    easing: 'ease-out',
+  },
+];
+const reactiveTransitionIndex = ref(0);
+const reactiveTransitionConfig = computed(
+  () => reactiveTransitionConfigs[reactiveTransitionIndex.value]!
+);
+
+function nextReactiveTransitionConfig() {
+  if (reactiveTransitionVisible.value) return;
+  reactiveTransitionIndex.value =
+    (reactiveTransitionIndex.value + 1) % reactiveTransitionConfigs.length;
+}
+
+function resetReactiveTransitionConfig() {
+  if (reactiveTransitionVisible.value) return;
+  reactiveTransitionIndex.value = 0;
+}
 
 const showPopup1 = () => {
   visible1.value = true;
@@ -130,6 +203,64 @@ const showRight = () => {
       </lk-popup>
     </demo-block>
 
+    <demo-block title="运行时动画配置">
+      <view
+        id="popup-reactive-transition-probe"
+        :data-mode="reactiveTransitionConfig.key"
+        :data-visible="reactiveTransitionVisible ? 'true' : 'false'"
+        :data-position="reactiveTransitionConfig.position"
+        :data-draggable="reactiveTransitionConfig.draggable ? 'true' : 'false'"
+        :data-animation="reactiveTransitionConfig.animation || 'none'"
+        :data-animation-type="reactiveTransitionConfig.animationType || 'none'"
+        :data-duration="String(reactiveTransitionConfig.duration)"
+        :data-delay="String(reactiveTransitionConfig.delay)"
+        :data-easing="reactiveTransitionConfig.easing"
+        class="reactive-transition-probe"
+      >
+        关闭弹层后切换配置，再打开应使用当前模式，而不是首次挂载时的动画。
+      </view>
+      <view class="button-row">
+        <lk-button
+          id="popup-reactive-transition-next"
+          :disabled="reactiveTransitionVisible"
+          @click="nextReactiveTransitionConfig"
+        >
+          下一组配置
+        </lk-button>
+        <lk-button
+          id="popup-reactive-transition-reset"
+          :disabled="reactiveTransitionVisible"
+          @click="resetReactiveTransitionConfig"
+        >
+          重置配置
+        </lk-button>
+        <lk-button
+          id="popup-reactive-transition-open"
+          type="primary"
+          @click="reactiveTransitionVisible = true"
+        >
+          打开探针
+        </lk-button>
+      </view>
+      <lk-popup
+        v-model="reactiveTransitionVisible"
+        :position="reactiveTransitionConfig.position"
+        :draggable="reactiveTransitionConfig.draggable"
+        :animation="reactiveTransitionConfig.animation"
+        :animation-type="reactiveTransitionConfig.animationType"
+        :duration="reactiveTransitionConfig.duration"
+        :delay="reactiveTransitionConfig.delay"
+        :easing="reactiveTransitionConfig.easing"
+        custom-class="popup-reactive-transition-target"
+        title="响应式动画探针"
+        closable
+      >
+        <view id="popup-reactive-transition-content" class="popup-content">
+          {{ reactiveTransitionConfig.key }}
+        </view>
+      </lk-popup>
+    </demo-block>
+
     <demo-block title="圆角与自定义圆角">
       <view class="button-row">
         <lk-button type="primary" @click="showPopup2">默认圆角</lk-button>
@@ -201,6 +332,13 @@ const showRight = () => {
     margin-left: 16rpx;
   }
   flex-wrap: wrap;
+}
+
+.reactive-transition-probe {
+  margin-bottom: 16rpx;
+  color: var(--lk-text-secondary);
+  font-size: 26rpx;
+  line-height: 1.5;
 }
 
 .popup-content {

--- a/src/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue
+++ b/src/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue
@@ -7,6 +7,7 @@ import { popupProps, popupEmits } from './popup.props';
 import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition';
 import {
   applyPopupRubberBand,
+  createPopupTransitionConfigSource,
   getPopupInitialOpenTranslateY,
   getPopupMinSnapY,
   getPopupTouchClientY,
@@ -41,12 +42,13 @@ const transitionConfig = computed(() =>
     easing: props.easing,
   })
 );
+const transitionConfigSource = createPopupTransitionConfigSource(() => transitionConfig.value);
 
 const {
   classes: transitionClasses,
   styles: transitionStyles,
   display,
-} = useTransition(() => props.modelValue, transitionConfig.value, {
+} = useTransition(() => props.modelValue, transitionConfigSource, {
   onAfterEnter: () => emit('after-enter'),
   onAfterLeave: () => emit('after-leave'),
 });

--- a/src/uni_modules/lucky-ui/components/lk-popup/popup.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-popup/popup.utils.ts
@@ -3,12 +3,10 @@ import { addUnit } from '../../core/src/utils/unit';
 import {
   ANIMATION_PRESETS,
   type TransitionConfig,
+  type TransitionName,
 } from '@/uni_modules/lucky-ui/composables/useTransition';
 
-export const POPUP_DEFAULT_TRANSITION_BY_POSITION: Record<
-  string,
-  NonNullable<TransitionConfig['name']>
-> = {
+export const POPUP_DEFAULT_TRANSITION_BY_POSITION: Record<string, TransitionName> = {
   center: 'zoom-in',
   top: 'slide-down',
   bottom: 'slide-up',
@@ -31,6 +29,13 @@ export function isPopupBottomDraggable(options: { position: string; draggable: b
   return options.position === 'bottom' && options.draggable;
 }
 
+export interface ResolvedPopupTransitionConfig {
+  name: TransitionName;
+  duration: number;
+  delay?: number;
+  easing: string;
+}
+
 export function resolvePopupTransitionConfig(options: {
   position: string;
   draggable: boolean;
@@ -39,22 +44,22 @@ export function resolvePopupTransitionConfig(options: {
   duration?: number;
   delay?: number;
   easing?: TransitionConfig['easing'];
-}): TransitionConfig {
+}): ResolvedPopupTransitionConfig {
   if (isPopupBottomDraggable(options)) {
     return {
       name: 'fade',
       duration: options.duration ?? 260,
       delay: options.delay,
-      easing: options.easing ?? 'ease-out',
+      easing: (options.easing as string | undefined) ?? 'ease-out',
     };
   }
 
   if (options.animationType) {
     return {
-      name: options.animationType,
+      name: options.animationType as TransitionName,
       duration: options.duration ?? 260,
       delay: options.delay,
-      easing: options.easing ?? 'ease-out',
+      easing: (options.easing as string | undefined) ?? 'ease-out',
     };
   }
 
@@ -64,7 +69,10 @@ export function resolvePopupTransitionConfig(options: {
       name: preset.animation,
       duration: options.duration ?? preset.duration ?? 260,
       delay: options.delay ?? preset.delay,
-      easing: options.easing ?? preset.easing ?? 'ease-out',
+      easing:
+        (options.easing as string | undefined) ??
+        (preset.easing as string | undefined) ??
+        'ease-out',
     };
   }
 
@@ -72,7 +80,22 @@ export function resolvePopupTransitionConfig(options: {
     name: POPUP_DEFAULT_TRANSITION_BY_POSITION[options.position] || 'zoom-in',
     duration: options.duration ?? 260,
     delay: options.delay ?? 0,
-    easing: options.easing ?? 'ease-out',
+    easing: (options.easing as string | undefined) ?? 'ease-out',
+  };
+}
+
+/**
+ * Exposes a resolved Popup transition as field getters so useTransition reads
+ * the latest props whenever it computes classes/styles or starts a new phase.
+ */
+export function createPopupTransitionConfigSource(
+  getConfig: () => ResolvedPopupTransitionConfig
+): TransitionConfig {
+  return {
+    name: () => getConfig().name,
+    duration: () => getConfig().duration,
+    delay: () => getConfig().delay ?? 0,
+    easing: () => getConfig().easing,
   };
 }
 

--- a/tests/unit/lk-popup-reactive-transition.spec.ts
+++ b/tests/unit/lk-popup-reactive-transition.spec.ts
@@ -1,0 +1,314 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import * as VueRuntime from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import * as TransitionModule from '../../src/uni_modules/lucky-ui/composables/useTransition';
+import * as PopupPropsModule from '../../src/uni_modules/lucky-ui/components/lk-popup/popup.props';
+import * as PopupUtilsModule from '../../src/uni_modules/lucky-ui/components/lk-popup/popup.utils';
+
+type HostNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: HostNode[];
+  parent: HostNode | null;
+  text?: string;
+};
+
+type CompilerSfc = {
+  parse: (
+    source: string,
+    options: { filename: string }
+  ) => { descriptor: { template?: { ast?: unknown } }; errors: unknown[] };
+  compileScript: (
+    descriptor: unknown,
+    options: {
+      id: string;
+      inlineTemplate: boolean;
+      templateOptions: { compilerOptions: { isCustomElement: (tag: string) => boolean } };
+    }
+  ) => { content: string };
+};
+
+type Babel = {
+  transformSync: (
+    source: string,
+    options: {
+      babelrc: boolean;
+      configFile: boolean;
+      filename: string;
+      plugins: unknown[];
+    }
+  ) => { code?: string | null } | null;
+};
+
+type CommonJsModule = {
+  exports: Record<string, unknown>;
+};
+
+const popupSfcUrl = new URL(
+  '../../src/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue',
+  import.meta.url
+);
+
+const testRenderer = VueRuntime.createRenderer<HostNode, HostNode>({
+  patchProp(element, key, _previousValue, nextValue) {
+    element.props[key] = nextValue;
+  },
+  insert(child, parent, anchor) {
+    child.parent = parent;
+    const anchorIndex = anchor ? parent.children.indexOf(anchor) : -1;
+    if (anchorIndex === -1) parent.children.push(child);
+    else parent.children.splice(anchorIndex, 0, child);
+  },
+  remove(child) {
+    if (!child.parent) return;
+    const index = child.parent.children.indexOf(child);
+    if (index >= 0) child.parent.children.splice(index, 1);
+    child.parent = null;
+  },
+  createElement(type) {
+    return { type, props: {}, children: [], parent: null };
+  },
+  createText(text) {
+    return { type: 'text', props: {}, children: [], parent: null, text };
+  },
+  createComment(text) {
+    return { type: 'comment', props: {}, children: [], parent: null, text };
+  },
+  setText(node, text) {
+    node.text = text;
+  },
+  setElementText(node, text) {
+    node.text = text;
+    node.children = [];
+  },
+  parentNode(node) {
+    return node.parent;
+  },
+  nextSibling(node) {
+    if (!node.parent) return null;
+    const index = node.parent.children.indexOf(node);
+    return node.parent.children[index + 1] ?? null;
+  },
+});
+
+function compileProductionPopup(): VueRuntime.Component {
+  const localRequire = createRequire(import.meta.url);
+  const uniPluginManifest = localRequire.resolve('@dcloudio/vite-plugin-uni/package.json');
+  const dependencyRequire = createRequire(uniPluginManifest);
+  const compiler = dependencyRequire('@vue/compiler-sfc') as CompilerSfc;
+  const babel = dependencyRequire('@babel/core') as Babel;
+  const typeScriptPlugin = (
+    dependencyRequire('@babel/plugin-transform-typescript') as { default: unknown }
+  ).default;
+  const commonJsPlugin = (
+    dependencyRequire('@babel/plugin-transform-modules-commonjs') as { default: unknown }
+  ).default;
+  const source = readFileSync(popupSfcUrl, 'utf8');
+  const { descriptor, errors } = compiler.parse(source, { filename: popupSfcUrl.pathname });
+
+  if (errors.length > 0) throw new Error(`Failed to parse lk-popup.vue: ${String(errors[0])}`);
+  // The parser's cached template AST predates our custom-element option.
+  if (descriptor.template) descriptor.template.ast = undefined;
+
+  const compiledScript = compiler.compileScript(descriptor, {
+    id: 'lk-popup-reactive-transition-production-wire',
+    inlineTemplate: true,
+    templateOptions: {
+      compilerOptions: {
+        isCustomElement: tag => tag === 'scroll-view',
+      },
+    },
+  });
+  const transformed = babel.transformSync(compiledScript.content, {
+    babelrc: false,
+    configFile: false,
+    filename: 'lk-popup.vue.ts',
+    plugins: [typeScriptPlugin, commonJsPlugin],
+  });
+
+  if (!transformed?.code) throw new Error('Failed to transform compiled lk-popup.vue script');
+
+  const EmptyChild = VueRuntime.defineComponent({ render: () => null });
+  const childModule = { __esModule: true, default: EmptyChild };
+  const requireFromPopup = (request: string): unknown => {
+    if (request === 'vue') return VueRuntime;
+    if (request === './popup.props') return PopupPropsModule;
+    if (request === './popup.utils') return PopupUtilsModule;
+    if (request === '@/uni_modules/lucky-ui/composables/useTransition') return TransitionModule;
+    if (request.endsWith('/lk-overlay.vue') || request.endsWith('/lk-icon.vue')) return childModule;
+    throw new Error(`Unexpected lk-popup.vue import: ${request}`);
+  };
+  const compiledModule: CommonJsModule = { exports: {} };
+  const executeModule = new Function('require', 'module', 'exports', transformed.code);
+  executeModule(requireFromPopup, compiledModule, compiledModule.exports);
+
+  return compiledModule.exports.default as VueRuntime.Component;
+}
+
+function findPopupPanel(node: HostNode): HostNode | undefined {
+  const classes = typeof node.props.class === 'string' ? node.props.class : '';
+  if (classes.split(' ').includes('lk-popup__panel')) return node;
+
+  for (const child of node.children) {
+    const panel = findPopupPanel(child);
+    if (panel) return panel;
+  }
+
+  return undefined;
+}
+
+describe('lk-popup reactive transition production wiring', () => {
+  it('uses seven closed-state prop changes when reopening the same mounted SFC instance', async () => {
+    vi.useFakeTimers();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.stubGlobal('uni', {
+      getSystemInfoSync: () => ({ windowHeight: 844 }),
+    });
+
+    const Popup = compileProductionPopup();
+    const popupRef = VueRuntime.ref<VueRuntime.ComponentPublicInstance>();
+    const props = VueRuntime.reactive({
+      modelValue: false,
+      overlay: false,
+      position: 'bottom',
+      draggable: false,
+      animation: 'bounce' as string | undefined,
+      animationType: 'fade-left' as string | undefined,
+      duration: 180,
+      delay: 0,
+      easing: 'ease-out',
+    });
+    const App = VueRuntime.defineComponent({
+      render: () => VueRuntime.h(Popup, { ...props, ref: popupRef }),
+    });
+    const root: HostNode = { type: 'root', props: {}, children: [], parent: null };
+    const app = testRenderer.createApp(App);
+
+    try {
+      app.mount(root);
+      const mountedInstance = popupRef.value;
+
+      props.modelValue = true;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await VueRuntime.nextTick();
+
+      let panel = findPopupPanel(root);
+      expect(panel?.props.class).toContain('lk-transition-fade-left');
+      expect(panel?.props.style).toMatchObject({
+        transitionDuration: '180ms',
+        transitionTimingFunction: 'ease-out',
+      });
+
+      await vi.advanceTimersByTimeAsync(180);
+      props.modelValue = false;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await vi.advanceTimersByTimeAsync(180);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)).toBeUndefined();
+
+      props.animation = undefined;
+      props.animationType = undefined;
+      await VueRuntime.nextTick();
+
+      props.modelValue = true;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await VueRuntime.nextTick();
+
+      panel = findPopupPanel(root);
+      expect(popupRef.value).toBe(mountedInstance);
+      expect(panel?.props.class).toContain('lk-transition-slide-up');
+      expect(panel?.props.class).toContain('lk-transition-entering');
+
+      await vi.advanceTimersByTimeAsync(179);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).toContain('lk-transition-entering');
+
+      await vi.advanceTimersByTimeAsync(1);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).not.toContain('lk-transition-entering');
+
+      props.modelValue = false;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await vi.advanceTimersByTimeAsync(180);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)).toBeUndefined();
+
+      props.draggable = true;
+      await VueRuntime.nextTick();
+
+      props.modelValue = true;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await VueRuntime.nextTick();
+
+      panel = findPopupPanel(root);
+      expect(popupRef.value).toBe(mountedInstance);
+      expect(panel?.props.class).toContain('lk-transition-fade');
+      expect(panel?.props.class).toContain('lk-transition-entering');
+
+      await vi.advanceTimersByTimeAsync(179);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).toContain('lk-transition-entering');
+
+      await vi.advanceTimersByTimeAsync(1);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).not.toContain('lk-transition-entering');
+
+      props.modelValue = false;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await vi.advanceTimersByTimeAsync(180);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)).toBeUndefined();
+
+      props.position = 'right';
+      props.draggable = false;
+      props.duration = 700;
+      props.delay = 45;
+      props.easing = 'linear';
+      await VueRuntime.nextTick();
+
+      props.modelValue = true;
+      await VueRuntime.nextTick();
+      await VueRuntime.nextTick();
+      await vi.advanceTimersByTimeAsync(16);
+      await VueRuntime.nextTick();
+
+      panel = findPopupPanel(root);
+      expect(popupRef.value).toBe(mountedInstance);
+      expect(panel?.props.class).toContain('lk-transition-slide-right');
+      expect(panel?.props.class).toContain('lk-transition-entering');
+      expect(panel?.props.style).toMatchObject({
+        transitionDuration: '700ms',
+        transitionDelay: '45ms',
+        transitionTimingFunction: 'linear',
+      });
+
+      await vi.advanceTimersByTimeAsync(744);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).toContain('lk-transition-entering');
+
+      await vi.advanceTimersByTimeAsync(1);
+      await VueRuntime.nextTick();
+      expect(findPopupPanel(root)?.props.class).not.toContain('lk-transition-entering');
+      expect(consoleWarn).not.toHaveBeenCalled();
+    } finally {
+      app.unmount();
+      consoleWarn.mockRestore();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(popup): refresh transition props`。
- 保留提交 `c82b7e8e7962` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。