### PR TITLE
fix(preload): preserve queue state invariants

### DIFF
--- a/docs/components/preload.md
+++ b/docs/components/preload.md
@@ -31,10 +31,7 @@ onMounted(() => {
   preloadPage({ path: '/pages_sub/settings/index', priority: PreloadPriority.MEDIUM });
 
   preloadImages(
-    [
-      'https://picsum.photos/420/240?random=11',
-      'https://picsum.photos/420/240?random=12',
-    ],
+    ['https://picsum.photos/420/240?random=11', 'https://picsum.photos/420/240?random=12'],
     PreloadPriority.LOW
   );
 });
@@ -113,15 +110,15 @@ console.log(isPreloaded('settings'));
 
 队列全局配置。
 
-| 参数           | 类型      | 默认值  | 说明                     |
-| -------------- | --------- | ------- | ------------------------ |
-| maxConcurrency | `number`  | `2`     | 最大并发数               |
-| defaultRetries | `number`  | `2`     | 默认重试次数             |
-| retryDelay     | `number`  | `1000`  | 重试延迟（毫秒）         |
-| idleThreshold  | `number`  | `10`    | 空闲时间阈值（毫秒）     |
-| taskTimeout    | `number`  | `30000` | 任务超时时间（毫秒）     |
-| debug          | `boolean` | `false` | 是否启用调试日志         |
-| pauseOnHidden  | `boolean` | `true`  | 页面隐藏时是否暂停预加载 |
+| 参数           | 类型      | 默认值  | 说明                         |
+| -------------- | --------- | ------- | ---------------------------- |
+| maxConcurrency | `number`  | `2`     | 同时执行的底层 executor 上限 |
+| defaultRetries | `number`  | `2`     | 默认重试次数                 |
+| retryDelay     | `number`  | `1000`  | 重试延迟（毫秒）             |
+| idleThreshold  | `number`  | `10`    | 空闲时间阈值（毫秒）         |
+| taskTimeout    | `number`  | `30000` | 逻辑尝试超时时间（毫秒）     |
+| debug          | `boolean` | `false` | 是否启用调试日志             |
+| pauseOnHidden  | `boolean` | `true`  | 页面隐藏时是否暂停预加载     |
 
 ### PreloadPriority
 
@@ -135,15 +132,21 @@ console.log(isPreloaded('settings'));
 
 ### 事件
 
-| 事件            | 说明     |
-| --------------- | -------- |
-| `task:start`    | 任务开始 |
-| `task:complete` | 任务完成 |
-| `task:error`    | 任务失败 |
-| `task:cancel`   | 任务取消 |
-| `queue:empty`   | 队列清空 |
-| `queue:pause`   | 队列暂停 |
-| `queue:resume`  | 队列恢复 |
+| 事件            | 说明                                             |
+| --------------- | ------------------------------------------------ |
+| `task:start`    | 任务开始                                         |
+| `task:complete` | 任务完成                                         |
+| `task:error`    | 任务失败                                         |
+| `task:cancel`   | 任务取消                                         |
+| `queue:change`  | 任一可观察状态迁移；回调中可重新读取原子统计快照 |
+| `queue:empty`   | 逻辑活动任务从非空变为空，每轮任务只触发一次     |
+| `queue:pause`   | 队列暂停                                         |
+| `queue:resume`  | 队列恢复                                         |
+
+`taskTimeout` 会结束当前逻辑尝试，但 JavaScript Promise 本身不可强制中止。若自定义
+`executor` 在超时或取消后仍未 settle，它会继续占用一个物理并发槽，队列不会以启动额外
+executor 的方式突破 `maxConcurrency`。需要立即释放资源的任务应在自身 executor 中实现
+可中止协议，并保证中止后 Promise 尽快 settle。
 
 ## 调试面板（推荐开发环境开启）
 
@@ -231,12 +234,12 @@ manager.addTask({
 
 ## 平台差异
 
-| 功能                | H5  | 微信小程序            | 其他小程序            |
-| ------------------- | --- | --------------------- | --------------------- |
-| requestIdleCallback | ✅  | setTimeout fallback   | setTimeout fallback   |
-| link prefetch       | ✅  | 依运行端能力          | 依运行端能力          |
-| uni.preloadPage     | 依运行端能力 | ✅           | 依运行端能力          |
-| Image 预加载        | ✅  | ✅ (uni.getImageInfo) | ✅ (uni.getImageInfo) |
+| 功能                | H5           | 微信小程序            | 其他小程序            |
+| ------------------- | ------------ | --------------------- | --------------------- |
+| requestIdleCallback | ✅           | setTimeout fallback   | setTimeout fallback   |
+| link prefetch       | ✅           | 依运行端能力          | 依运行端能力          |
+| uni.preloadPage     | 依运行端能力 | ✅                    | 依运行端能力          |
+| Image 预加载        | ✅           | ✅ (uni.getImageInfo) | ✅ (uni.getImageInfo) |
 
 ## 注意事项
 

--- a/src/uni_modules/lucky-ui/components/lk-preload-debugger/lk-preload-debugger.vue
+++ b/src/uni_modules/lucky-ui/components/lk-preload-debugger/lk-preload-debugger.vue
@@ -104,12 +104,10 @@ function handleClear() {
 
 function handleTaskStart(event: Parameters<PreloadEventHandler>[0]) {
   addLog('start', t('taskStart', { resource: event.task?.resource || t('unknown') }));
-  updateStats();
 }
 
 function handleTaskComplete(event: Parameters<PreloadEventHandler>[0]) {
   addLog('complete', t('taskComplete', { resource: event.task?.resource || t('unknown') }));
-  updateStats();
 }
 
 function handleTaskError(event: Parameters<PreloadEventHandler>[0]) {
@@ -120,12 +118,12 @@ function handleTaskError(event: Parameters<PreloadEventHandler>[0]) {
       message: event.error?.message || '',
     })
   );
-  updateStats();
 }
 
 onMounted(() => {
   updateStats();
 
+  manager.on('queue:change', updateStats);
   manager.on('task:start', handleTaskStart);
   manager.on('task:complete', handleTaskComplete);
   manager.on('task:error', handleTaskError);
@@ -134,6 +132,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  manager.off('queue:change', updateStats);
   manager.off('task:start', handleTaskStart);
   manager.off('task:complete', handleTaskComplete);
   manager.off('task:error', handleTaskError);

--- a/src/uni_modules/lucky-ui/core/src/preload/queue.ts
+++ b/src/uni_modules/lucky-ui/core/src/preload/queue.ts
@@ -30,11 +30,23 @@ const DEFAULT_CONFIG: PreloadConfig = {
  */
 export class PreloadQueue {
   private queue: PreloadTask[] = [];
+  private retryingTasks: Map<string, PreloadTask> = new Map();
+  private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private runningTasks: Map<string, PreloadTask> = new Map();
   private completedTasks: Map<string, PreloadTask> = new Map();
+  private taskAttempts: Map<string, number> = new Map();
+  private inFlightAttempts: Map<number, string> = new Map();
+  private attemptTimeouts: Map<number, ReturnType<typeof setTimeout>> = new Map();
+  private attemptSettleTimers: Set<ReturnType<typeof setTimeout>> = new Set();
+  private nextInFlightAttemptId = 0;
+  private generation = 0;
   private config: PreloadConfig;
   private isPaused = false;
   private isProcessing = false;
+  private isProcessingScheduled = false;
+  private processingScheduleVersion = 0;
+  private processingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
+  private emptyEventArmed = false;
   private eventHandlers: Map<PreloadEventType, Set<PreloadEventHandler>> = new Map();
   private idleCallbackId: number | null = null;
   private pageVisible = true;
@@ -54,7 +66,7 @@ export class PreloadQueue {
           if (this.pageVisible) {
             this.scheduleProcessing();
           } else {
-            this.cancelIdleCallback();
+            this.cancelScheduledProcessing();
           }
         }
       });
@@ -106,18 +118,24 @@ export class PreloadQueue {
       maxRetries: task.maxRetries ?? this.config.defaultRetries,
     };
 
-    // 按优先级插入队列
-    const insertIndex = this.queue.findIndex(t => t.priority > newTask.priority);
-    if (insertIndex === -1) {
-      this.queue.push(newTask);
-    } else {
-      this.queue.splice(insertIndex, 0, newTask);
-    }
+    this.enqueueTask(newTask);
+    this.emptyEventArmed = true;
+    this.emitQueueChange(newTask);
 
     this.log('Task added:', newTask.id, newTask.resource);
     this.scheduleProcessing();
 
     return newTask.id;
+  }
+
+  /** 按优先级插入待执行队列 */
+  private enqueueTask(task: PreloadTask): void {
+    const insertIndex = this.queue.findIndex(t => t.priority > task.priority);
+    if (insertIndex === -1) {
+      this.queue.push(task);
+    } else {
+      this.queue.splice(insertIndex, 0, task);
+    }
   }
 
   /** 取消任务 */
@@ -126,18 +144,25 @@ export class PreloadQueue {
     const queueIndex = this.queue.findIndex(t => t.id === taskId);
     if (queueIndex !== -1) {
       const task = this.queue[queueIndex];
-      task.status = PreloadTaskStatus.CANCELLED;
       this.queue.splice(queueIndex, 1);
-      this.completedTasks.set(taskId, task);
-      this.emit('task:cancel', task);
-      this.log('Task cancelled:', taskId);
+      this.completeCancellation(task);
       return true;
     }
 
-    // 标记运行中的任务为已取消（实际取消需要在执行器中处理）
+    const retryingTask = this.retryingTasks.get(taskId);
+    if (retryingTask) {
+      this.retryingTasks.delete(taskId);
+      this.clearRetryTimer(taskId);
+      this.completeCancellation(retryingTask);
+      return true;
+    }
+
+    // 执行器本身可能无法中断，但取消后其旧 attempt 不得再提交状态。
     const runningTask = this.runningTasks.get(taskId);
     if (runningTask) {
-      runningTask.status = PreloadTaskStatus.CANCELLED;
+      this.runningTasks.delete(taskId);
+      this.completeCancellation(runningTask);
+      this.scheduleProcessing();
       return true;
     }
 
@@ -147,7 +172,7 @@ export class PreloadQueue {
   /** 暂停队列处理 */
   pause(): void {
     this.isPaused = true;
-    this.cancelIdleCallback();
+    this.cancelScheduledProcessing();
     this.emit('queue:pause');
     this.log('Queue paused');
   }
@@ -162,12 +187,31 @@ export class PreloadQueue {
 
   /** 清空队列 */
   clear(): void {
-    this.queue.forEach(task => {
-      task.status = PreloadTaskStatus.CANCELLED;
-      this.completedTasks.set(task.id, task);
-    });
+    this.generation++;
+    this.cancelScheduledProcessing();
+    this.retryTimers.forEach(timer => clearTimeout(timer));
+    this.retryTimers.clear();
+
+    const activeTasks = new Map<string, PreloadTask>();
+    this.queue.forEach(task => activeTasks.set(task.id, task));
+    this.retryingTasks.forEach(task => activeTasks.set(task.id, task));
+    this.runningTasks.forEach(task => activeTasks.set(task.id, task));
+
     this.queue = [];
-    this.cancelIdleCallback();
+    this.retryingTasks.clear();
+    this.runningTasks.clear();
+    this.taskAttempts.clear();
+
+    activeTasks.forEach(task => {
+      this.markTaskCancelled(task);
+    });
+
+    this.emitQueueChange();
+    activeTasks.forEach(task => {
+      this.emit('task:cancel', task);
+    });
+    this.maybeEmitQueueEmpty();
+
     this.log('Queue cleared');
   }
 
@@ -184,8 +228,12 @@ export class PreloadQueue {
     });
 
     return {
-      total: this.queue.length + this.runningTasks.size + this.completedTasks.size,
-      pending: this.queue.length,
+      total:
+        this.queue.length +
+        this.retryingTasks.size +
+        this.runningTasks.size +
+        this.completedTasks.size,
+      pending: this.queue.length + this.retryingTasks.size,
       running: this.runningTasks.size,
       completed,
       failed,
@@ -211,23 +259,68 @@ export class PreloadQueue {
 
   /** 取消空闲回调 */
   private cancelIdleCallback(): void {
+    const idleCallbackId = this.idleCallbackId;
+    this.idleCallbackId = null;
+
     // #ifdef H5
     if (
-      this.idleCallbackId !== null &&
+      idleCallbackId !== null &&
       typeof window !== 'undefined' &&
       'cancelIdleCallback' in window
     ) {
       (window as typeof window & { cancelIdleCallback: (id: number) => void }).cancelIdleCallback(
-        this.idleCallbackId
+        idleCallbackId
       );
-      this.idleCallbackId = null;
     }
     // #endif
   }
 
+  /** 取消尚未开始的队列调度，不影响已经执行中的底层 executor */
+  private cancelScheduledProcessing(): void {
+    this.processingScheduleVersion++;
+    this.isProcessingScheduled = false;
+    this.cancelIdleCallback();
+    this.processingTimers.forEach(timer => clearTimeout(timer));
+    this.processingTimers.clear();
+  }
+
+  /** 注册降级调度 timer；源码测试同时保留条件编译分支时也只消费一次 */
+  private scheduleProcessingTimer(version: number, delay: number): void {
+    const timer = setTimeout(() => {
+      this.processingTimers.delete(timer);
+      this.runScheduledQueueProcessing(version);
+    }, delay);
+    this.processingTimers.add(timer);
+  }
+
+  /** 原子消费一次队列调度，并清理同轮残留回调 */
+  private takeProcessingSchedule(version: number): boolean {
+    if (!this.isProcessingScheduled || version !== this.processingScheduleVersion) {
+      return false;
+    }
+
+    this.isProcessingScheduled = false;
+    this.cancelIdleCallback();
+    this.processingTimers.forEach(timer => clearTimeout(timer));
+    this.processingTimers.clear();
+    return true;
+  }
+
+  /** 执行降级/小程序调度回调 */
+  private runScheduledQueueProcessing(version: number): void {
+    if (this.takeProcessingSchedule(version)) {
+      this.processQueue();
+    }
+  }
+
   /** 调度处理（使用 requestIdleCallback 或 setTimeout） */
   private scheduleProcessing(): void {
-    if (this.isPaused || this.isProcessing || this.queue.length === 0) {
+    if (
+      this.isPaused ||
+      this.isProcessing ||
+      this.isProcessingScheduled ||
+      !this.canStartNewTask()
+    ) {
       return;
     }
 
@@ -235,7 +328,8 @@ export class PreloadQueue {
       return;
     }
 
-    this.cancelIdleCallback();
+    this.isProcessingScheduled = true;
+    const version = ++this.processingScheduleVersion;
 
     // #ifdef H5
     if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
@@ -248,18 +342,23 @@ export class PreloadQueue {
         }
       ).requestIdleCallback;
       this.idleCallbackId = ric(
-        deadline => this.processWithDeadline(deadline),
+        deadline => {
+          this.idleCallbackId = null;
+          if (this.takeProcessingSchedule(version)) {
+            this.processWithDeadline(deadline);
+          }
+        },
         { timeout: 5000 } // 最多等待 5 秒
       );
     } else {
       // 降级使用 setTimeout
-      setTimeout(() => this.processQueue(), 0);
+      this.scheduleProcessingTimer(version, 0);
     }
     // #endif
 
     // #ifndef H5
     // 小程序环境使用 setTimeout
-    setTimeout(() => this.processQueue(), 16); // 约一帧的时间
+    this.scheduleProcessingTimer(version, 16); // 约一帧的时间
     // #endif
   }
 
@@ -274,11 +373,9 @@ export class PreloadQueue {
 
     this.isProcessing = false;
 
-    // 如果还有任务，继续调度
-    if (this.queue.length > 0) {
+    // 空闲预算不足但仍有可运行任务时，继续调度。
+    if (this.canStartNewTask()) {
       this.scheduleProcessing();
-    } else if (this.runningTasks.size === 0) {
-      this.emit('queue:empty');
     }
   }
 
@@ -293,66 +390,111 @@ export class PreloadQueue {
 
     this.isProcessing = false;
 
-    // 如果还有任务，继续调度
-    if (this.queue.length > 0) {
+    if (this.canStartNewTask()) {
       this.scheduleProcessing();
-    } else if (this.runningTasks.size === 0) {
-      this.emit('queue:empty');
     }
   }
 
   /** 检查是否可以启动新任务 */
   private canStartNewTask(): boolean {
     return (
-      !this.isPaused && this.queue.length > 0 && this.runningTasks.size < this.config.maxConcurrency
+      !this.isPaused &&
+      this.inFlightAttempts.size < this.config.maxConcurrency &&
+      this.findNextRunnableTaskIndex() !== -1
     );
+  }
+
+  /** 已超时但底层尚未结束的 attempt 仍占槽，且同一任务不得并行重试 */
+  private findNextRunnableTaskIndex(): number {
+    return this.queue.findIndex(task => !this.hasInFlightAttempt(task.id));
+  }
+
+  private hasInFlightAttempt(taskId: string): boolean {
+    return Array.from(this.inFlightAttempts.values()).some(id => id === taskId);
   }
 
   /** 启动下一个任务 */
   private startNextTask(): void {
-    const task = this.queue.shift();
-    if (!task) return;
+    const taskIndex = this.findNextRunnableTaskIndex();
+    if (taskIndex === -1) return;
+
+    const [task] = this.queue.splice(taskIndex, 1);
 
     task.status = PreloadTaskStatus.RUNNING;
     task.startedAt = Date.now();
     this.runningTasks.set(task.id, task);
 
+    const generation = this.generation;
+    const attempt = (this.taskAttempts.get(task.id) ?? 0) + 1;
+    this.taskAttempts.set(task.id, attempt);
+    const inFlightAttemptId = ++this.nextInFlightAttemptId;
+    this.inFlightAttempts.set(inFlightAttemptId, task.id);
+
+    this.emitQueueChange(task);
+
+    if (this.runningTasks.get(task.id) !== task || task.status !== PreloadTaskStatus.RUNNING) {
+      this.releaseInFlightAttempt(inFlightAttemptId);
+      return;
+    }
+
     this.emit('task:start', task);
     this.log('Task started:', task.id, task.resource);
 
-    this.executeTask(task);
+    if (this.runningTasks.get(task.id) !== task || task.status !== PreloadTaskStatus.RUNNING) {
+      this.releaseInFlightAttempt(inFlightAttemptId);
+      return;
+    }
+
+    this.executeTask(task, generation, attempt, inFlightAttemptId);
   }
 
   /** 执行任务 */
-  private async executeTask(task: PreloadTask): Promise<void> {
+  private async executeTask(
+    task: PreloadTask,
+    generation: number,
+    attempt: number,
+    inFlightAttemptId: number
+  ): Promise<void> {
+    let rejectTimeout!: (error: Error) => void;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error(`Task timeout: ${task.id}`)), this.config.taskTimeout);
+      rejectTimeout = reject;
     });
+    const timeoutId = setTimeout(() => {
+      this.attemptTimeouts.delete(inFlightAttemptId);
+      rejectTimeout(new Error(`Task timeout: ${task.id}`));
+    }, this.config.taskTimeout);
+    this.attemptTimeouts.set(inFlightAttemptId, timeoutId);
+
+    let executorPromise: Promise<void>;
+    try {
+      executorPromise = Promise.resolve(
+        task.executor ? task.executor() : this.defaultExecutor(task)
+      );
+    } catch (error) {
+      executorPromise = Promise.reject(error);
+    }
+
+    void executorPromise.then(
+      () => this.releaseInFlightAttempt(inFlightAttemptId),
+      () => this.releaseInFlightAttempt(inFlightAttemptId)
+    );
 
     try {
-      let executor: () => Promise<void>;
+      await Promise.race([executorPromise, timeoutPromise]);
 
-      if (task.executor) {
-        executor = task.executor;
-      } else {
-        // 使用默认执行器
-        executor = () => this.defaultExecutor(task);
-      }
-
-      await Promise.race([executor(), timeoutPromise]);
-
-      // 检查任务是否被取消
-      if (task.status === PreloadTaskStatus.CANCELLED) {
+      if (!this.isCurrentAttempt(task, generation, attempt)) {
         return;
       }
 
       task.status = PreloadTaskStatus.COMPLETED;
       task.completedAt = Date.now();
+      this.finishTask(task);
+      this.emitQueueChange(task);
       this.emit('task:complete', task);
+      this.maybeEmitQueueEmpty();
       this.log('Task completed:', task.id, task.resource);
     } catch (error) {
-      // 检查任务是否被取消
-      if (task.status === PreloadTaskStatus.CANCELLED) {
+      if (!this.isCurrentAttempt(task, generation, attempt)) {
         return;
       }
 
@@ -363,32 +505,142 @@ export class PreloadQueue {
         this.log('Task retrying:', task.id, `(${task.retryCount}/${task.maxRetries})`);
         task.status = PreloadTaskStatus.PENDING;
         this.runningTasks.delete(task.id);
+        this.retryingTasks.set(task.id, task);
 
-        setTimeout(() => {
-          // 重新加入队列（保持优先级）
-          const insertIndex = this.queue.findIndex(t => t.priority > task.priority);
-          if (insertIndex === -1) {
-            this.queue.push(task);
-          } else {
-            this.queue.splice(insertIndex, 0, task);
+        const retryTimer = setTimeout(() => {
+          this.retryTimers.delete(task.id);
+
+          if (
+            generation !== this.generation ||
+            this.retryingTasks.get(task.id) !== task ||
+            task.status !== PreloadTaskStatus.PENDING
+          ) {
+            return;
           }
+
+          this.retryingTasks.delete(task.id);
+          this.enqueueTask(task);
+          this.emitQueueChange(task);
           this.scheduleProcessing();
         }, this.config.retryDelay);
+        this.retryTimers.set(task.id, retryTimer);
+        this.emitQueueChange(task);
 
         return;
       }
 
       task.status = PreloadTaskStatus.FAILED;
       task.completedAt = Date.now();
+      this.finishTask(task);
+      this.emitQueueChange(task);
       this.emit('task:error', task, error as Error);
+      this.maybeEmitQueueEmpty();
       this.log('Task failed:', task.id, error);
     } finally {
-      this.runningTasks.delete(task.id);
-      this.completedTasks.set(task.id, task);
-
-      // 继续处理队列
       this.scheduleProcessing();
     }
+  }
+
+  /** 只有底层 executor 真正 settle 才释放物理并发槽 */
+  private releaseInFlightAttempt(inFlightAttemptId: number): void {
+    if (!this.inFlightAttempts.delete(inFlightAttemptId)) {
+      return;
+    }
+
+    const timeoutId = this.attemptTimeouts.get(inFlightAttemptId);
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      this.attemptTimeouts.delete(inFlightAttemptId);
+    }
+
+    const settleTimer = setTimeout(() => {
+      this.attemptSettleTimers.delete(settleTimer);
+      this.scheduleProcessing();
+    }, 0);
+    this.attemptSettleTimers.add(settleTimer);
+
+    // queue:empty 描述逻辑队列；物理 attempt settle 只释放槽，不产生新的逻辑边沿。
+  }
+
+  /** 当前异步 attempt 是否仍拥有该任务的提交权 */
+  private isCurrentAttempt(task: PreloadTask, generation: number, attempt: number): boolean {
+    return (
+      generation === this.generation &&
+      this.runningTasks.get(task.id) === task &&
+      this.taskAttempts.get(task.id) === attempt &&
+      task.status === PreloadTaskStatus.RUNNING
+    );
+  }
+
+  /** 将终态任务从活动集合原子迁移到完成账本 */
+  private finishTask(task: PreloadTask): void {
+    this.runningTasks.delete(task.id);
+    this.retryingTasks.delete(task.id);
+    this.clearRetryTimer(task.id);
+    this.taskAttempts.delete(task.id);
+    this.completedTasks.set(task.id, task);
+  }
+
+  /** 只写入取消终态；clear 用它先完成整批账本，再发送事件 */
+  private markTaskCancelled(task: PreloadTask): void {
+    task.status = PreloadTaskStatus.CANCELLED;
+    task.completedAt = Date.now();
+    this.taskAttempts.delete(task.id);
+    this.clearAttemptTimeouts(task.id);
+    this.completedTasks.set(task.id, task);
+  }
+
+  /** 取消单个逻辑任务并立即发布完整状态 */
+  private completeCancellation(task: PreloadTask): void {
+    this.markTaskCancelled(task);
+    this.emitQueueChange(task);
+    this.emit('task:cancel', task);
+    this.maybeEmitQueueEmpty();
+    this.log('Task cancelled:', task.id);
+  }
+
+  /** 所有逻辑任务均进入终态才算 empty；未结束 executor 不影响逻辑 empty */
+  private isLogicallyEmpty(): boolean {
+    return this.queue.length === 0 && this.retryingTasks.size === 0 && this.runningTasks.size === 0;
+  }
+
+  /** 非空到空的边沿事件，每轮 workload 最多一次 */
+  private maybeEmitQueueEmpty(): void {
+    if (!this.emptyEventArmed || !this.isLogicallyEmpty()) {
+      return;
+    }
+
+    this.emptyEventArmed = false;
+    this.emit('queue:empty');
+  }
+
+  /** 通知统计消费者重新读取原子快照 */
+  private emitQueueChange(task?: PreloadTask): void {
+    this.emit('queue:change', task);
+  }
+
+  /** 清理指定任务的重试延时 */
+  private clearRetryTimer(taskId: string): void {
+    const timer = this.retryTimers.get(taskId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.retryTimers.delete(taskId);
+    }
+  }
+
+  /** 取消逻辑任务后不再需要 attempt timeout，但底层 executor 仍占物理槽直到 settle */
+  private clearAttemptTimeouts(taskId: string): void {
+    this.inFlightAttempts.forEach((inFlightTaskId, inFlightAttemptId) => {
+      if (inFlightTaskId !== taskId) {
+        return;
+      }
+
+      const timer = this.attemptTimeouts.get(inFlightAttemptId);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        this.attemptTimeouts.delete(inFlightAttemptId);
+      }
+    });
   }
 
   /** 默认执行器 */
@@ -409,7 +661,7 @@ export class PreloadQueue {
 
   /** 获取队列中的所有任务（只读） */
   getTasks(): readonly PreloadTask[] {
-    return [...this.queue];
+    return [...this.queue, ...this.retryingTasks.values()];
   }
 
   /** 获取正在运行的任务（只读） */

--- a/src/uni_modules/lucky-ui/core/src/preload/types.ts
+++ b/src/uni_modules/lucky-ui/core/src/preload/types.ts
@@ -93,6 +93,7 @@ export type PreloadEventType =
   | 'task:complete'
   | 'task:error'
   | 'task:cancel'
+  | 'queue:change'
   | 'queue:empty'
   | 'queue:pause'
   | 'queue:resume';

--- a/src/uni_modules/lucky-ui/core/src/preload/usePreload.ts
+++ b/src/uni_modules/lucky-ui/core/src/preload/usePreload.ts
@@ -85,11 +85,9 @@ export function usePreload(options: UsePreloadOptions = {}): UsePreloadReturn {
   };
 
   onMounted(() => {
-    // 监听内部事件以更新统计
-    manager.on('task:start', internalHandler);
-    manager.on('task:complete', internalHandler);
-    manager.on('task:error', internalHandler);
-    manager.on('task:cancel', internalHandler);
+    // 所有可观测状态迁移统一通过 queue:change 发布原子快照。
+    manager.on('queue:change', internalHandler);
+    updateStats();
 
     // 自动开始预加载
     if (autoStart) {
@@ -100,11 +98,7 @@ export function usePreload(options: UsePreloadOptions = {}): UsePreloadReturn {
   });
 
   onUnmounted(() => {
-    // 清理内部监听
-    manager.off('task:start', internalHandler);
-    manager.off('task:complete', internalHandler);
-    manager.off('task:error', internalHandler);
-    manager.off('task:cancel', internalHandler);
+    manager.off('queue:change', internalHandler);
 
     // 清理用户添加的监听
     eventListeners.forEach(({ event, handler }) => {

--- a/tests/unit/preload-consumers.spec.ts
+++ b/tests/unit/preload-consumers.spec.ts
@@ -1,0 +1,92 @@
+import { createRenderer, defineComponent, nextTick } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePreload } from '../../src/uni_modules/lucky-ui/core/src/preload/usePreload';
+import {
+  getPreloadManager,
+  resetPreloadManager,
+} from '../../src/uni_modules/lucky-ui/core/src/preload/manager';
+import { resetPreloadQueue } from '../../src/uni_modules/lucky-ui/core/src/preload/queue';
+import {
+  PreloadPriority,
+  PreloadResourceType,
+} from '../../src/uni_modules/lucky-ui/core/src/preload/types';
+
+type TestNode = Record<string, unknown>;
+
+const testRenderer = createRenderer<TestNode, TestNode>({
+  patchProp() {},
+  insert() {},
+  remove() {},
+  createElement() {
+    return {};
+  },
+  createText() {
+    return {};
+  },
+  createComment() {
+    return {};
+  },
+  setText() {},
+  setElementText() {},
+  parentNode() {
+    return null;
+  },
+  nextSibling() {
+    return null;
+  },
+});
+
+afterEach(() => {
+  resetPreloadManager();
+  resetPreloadQueue();
+});
+
+describe('preload queue consumers', () => {
+  it('keeps usePreload stats current through one paired queue:change subscription', async () => {
+    const manager = getPreloadManager();
+    manager.pause();
+    const onSpy = vi.spyOn(manager, 'on');
+    const offSpy = vi.spyOn(manager, 'off');
+    let exposed!: ReturnType<typeof usePreload>;
+
+    const App = defineComponent({
+      setup() {
+        exposed = usePreload();
+        return () => null;
+      },
+    });
+    const app = testRenderer.createApp(App);
+    app.mount({});
+
+    manager.addTask({
+      type: PreloadResourceType.CUSTOM,
+      priority: PreloadPriority.MEDIUM,
+      resource: 'paused-resource',
+      maxRetries: 0,
+      executor: () => Promise.resolve(),
+    });
+    await nextTick();
+
+    expect(exposed.stats.value).toMatchObject({ pending: 1, running: 0 });
+    expect(exposed.isLoading.value).toBe(true);
+    expect(onSpy.mock.calls.filter(([event]) => event === 'queue:change')).toHaveLength(1);
+
+    app.unmount();
+    expect(offSpy.mock.calls.filter(([event]) => event === 'queue:change')).toHaveLength(1);
+  });
+
+  it('pairs the preload debugger queue:change subscription statically', async () => {
+    const source = await import('node:fs/promises').then(fs =>
+      fs.readFile(
+        new URL(
+          '../../src/uni_modules/lucky-ui/components/lk-preload-debugger/lk-preload-debugger.vue',
+          import.meta.url
+        ),
+        'utf8'
+      )
+    );
+
+    expect(source.match(/manager\.on\('queue:change', updateStats\)/g)).toHaveLength(1);
+    expect(source.match(/manager\.off\('queue:change', updateStats\)/g)).toHaveLength(1);
+  });
+});

--- a/tests/unit/preload-queue.spec.ts
+++ b/tests/unit/preload-queue.spec.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PreloadQueue,
+  getPreloadQueue,
+  resetPreloadQueue,
+} from '../../src/uni_modules/lucky-ui/core/src/preload/queue';
+import {
+  PreloadPriority,
+  PreloadResourceType,
+  PreloadTaskStatus,
+  type PreloadStats,
+} from '../../src/uni_modules/lucky-ui/core/src/preload/types';
+
+const QUEUE_CONFIG = {
+  maxConcurrency: 1,
+  defaultRetries: 1,
+  retryDelay: 100,
+  idleThreshold: 0,
+  taskTimeout: 10_000,
+  pauseOnHidden: false,
+};
+
+function expectPartition(stats: PreloadStats): void {
+  expect(stats.total).toBe(
+    stats.pending + stats.running + stats.completed + stats.failed + stats.cancelled
+  );
+}
+
+function addTask(queue: PreloadQueue, executor: () => Promise<void>, maxRetries = 1): string {
+  return queue.addTask({
+    type: PreloadResourceType.CUSTOM,
+    priority: PreloadPriority.MEDIUM,
+    resource: 'test-resource',
+    maxRetries,
+    executor,
+  });
+}
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function startScheduledWork(): Promise<void> {
+  // Source contains H5's 0 ms fallback and MP's 16 ms fallback before conditional compilation.
+  await vi.advanceTimersByTimeAsync(16);
+}
+
+describe('PreloadQueue retry state invariants', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetPreloadQueue();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('keeps retry delay in pending without entering the completed ledger', async () => {
+    const executor = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('retry once'))
+      .mockResolvedValueOnce(undefined);
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const completeStats: PreloadStats[] = [];
+    queue.on('task:complete', () => completeStats.push(queue.getStats()));
+
+    addTask(queue, executor);
+    await startScheduledWork();
+
+    const retrying = queue.getStats();
+    expect(retrying).toEqual({
+      total: 1,
+      pending: 1,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+    });
+    expectPartition(retrying);
+    expect(retrying.running > 0 || retrying.pending > 0).toBe(true);
+    expect(queue.getTasks()).toHaveLength(1);
+    expect(queue.getTasks()[0].status).toBe(PreloadTaskStatus.PENDING);
+    expect(executor).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(83);
+    expect(executor).toHaveBeenCalledTimes(1);
+    expectPartition(queue.getStats());
+
+    await vi.advanceTimersByTimeAsync(1);
+    await startScheduledWork();
+    const completed = queue.getStats();
+    expect(completed).toEqual({
+      total: 1,
+      pending: 0,
+      running: 0,
+      completed: 1,
+      failed: 0,
+      cancelled: 0,
+    });
+    expectPartition(completed);
+    expect(completed.running > 0 || completed.pending > 0).toBe(false);
+    expect(executor).toHaveBeenCalledTimes(2);
+    expect(completeStats).toEqual([completed]);
+  });
+
+  it('counts the final failed attempt exactly once', async () => {
+    const executor = vi.fn<() => Promise<void>>().mockRejectedValue(new Error('always fails'));
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const errorStats: PreloadStats[] = [];
+    queue.on('task:error', () => errorStats.push(queue.getStats()));
+
+    addTask(queue, executor);
+    await startScheduledWork();
+    await vi.advanceTimersByTimeAsync(100);
+    await startScheduledWork();
+
+    const failed = queue.getStats();
+    expect(failed).toEqual({
+      total: 1,
+      pending: 0,
+      running: 0,
+      completed: 0,
+      failed: 1,
+      cancelled: 0,
+    });
+    expectPartition(failed);
+    expect(failed.running > 0 || failed.pending > 0).toBe(false);
+    expect(executor).toHaveBeenCalledTimes(2);
+    expect(errorStats).toEqual([failed]);
+  });
+
+  it('cancels a retry wait and never starts another attempt', async () => {
+    const executor = vi.fn<() => Promise<void>>().mockRejectedValue(new Error('retry later'));
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const taskId = addTask(queue, executor);
+
+    await startScheduledWork();
+    expect(queue.getStats().pending).toBe(1);
+    expect(queue.cancelTask(taskId)).toBe(true);
+
+    const cancelled = queue.getStats();
+    expect(cancelled).toEqual({
+      total: 1,
+      pending: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 1,
+    });
+    expectPartition(cancelled);
+    expect(cancelled.running > 0 || cancelled.pending > 0).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(queue.getStats()).toEqual(cancelled);
+  });
+
+  it('prevents an attempt from a reset queue from writing into the fresh generation', async () => {
+    let resolveOld!: () => void;
+    const oldExecutor = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveOld = resolve;
+        })
+    );
+    const oldQueue = getPreloadQueue(QUEUE_CONFIG);
+    addTask(oldQueue, oldExecutor, 0);
+    await startScheduledWork();
+    expect(oldQueue.getStats().running).toBe(1);
+
+    resetPreloadQueue();
+    const freshQueue = getPreloadQueue(QUEUE_CONFIG);
+    const freshExecutor = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    addTask(freshQueue, freshExecutor, 0);
+    await startScheduledWork();
+
+    const freshCompleted = freshQueue.getStats();
+    expect(freshCompleted.completed).toBe(1);
+    expectPartition(freshCompleted);
+
+    resolveOld();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(oldQueue.getStats()).toEqual({
+      total: 1,
+      pending: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 1,
+    });
+    expect(freshQueue.getStats()).toEqual(freshCompleted);
+    expect(freshExecutor).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits queue:empty exactly once per logical non-empty to empty transition', async () => {
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const empty = vi.fn();
+    queue.on('queue:empty', empty);
+
+    addTask(queue, vi.fn<() => Promise<void>>().mockResolvedValue(undefined), 0);
+    await startScheduledWork();
+    await vi.runOnlyPendingTimersAsync();
+    expect(empty).toHaveBeenCalledTimes(1);
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(empty).toHaveBeenCalledTimes(1);
+
+    const queuedId = addTask(queue, vi.fn<() => Promise<void>>().mockResolvedValue(undefined), 0);
+    expect(queue.cancelTask(queuedId)).toBe(true);
+    await vi.runOnlyPendingTimersAsync();
+    expect(empty).toHaveBeenCalledTimes(2);
+
+    queue.pause();
+    addTask(queue, vi.fn<() => Promise<void>>().mockResolvedValue(undefined), 0);
+    queue.clear();
+    await vi.runOnlyPendingTimersAsync();
+    expect(empty).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps a cancelled running executor in the physical concurrency slot until it settles', async () => {
+    const first = deferred();
+    const second = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const firstId = addTask(queue, () => first.promise, 0);
+    addTask(queue, second, 0);
+
+    await startScheduledWork();
+    expect(queue.cancelTask(firstId)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(second).not.toHaveBeenCalled();
+
+    first.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(queue.getStats()).toMatchObject({ completed: 1, cancelled: 1 });
+  });
+
+  it('keeps clear() executors in physical slots before reusing the same queue', async () => {
+    const first = deferred();
+    const second = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    addTask(queue, () => first.promise, 0);
+
+    await startScheduledWork();
+    queue.clear();
+    addTask(queue, second, 0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(second).not.toHaveBeenCalled();
+
+    first.resolve();
+    await vi.runOnlyPendingTimersAsync();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not release a timed-out executor slot until the underlying promise settles', async () => {
+    const first = deferred();
+    const second = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const queue = new PreloadQueue({ ...QUEUE_CONFIG, taskTimeout: 50 });
+    addTask(queue, () => first.promise, 0);
+    addTask(queue, second, 0);
+
+    await startScheduledWork();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(queue.getStats()).toMatchObject({ failed: 1, pending: 1, running: 0 });
+    expect(second).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(second).not.toHaveBeenCalled();
+    first.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(16);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the timed-out attempt to settle before starting its retry', async () => {
+    const first = deferred();
+    const retry = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const executor = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(retry);
+    const queue = new PreloadQueue({ ...QUEUE_CONFIG, taskTimeout: 50 });
+    addTask(queue, executor);
+
+    await startScheduledWork();
+    await vi.advanceTimersByTimeAsync(150);
+    expect(queue.getStats()).toMatchObject({ pending: 1, running: 0 });
+    expect(executor).toHaveBeenCalledTimes(1);
+
+    first.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(16);
+    expect(executor).toHaveBeenCalledTimes(2);
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(queue.getStats()).toMatchObject({ completed: 1, pending: 0, running: 0 });
+  });
+
+  it('publishes atomic queue:change snapshots for paused add and retry wait', async () => {
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const snapshots: PreloadStats[] = [];
+    queue.on('queue:change', () => snapshots.push(queue.getStats()));
+    queue.pause();
+
+    addTask(queue, vi.fn<() => Promise<void>>().mockRejectedValue(new Error('retry')));
+    expect(snapshots.at(-1)).toMatchObject({ pending: 1, running: 0 });
+
+    queue.resume();
+    await startScheduledWork();
+    expect(snapshots).toContainEqual({
+      total: 1,
+      pending: 1,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+    });
+  });
+
+  it('writes the complete cancellation ledger before clear emits task:cancel', () => {
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const snapshots: PreloadStats[] = [];
+    queue.pause();
+    addTask(queue, vi.fn<() => Promise<void>>().mockResolvedValue(undefined), 0);
+    addTask(queue, vi.fn<() => Promise<void>>().mockResolvedValue(undefined), 0);
+    queue.on('task:cancel', () => snapshots.push(queue.getStats()));
+
+    queue.clear();
+
+    expect(snapshots).toEqual([
+      { total: 2, pending: 0, running: 0, completed: 0, failed: 0, cancelled: 2 },
+      { total: 2, pending: 0, running: 0, completed: 0, failed: 0, cancelled: 2 },
+    ]);
+  });
+
+  it('cleans retry and scheduling timers when retry wait is cancelled', async () => {
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const taskId = addTask(
+      queue,
+      vi.fn<() => Promise<void>>().mockRejectedValue(new Error('retry'))
+    );
+
+    await startScheduledWork();
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    queue.cancelTask(taskId);
+    await vi.runOnlyPendingTimersAsync();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps queue:change reentrant cancellation ordered and timer-free', async () => {
+    const queue = new PreloadQueue(QUEUE_CONFIG);
+    const events: string[] = [];
+    let taskId = '';
+    let changeCount = 0;
+    queue.on('queue:change', () => {
+      changeCount++;
+      if (taskId && changeCount === 3) {
+        queue.cancelTask(taskId);
+      }
+    });
+    queue.on('task:start', () => events.push('start'));
+    queue.on('task:cancel', () => events.push('cancel'));
+
+    taskId = addTask(queue, vi.fn<() => Promise<void>>().mockRejectedValue(new Error('retry')));
+    await startScheduledWork();
+
+    expect(events).toEqual(['start', 'cancel']);
+    expect(queue.getStats()).toMatchObject({ pending: 0, running: 0, cancelled: 1 });
+    await vi.runOnlyPendingTimersAsync();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(preload): preserve queue state invariants`。
- 保留提交 `a4961783c209` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。