### PR TITLE
fix(skeleton): preserve host across loading

### DIFF
--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -51,12 +51,14 @@ phone: skeleton
 ## 作为内容占位容器
 
 当 `loading` 为 `false` 时，组件会渲染默认插槽内容。这是最推荐的业务接入方式。
+组件始终保留同一个可视宿主；切换前后 `id`、`customClass` 与 `customStyle`
+不会丢失，也不会额外增加或移除一层宿主包装。
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const loading = ref(true)
+const loading = ref(true);
 </script>
 
 <template>
@@ -82,7 +84,7 @@ const loading = ref(true)
 
 ```vue
 <script setup lang="ts">
-import SkeletonDemo from '@/components/demos/skeleton-demo.vue'
+import SkeletonDemo from '@/components/demos/skeleton-demo.vue';
 </script>
 
 <template>
@@ -104,23 +106,24 @@ import SkeletonDemo from '@/components/demos/skeleton-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| customClass | 组件可视根节点自定义类名 | `string \| object \| array` | `''` |
-| customStyle | 组件可视根节点自定义样式 | `string \| object` | `''` |
-| loading | 是否显示骨架；为 `false` 时渲染默认插槽 | `boolean` | `true` |
-| avatar | 是否显示头像占位 | `boolean` | `false` |
-| avatarSize | 头像尺寸 | `string` | `'72rpx'` |
-| title | 是否显示标题占位 | `boolean` | `false` |
-| titleWidth | 标题宽度 | `string` | `'40%'` |
-| titleHeight | 标题高度 | `string` | `'32rpx'` |
-| rows | 内容占位行数 | `number` | `3` |
-| rowWidth | 每行宽度；可传单值或数组 | `string \| string[]` | `'100%'` |
-| rowHeight | 每行高度；可传单值或数组 | `string \| string[]` | `'32rpx'` |
-| animated | 是否开启动画 | `boolean` | `true` |
-| round | 是否使用圆角风格 | `boolean` | `false` |
-| duration | 动画时长（秒或时间字符串） | `number \| string` | `2.4` |
-| easing | 动画缓动函数 | `string` | `'ease-in-out'` |
+| 参数        | 说明                                    | 类型                        | 默认值          |
+| ----------- | --------------------------------------- | --------------------------- | --------------- |
+| id          | 稳定宿主节点 id，加载前后保持不变       | `string`                    | `''`            |
+| customClass | 组件可视根节点自定义类名                | `string \| object \| array` | `''`            |
+| customStyle | 组件可视根节点自定义样式                | `string \| object`          | `''`            |
+| loading     | 是否显示骨架；为 `false` 时渲染默认插槽 | `boolean`                   | `true`          |
+| avatar      | 是否显示头像占位                        | `boolean`                   | `false`         |
+| avatarSize  | 头像尺寸                                | `string`                    | `'72rpx'`       |
+| title       | 是否显示标题占位                        | `boolean`                   | `false`         |
+| titleWidth  | 标题宽度                                | `string`                    | `'40%'`         |
+| titleHeight | 标题高度                                | `string`                    | `'32rpx'`       |
+| rows        | 内容占位行数                            | `number`                    | `3`             |
+| rowWidth    | 每行宽度；可传单值或数组                | `string \| string[]`        | `'100%'`        |
+| rowHeight   | 每行高度；可传单值或数组                | `string \| string[]`        | `'32rpx'`       |
+| animated    | 是否开启动画                            | `boolean`                   | `true`          |
+| round       | 是否使用圆角风格                        | `boolean`                   | `false`         |
+| duration    | 动画时长（秒或时间字符串）              | `number \| string`          | `2.4`           |
+| easing      | 动画缓动函数                            | `string`                    | `'ease-in-out'` |
 
 ### Events
 
@@ -128,8 +131,8 @@ import SkeletonDemo from '@/components/demos/skeleton-demo.vue'
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
+| 插槽名  | 说明                                     |
+| ------- | ---------------------------------------- |
 | default | 当 `loading` 为 `false` 时显示的真实内容 |
 
 ## 使用建议
@@ -141,3 +144,17 @@ import SkeletonDemo from '@/components/demos/skeleton-demo.vue'
 ::: warning
 如果你只是想表达“正在处理中”，优先使用 `lk-loading`；如果要模拟页面结构，优先使用 `lk-skeleton`。
 :::
+
+## Peekit 验收合同
+
+Demo 提供 `#skeleton-stable-host-fixture`、`#skeleton-stable-host`、
+`#skeleton-stable-content` 与 `#skeleton-stable-host-toggle`。H5 与微信小程序需分别执行：
+
+1. 初始读取 `#skeleton-stable-host` 的 id、class、style、rect 和直接子节点数量。
+2. 点击切换按钮，确认 fixture 的 `data-loading` 从 `true` 变为 `false`，同一个
+   `#skeleton-stable-host` 仍存在，`skeleton-stable-host-probe` 与 `grid-area: content`
+   保持，且内部出现 `#skeleton-stable-content`。
+3. 再次切回 loading，宿主仍存在且 rect 中没有非有限值；全程 console/runtime error 为 0。
+
+构建成功或只看到 WXML 条件分支不能代替运行态；截图只能辅助检查布局，不能代替
+节点身份、属性和几何断言。

--- a/src/components/demos/skeleton-demo.vue
+++ b/src/components/demos/skeleton-demo.vue
@@ -7,9 +7,15 @@ import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 
 const loading = ref(true);
+const stableHostLoading = ref(true);
+const stableHostStyle = { display: 'grid', gridArea: 'content' };
 
 const toggleLoading = () => {
   loading.value = !loading.value;
+};
+
+const toggleStableHost = () => {
+  stableHostLoading.value = !stableHostLoading.value;
 };
 </script>
 
@@ -65,6 +71,31 @@ const toggleLoading = () => {
         {{ loading ? '加载完成' : '重新加载' }}
       </lk-button>
     </demo-block>
+
+    <demo-block title="稳定宿主">
+      <view
+        id="skeleton-stable-host-fixture"
+        class="skeleton-stable-layout"
+        :data-loading="stableHostLoading ? 'true' : 'false'"
+      >
+        <lk-skeleton
+          id="skeleton-stable-host"
+          :loading="stableHostLoading"
+          avatar
+          title
+          :rows="2"
+          custom-class="skeleton-stable-host-probe"
+          :custom-style="stableHostStyle"
+        >
+          <view id="skeleton-stable-content" class="skeleton-stable-content">
+            已加载的确定性内容
+          </view>
+        </lk-skeleton>
+      </view>
+      <lk-button id="skeleton-stable-host-toggle" type="primary" @click="toggleStableHost">
+        {{ stableHostLoading ? '显示真实内容' : '显示骨架' }}
+      </lk-button>
+    </demo-block>
   </view>
 </template>
 <style scoped lang="scss">
@@ -114,5 +145,18 @@ const toggleLoading = () => {
   font-size: 28rpx;
   color: var(--lk-text-primary);
   line-height: 1.6;
+}
+
+.skeleton-stable-layout {
+  display: grid;
+  grid-template-areas: 'content';
+}
+
+.skeleton-stable-content {
+  padding: 24rpx;
+  border-radius: var(--lk-radius-md);
+  background: var(--lk-bg-page);
+  color: var(--lk-text-primary);
+  font-size: 28rpx;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-skeleton/lk-skeleton.scss
+++ b/src/uni_modules/lucky-ui/components/lk-skeleton/lk-skeleton.scss
@@ -22,8 +22,10 @@
   --lk-skel-base: var(--lk-skeleton-start);
   --lk-skel-highlight: var(--lk-skeleton-end);
 
-  display: flex;
-  align-items: flex-start;
+  @include e(body) {
+    display: flex;
+    align-items: flex-start;
+  }
 
   @include e(avatar) {
     margin-right: var(--lk-spacing-sm);

--- a/src/uni_modules/lucky-ui/components/lk-skeleton/lk-skeleton.vue
+++ b/src/uni_modules/lucky-ui/components/lk-skeleton/lk-skeleton.vue
@@ -38,32 +38,32 @@ const animatedClass = computed(() => resolveSkeletonAnimatedClass(props.animated
 </script>
 
 <template>
-  <view v-if="loading" :class="rootClass" :style="hostStyle">
-    <view
-      v-if="avatar"
-      class="lk-skeleton__avatar"
-      :class="animatedClass"
-      :style="avatarStyle"
-    ></view>
-    <view class="lk-skeleton__content">
-      <view v-if="title" class="lk-skeleton__title" :class="animatedClass" :style="titleStyle" />
+  <view :id="id" :class="rootClass" :style="hostStyle">
+    <view v-if="loading" class="lk-skeleton__body">
       <view
-        v-for="rowIndex in rows"
-        :key="rowIndex"
-        class="lk-skeleton__row"
-        :style="
-          resolveSkeletonRowStyle({
-            rowWidth,
-            rowHeight,
-            index: rowIndex - 1,
-          })
-        "
+        v-if="avatar"
+        class="lk-skeleton__avatar"
         :class="animatedClass"
-      />
+        :style="avatarStyle"
+      ></view>
+      <view class="lk-skeleton__content">
+        <view v-if="title" class="lk-skeleton__title" :class="animatedClass" :style="titleStyle" />
+        <view
+          v-for="rowIndex in rows"
+          :key="rowIndex"
+          class="lk-skeleton__row"
+          :style="
+            resolveSkeletonRowStyle({
+              rowWidth,
+              rowHeight,
+              index: rowIndex - 1,
+            })
+          "
+          :class="animatedClass"
+        />
+      </view>
     </view>
-  </view>
-  <view v-else>
-    <slot />
+    <slot v-else />
   </view>
 </template>
 

--- a/tests/unit/lk-skeleton.spec.ts
+++ b/tests/unit/lk-skeleton.spec.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import {
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import * as VueRuntime from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import * as SkeletonPropsModule from '../../src/uni_modules/lucky-ui/components/lk-skeleton/skeleton.props';
+import * as SkeletonUtilsModule from '../../src/uni_modules/lucky-ui/components/lk-skeleton/skeleton.utils';
+
+const {
   resolveSkeletonAnimatedClass,
   resolveSkeletonAvatarStyle,
   resolveSkeletonHostStyle,
@@ -7,9 +16,238 @@ import {
   resolveSkeletonRowStyle,
   resolveSkeletonRootClass,
   resolveSkeletonTitleStyle,
-} from '../../src/uni_modules/lucky-ui/components/lk-skeleton/skeleton.utils';
+} = SkeletonUtilsModule;
+
+type HostNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: HostNode[];
+  parent: HostNode | null;
+  text?: string;
+};
+
+type CompilerSfc = {
+  parse: (
+    source: string,
+    options: { filename: string }
+  ) => { descriptor: unknown; errors: unknown[] };
+  compileScript: (
+    descriptor: unknown,
+    options: {
+      id: string;
+      inlineTemplate: boolean;
+      templateOptions: { compilerOptions: { isCustomElement: (tag: string) => boolean } };
+    }
+  ) => { content: string };
+};
+
+type Babel = {
+  transformSync: (
+    source: string,
+    options: {
+      babelrc: boolean;
+      configFile: boolean;
+      filename: string;
+      plugins: unknown[];
+    }
+  ) => { code?: string | null } | null;
+};
+
+type CommonJsModule = { exports: Record<string, unknown> };
+
+const nodeRequire = createRequire(import.meta.url);
+const skeletonSfcUrl = new URL(
+  '../../src/uni_modules/lucky-ui/components/lk-skeleton/lk-skeleton.vue',
+  import.meta.url
+);
+const skeletonRenderer = VueRuntime.createRenderer<HostNode, HostNode>({
+  patchProp(element, key, _previousValue, nextValue) {
+    element.props[key] = nextValue;
+  },
+  insert(child, parent, anchor) {
+    child.parent = parent;
+    const anchorIndex = anchor ? parent.children.indexOf(anchor) : -1;
+    if (anchorIndex === -1) parent.children.push(child);
+    else parent.children.splice(anchorIndex, 0, child);
+  },
+  remove(child) {
+    if (!child.parent) return;
+    const index = child.parent.children.indexOf(child);
+    if (index >= 0) child.parent.children.splice(index, 1);
+    child.parent = null;
+  },
+  createElement(type) {
+    return { type, props: {}, children: [], parent: null };
+  },
+  createText(text) {
+    return { type: 'text', props: {}, children: [], parent: null, text };
+  },
+  createComment(text) {
+    return { type: 'comment', props: {}, children: [], parent: null, text };
+  },
+  setText(node, text) {
+    node.text = text;
+  },
+  setElementText(node, text) {
+    node.text = text;
+    node.children = [];
+  },
+  parentNode(node) {
+    return node.parent;
+  },
+  nextSibling(node) {
+    if (!node.parent) return null;
+    const index = node.parent.children.indexOf(node);
+    return node.parent.children[index + 1] ?? null;
+  },
+});
+
+function compileProductionSkeleton(): VueRuntime.Component {
+  const uniPluginManifest = nodeRequire.resolve('@dcloudio/vite-plugin-uni/package.json');
+  const dependencyRequire = createRequire(uniPluginManifest);
+  const compiler = dependencyRequire('@vue/compiler-sfc') as CompilerSfc;
+  const babel = dependencyRequire('@babel/core') as Babel;
+  const typeScriptPlugin = (
+    dependencyRequire('@babel/plugin-transform-typescript') as { default: unknown }
+  ).default;
+  const commonJsPlugin = (
+    dependencyRequire('@babel/plugin-transform-modules-commonjs') as { default: unknown }
+  ).default;
+  const source = readFileSync(skeletonSfcUrl, 'utf8');
+  const { descriptor, errors } = compiler.parse(source, { filename: skeletonSfcUrl.pathname });
+
+  if (errors.length > 0) throw new Error(`Failed to parse lk-skeleton.vue: ${String(errors[0])}`);
+
+  const compiled = compiler.compileScript(descriptor, {
+    id: 'lk-skeleton-stable-host-production-wire',
+    inlineTemplate: true,
+    templateOptions: { compilerOptions: { isCustomElement: tag => tag === 'view' } },
+  });
+  const transformed = babel.transformSync(compiled.content, {
+    babelrc: false,
+    configFile: false,
+    filename: 'lk-skeleton.vue.ts',
+    plugins: [typeScriptPlugin, commonJsPlugin],
+  });
+
+  if (!transformed?.code) throw new Error('Failed to transform compiled lk-skeleton.vue');
+
+  const requireFromSkeleton = (request: string): unknown => {
+    if (request === 'vue') return VueRuntime;
+    if (request === './skeleton.props') return SkeletonPropsModule;
+    if (request === './skeleton.utils') return SkeletonUtilsModule;
+    throw new Error(`Unexpected lk-skeleton.vue import: ${request}`);
+  };
+  const compiledModule: CommonJsModule = { exports: {} };
+  const executeModule = new Function('require', 'module', 'exports', transformed.code);
+  executeModule(requireFromSkeleton, compiledModule, compiledModule.exports);
+  return compiledModule.exports.default as VueRuntime.Component;
+}
+
+function findById(node: HostNode, id: string): HostNode | undefined {
+  if (node.props.id === id) return node;
+  for (const child of node.children) {
+    const match = findById(child, id);
+    if (match) return match;
+  }
+  return undefined;
+}
 
 describe('lk-skeleton display rules', () => {
+  it('keeps the production SFC host identity and BaseProps across loading changes', async () => {
+    const Skeleton = compileProductionSkeleton();
+    const loading = VueRuntime.ref(true);
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const App = VueRuntime.defineComponent({
+      render: () =>
+        VueRuntime.h(
+          Skeleton,
+          {
+            id: 'stable-skeleton',
+            loading: loading.value,
+            avatar: true,
+            title: true,
+            customClass: 'audit-skeleton',
+            customStyle: { gridArea: 'content', display: 'grid' },
+          },
+          {
+            default: () =>
+              VueRuntime.h('view', { id: 'stable-skeleton-content' }, 'loaded content'),
+          }
+        ),
+    });
+    const root: HostNode = { type: 'root', props: {}, children: [], parent: null };
+    const app = skeletonRenderer.createApp(App);
+
+    try {
+      app.mount(root);
+      const loadingHost = findById(root, 'stable-skeleton');
+      expect(loadingHost).toBeTruthy();
+      expect(String(loadingHost?.props.class)).toContain('audit-skeleton');
+      expect(loadingHost?.props.style).toMatchObject({
+        display: 'grid',
+        gridArea: 'content',
+      });
+      expect(findById(root, 'stable-skeleton-content')).toBeUndefined();
+
+      loading.value = false;
+      await VueRuntime.nextTick();
+      const loadedHost = findById(root, 'stable-skeleton');
+      expect(loadedHost).toBe(loadingHost);
+      expect(String(loadedHost?.props.class)).toContain('audit-skeleton');
+      expect(loadedHost?.props.style).toMatchObject({
+        display: 'grid',
+        gridArea: 'content',
+      });
+      const loadedContent = findById(root, 'stable-skeleton-content');
+      expect(loadedContent).toBeTruthy();
+      expect(loadedContent?.parent).toBe(loadedHost);
+      expect(loadedHost?.children.filter(child => child.type === 'view')).toHaveLength(1);
+
+      loading.value = true;
+      await VueRuntime.nextTick();
+      expect(findById(root, 'stable-skeleton')).toBe(loadingHost);
+      expect(findById(root, 'stable-skeleton-content')).toBeUndefined();
+      expect(warning).not.toHaveBeenCalled();
+    } finally {
+      app.unmount();
+      warning.mockRestore();
+    }
+  });
+
+  it('compiles one stable WeChat host around both loading branches', () => {
+    const uniBin = nodeRequire.resolve('@dcloudio/vite-plugin-uni/bin/uni.js');
+    const temporaryParent = resolve(tmpdir());
+    const outputDirectory = mkdtempSync(join(temporaryParent, 'lucky-ui-skeleton-host-mp-'));
+    const componentDirectory = join(outputDirectory, 'uni_modules/lucky-ui/components/lk-skeleton');
+    const wxmlPath = join(componentDirectory, 'lk-skeleton.wxml');
+
+    expect(dirname(outputDirectory)).toBe(temporaryParent);
+    expect(existsSync(wxmlPath)).toBe(false);
+
+    try {
+      execFileSync(process.execPath, [uniBin, 'build', '-p', 'mp-weixin'], {
+        cwd: process.cwd(),
+        env: { ...process.env, NODE_ENV: 'production', UNI_OUTPUT_DIR: outputDirectory },
+        stdio: 'pipe',
+      });
+      const wxml = readFileSync(wxmlPath, 'utf8');
+      const stableHost = wxml.match(
+        /^<view id="\{\{[A-Za-z_$][\w$]*\}\}" class="\{\{[A-Za-z_$][\w$]*\}\}" style="\{\{[A-Za-z_$][\w$]*\}\}">([\s\S]*)<\/view>$/
+      );
+
+      expect(stableHost).toBeTruthy();
+      expect(wxml.match(/\bid=/g)).toHaveLength(1);
+      expect(stableHost?.[1]).toMatch(
+        /^<view wx:if="\{\{[A-Za-z_$][\w$]*\}\}" class="lk-skeleton__body">[\s\S]*<\/view><slot wx:else\/>$/
+      );
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+
+    expect(existsSync(outputDirectory)).toBe(false);
+  }, 60_000);
+
   it('resolves indexed width and height values with last item fallback', () => {
     expect(resolveSkeletonIndexedValue(['40%', '80%'], 0, '100%')).toBe('40%');
     expect(resolveSkeletonIndexedValue(['40%', '80%'], 3, '100%')).toBe('80%');
@@ -18,54 +256,67 @@ describe('lk-skeleton display rules', () => {
   });
 
   it('builds host animation variables', () => {
-    expect(resolveSkeletonHostStyle({
-      duration: 2.4,
-      easing: 'ease-in-out',
-      customStyle: { marginTop: '8rpx' },
-    })).toEqual([{
-      '--lk-skel-duration': '2.4s',
-      '--lk-skel-ease': 'ease-in-out',
-    }, { marginTop: '8rpx' }]);
-
-    expect(resolveSkeletonHostStyle({
-      duration: '',
-      easing: 'linear',
-    })).toEqual([{
-      '--lk-skel-duration': '1.8s',
-      '--lk-skel-ease': 'linear',
-    }, '']);
-
-    expect(resolveSkeletonRootClass('custom-skeleton')).toEqual([
-      'lk-skeleton',
-      'custom-skeleton',
+    expect(
+      resolveSkeletonHostStyle({
+        duration: 2.4,
+        easing: 'ease-in-out',
+        customStyle: { marginTop: '8rpx' },
+      })
+    ).toEqual([
+      {
+        '--lk-skel-duration': '2.4s',
+        '--lk-skel-ease': 'ease-in-out',
+      },
+      { marginTop: '8rpx' },
     ]);
+
+    expect(
+      resolveSkeletonHostStyle({
+        duration: '',
+        easing: 'linear',
+      })
+    ).toEqual([
+      {
+        '--lk-skel-duration': '1.8s',
+        '--lk-skel-ease': 'linear',
+      },
+      '',
+    ]);
+
+    expect(resolveSkeletonRootClass('custom-skeleton')).toEqual(['lk-skeleton', 'custom-skeleton']);
   });
 
   it('builds avatar and title styles', () => {
-    expect(resolveSkeletonAvatarStyle({
-      avatarSize: '72rpx',
-      round: true,
-    })).toEqual({
+    expect(
+      resolveSkeletonAvatarStyle({
+        avatarSize: '72rpx',
+        round: true,
+      })
+    ).toEqual({
       width: '72rpx',
       height: '72rpx',
       borderRadius: '50%',
     });
 
-    expect(resolveSkeletonTitleStyle({
-      titleWidth: '40%',
-      titleHeight: '32rpx',
-    })).toEqual({
+    expect(
+      resolveSkeletonTitleStyle({
+        titleWidth: '40%',
+        titleHeight: '32rpx',
+      })
+    ).toEqual({
       width: '40%',
       height: '32rpx',
     });
   });
 
   it('builds row style and animation class', () => {
-    expect(resolveSkeletonRowStyle({
-      rowWidth: ['100%', '60%'],
-      rowHeight: '32rpx',
-      index: 2,
-    })).toEqual({
+    expect(
+      resolveSkeletonRowStyle({
+        rowWidth: ['100%', '60%'],
+        rowHeight: '32rpx',
+        index: 2,
+      })
+    ).toEqual({
       width: '60%',
       height: '32rpx',
     });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(skeleton): preserve host across loading`。
- 保留提交 `3d4fa4b87ca6` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。