### PR TITLE
fix(theme): isolate native select reset

### DIFF
--- a/src/components/demos/root-demo.vue
+++ b/src/components/demos/root-demo.vue
@@ -17,6 +17,27 @@ function showToast() {
     <demo-block title="Toast 宿主">
       <lk-button block @click="showToast">显示 Toast</lk-button>
     </demo-block>
+
+    <!-- #ifdef H5 -->
+    <demo-block title="H5 native select reset">
+      <view
+        id="theme-select-reset-fixture"
+        class="theme-select-reset-fixture"
+        data-expected-font-family="Courier New"
+        data-expected-font-size="19px"
+      >
+        <text id="theme-select-reset-reference">Inherited font reference</text>
+        <select
+          id="theme-select-reset-probe"
+          class="theme-select-reset-probe"
+          aria-label="Theme select reset probe"
+          data-reset-contract="font-inherit"
+        >
+          <option>Inherited font select</option>
+        </select>
+      </view>
+    </demo-block>
+    <!-- #endif -->
   </lk-root>
 </template>
 
@@ -30,4 +51,30 @@ function showToast() {
 .root-demo {
   --lk-demo-block-self-gap: 0;
 }
+
+/* #ifdef H5 */
+.theme-select-reset-fixture {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  color: var(--lk-text-primary);
+  font-family: 'Courier New', monospace;
+  font-size: 19px;
+  font-style: italic;
+  font-weight: 700;
+  line-height: 29px;
+  background: var(--lk-fill-1);
+  border-radius: var(--lk-radius-sm);
+}
+
+.theme-select-reset-probe {
+  width: 100%;
+  padding: 8px 12px;
+  color: inherit;
+  background: var(--lk-bg-container);
+  border: 1px solid var(--lk-color-border);
+  border-radius: var(--lk-radius-xs);
+}
+/* #endif */
 </style>

--- a/src/uni_modules/lucky-ui/theme/src/base/_reset.scss
+++ b/src/uni_modules/lucky-ui/theme/src/base/_reset.scss
@@ -27,10 +27,15 @@ image {
 
 button,
 input,
-textarea,
+textarea {
+  font: inherit;
+}
+
+/* #ifdef H5 */
 select {
   font: inherit;
 }
+/* #endif */
 
 page,
 view,

--- a/tests/unit/theme-base-styles.spec.ts
+++ b/tests/unit/theme-base-styles.spec.ts
@@ -1,21 +1,28 @@
 import path from 'node:path';
+import { initPreContext, preCss } from '@dcloudio/uni-cli-shared/dist/preprocess';
 import postcss from 'postcss';
 import * as sass from 'sass';
 import { describe, expect, it } from 'vitest';
 
 const THEME_ENTRY = path.join(process.cwd(), 'src/uni_modules/lucky-ui/theme/src/index.scss');
+type ThemePlatform = 'h5' | 'mp-weixin';
 
 function compileThemeCss(): string {
   return sass.compile(THEME_ENTRY, { style: 'expanded' }).css;
 }
 
-function colorDeclarationsForSelector(css: string, selector: string): string[] {
+function compileThemeCssForPlatform(platform: ThemePlatform): string {
+  initPreContext(platform);
+  return preCss(compileThemeCss()) as string;
+}
+
+function declarationsForSelector(css: string, selector: string, property: string): string[] {
   const values: string[] = [];
 
   postcss.parse(css).walkRules(rule => {
     if (!rule.selectors.map(item => item.trim()).includes(selector)) return;
 
-    rule.walkDecls('color', declaration => {
+    rule.walkDecls(property, declaration => {
       values.push(declaration.value);
     });
   });
@@ -37,9 +44,9 @@ describe('theme base styles', () => {
   it('defines the default text color on page without overriding descendant inheritance', () => {
     const css = compileThemeCss();
 
-    expect(colorDeclarationsForSelector(css, 'page')).toContain('var(--lk-text-primary)');
-    expect(colorDeclarationsForSelector(css, 'view')).toEqual([]);
-    expect(colorDeclarationsForSelector(css, 'text')).toEqual([]);
+    expect(declarationsForSelector(css, 'page', 'color')).toContain('var(--lk-text-primary)');
+    expect(declarationsForSelector(css, 'view', 'color')).toEqual([]);
+    expect(declarationsForSelector(css, 'text', 'color')).toEqual([]);
   });
 
   it('includes cross-platform theme transition rules in the public entry', () => {
@@ -48,5 +55,18 @@ describe('theme base styles', () => {
     expect(selectors).toContain('.lk-theme-transition');
     expect(selectors).toContain('.lk-theme-switching *');
     expect(selectors).toContain('.lk-theme-switching view');
+  });
+
+  it('keeps the native select reset on H5 without leaking it into MP-WEIXIN CSS', () => {
+    const h5Css = compileThemeCssForPlatform('h5');
+    const mpWeixinCss = compileThemeCssForPlatform('mp-weixin');
+
+    expect(declarationsForSelector(h5Css, 'select', 'font')).toContain('inherit');
+    expect(declarationsForSelector(mpWeixinCss, 'select', 'font')).toEqual([]);
+
+    for (const selector of ['button', 'input', 'textarea']) {
+      expect(declarationsForSelector(h5Css, selector, 'font')).toContain('inherit');
+      expect(declarationsForSelector(mpWeixinCss, selector, 'font')).toContain('inherit');
+    }
   });
 });


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(theme): isolate native select reset`。
- 保留提交 `a51d68816c7a` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。