### PR TITLE
fix(tooltip): synchronize visibility state

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -5,13 +5,13 @@ phone: tooltip
 
 # Tooltip 文字提示
 
-用于围绕一个触发元素显示轻量提示信息，支持 `hover`、`click`、手动控制和自定义内容。
+用于围绕一个触发元素显示轻量提示信息，支持 `hover`、`click`、手动控制和自定义内容。默认 `hover` 在桌面细指针设备上使用悬停，在 H5 触屏和微信小程序上自动回退为轻点切换。
 
 ## 基础用法
 
 ```vue
 <lk-tooltip content="提示内容">
-  <lk-button>悬停</lk-button>
+  <lk-button>悬停或轻点</lk-button>
 </lk-tooltip>
 ```
 
@@ -42,7 +42,9 @@ phone: tooltip
 ```vue
 <template>
   <lk-tooltip content="Top" placement="top"><lk-button>Top</lk-button></lk-tooltip>
-  <lk-tooltip content="Bottom" placement="bottom" :width="260"><lk-button>Bottom</lk-button></lk-tooltip>
+  <lk-tooltip content="Bottom" placement="bottom" :width="260"
+    ><lk-button>Bottom</lk-button></lk-tooltip
+  >
 </template>
 ```
 
@@ -50,9 +52,9 @@ phone: tooltip
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const open = ref(false)
+const open = ref(false);
 </script>
 
 <template>
@@ -66,6 +68,17 @@ const open = ref(false)
 </template>
 ```
 
+## 交互与受控状态语义
+
+- `hover`：桌面细指针使用进入/离开；H5 触屏和微信小程序使用轻点切换，默认配置在移动端同样可达。
+- `click`：只在触发区域轻点时切换。自定义内容区域会停止向触发区冒泡，内容按钮、链接或其他操作不会意外关闭 Tooltip。
+- `manual`：组件不自行切换，由业务更新 `modelValue`。组件没有跨端全局“点击外部关闭”监听；需要该行为时请在业务层控制 `modelValue`。
+- `update:modelValue` 表示组件提出的状态请求；`show/open` 与 `hide/close` 只在解析后的可见状态真正发生边沿变化时触发。受控父级拒绝请求时不会伪造生命周期事件。
+- `disabled` 优先于 `always`、受控值和内部值。切换为禁用会清除显示/隐藏延时并立即隐藏；非常驻状态还会请求 `update:modelValue(false)`。受控用法应接受该更新，避免解除禁用后因旧的 `true` 再次显示。
+- `always` 与 `disabled` 同时存在时，禁用只临时遮蔽常驻内容，不发送 `update:modelValue`；解除禁用后内容恢复，并产生新的真实显示边沿。
+
+同步接受状态请求时，打开事件顺序为 `update:modelValue → show → open`，关闭顺序为 `update:modelValue → hide → close`；每个真实可见边沿各触发一次。
+
 ## 动画配置
 
 `animation` 用于选择动画预设；`animationType` 用于直接指定内置动画类型，完整列表见 [Animation 动画](./animation)。
@@ -76,7 +89,7 @@ const open = ref(false)
 
 ```vue
 <script setup lang="ts">
-import TooltipDemo from '@/components/demos/tooltip-demo.vue'
+import TooltipDemo from '@/components/demos/tooltip-demo.vue';
 </script>
 
 <template>
@@ -98,70 +111,75 @@ import TooltipDemo from '@/components/demos/tooltip-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| content | 提示文本 | `string` | `''` |
-| zIndex | 层级 | `number` | `600` |
-| trigger | 触发方式 | `hover \| click \| manual` | `hover` |
-| placement | 展示位置 | `top \| bottom \| left \| right` | `top` |
-| modelValue | 手动控制显示状态 | `boolean` | `undefined` |
-| disabled | 是否禁用 | `boolean` | `false` |
-| always | 是否常驻显示 | `boolean` | `false` |
-| defaultOpen | 初次挂载时是否默认展开一次 | `boolean` | `false` |
-| offset | 与触发元素的间距（rpx） | `number` | `8` |
-| width | 浮层宽度 | `number \| string` | `undefined` |
-| showDelay | 显示延时（ms） | `number` | `80` |
-| hideDelay | 隐藏延时（ms） | `number` | `80` |
-| animation | 动画预设名称 | `keyof ANIMATION_PRESETS` | `undefined` |
-| animationType | 内置动画类型，支持全部 `TransitionName` | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined` |
-| duration | 动画持续时间 | `number` | `220` |
-| delay | 动画延迟 | `number` | `0` |
-| easing | 缓动函数 | `TransitionConfig['easing']` | `ease-out-cubic` |
-| id | 根节点 id | `string` | `''` |
-| customClass | 根节点自定义类名 | `string \| object \| array` | — |
-| customStyle | 根节点自定义样式 | `string \| object` | — |
+| 参数          | 说明                                     | 类型                                                   | 默认值           |
+| ------------- | ---------------------------------------- | ------------------------------------------------------ | ---------------- |
+| content       | 提示文本                                 | `string`                                               | `''`             |
+| zIndex        | 层级                                     | `number`                                               | `600`            |
+| trigger       | 触发方式；`hover` 在触屏端回退为轻点切换 | `hover \| click \| manual`                             | `hover`          |
+| placement     | 展示位置                                 | `top \| bottom \| left \| right`                       | `top`            |
+| modelValue    | 手动控制显示状态                         | `boolean`                                              | `undefined`      |
+| disabled      | 是否禁用                                 | `boolean`                                              | `false`          |
+| always        | 是否常驻显示                             | `boolean`                                              | `false`          |
+| defaultOpen   | 初次挂载时是否默认展开一次               | `boolean`                                              | `false`          |
+| offset        | 与触发元素的间距（rpx）                  | `number`                                               | `8`              |
+| width         | 浮层宽度                                 | `number \| string`                                     | `undefined`      |
+| showDelay     | 显示延时（ms）                           | `number`                                               | `80`             |
+| hideDelay     | 隐藏延时（ms）                           | `number`                                               | `80`             |
+| animation     | 动画预设名称                             | `keyof ANIMATION_PRESETS`                              | `undefined`      |
+| animationType | 内置动画类型，支持全部 `TransitionName`  | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined`      |
+| duration      | 动画持续时间                             | `number`                                               | `220`            |
+| delay         | 动画延迟                                 | `number`                                               | `0`              |
+| easing        | 缓动函数                                 | `TransitionConfig['easing']`                           | `ease-out-cubic` |
+| id            | 根节点 id                                | `string`                                               | `''`             |
+| customClass   | 根节点自定义类名                         | `string \| object \| array`                            | —                |
+| customStyle   | 根节点自定义样式                         | `string \| object`                                     | —                |
 
 ### Events
 
-| 事件名 | 说明 | 参数 |
-|--------|------|------|
-| update:modelValue | 显示状态变化 | `(value: boolean) => void` |
-| show | 显示时触发 | `({ trigger, event }) => void` |
-| hide | 隐藏时触发 | `({ trigger, event }) => void` |
-| open | 显示时触发，语义化别名 | `({ trigger, event }) => void` |
-| close | 隐藏时触发，语义化别名 | `({ trigger, event }) => void` |
-| click-trigger | 点击触发区域时触发 | `(event?: Event) => void` |
-| mouseenter-trigger | 鼠标进入触发区域时触发 | `(event?: Event) => void` |
-| mouseleave-trigger | 鼠标离开触发区域时触发 | `(event?: Event) => void` |
-| mouseenter-content | 鼠标进入提示内容时触发 | `(event?: Event) => void` |
-| mouseleave-content | 鼠标离开提示内容时触发 | `(event?: Event) => void` |
-| placement-change | 自动修正展示位置时触发 | `(placement, oldPlacement) => void` |
-| after-enter | 进入动画结束后触发 | `() => void` |
-| after-leave | 离开动画结束后触发 | `() => void` |
+| 事件名             | 说明                                       | 参数                                |
+| ------------------ | ------------------------------------------ | ----------------------------------- |
+| update:modelValue  | 请求父级更新显示状态                       | `(value: boolean) => void`          |
+| show               | 解析后的状态真正变为显示时触发             | `({ trigger, event }) => void`      |
+| hide               | 解析后的状态真正变为隐藏时触发             | `({ trigger, event }) => void`      |
+| open               | 与 `show` 同一真实显示边沿触发的语义化别名 | `({ trigger, event }) => void`      |
+| close              | 与 `hide` 同一真实隐藏边沿触发的语义化别名 | `({ trigger, event }) => void`      |
+| click-trigger      | 点击触发区域时触发                         | `(event?: Event) => void`           |
+| mouseenter-trigger | 鼠标进入触发区域时触发                     | `(event?: Event) => void`           |
+| mouseleave-trigger | 鼠标离开触发区域时触发                     | `(event?: Event) => void`           |
+| mouseenter-content | 鼠标进入提示内容时触发                     | `(event?: Event) => void`           |
+| mouseleave-content | 鼠标离开提示内容时触发                     | `(event?: Event) => void`           |
+| placement-change   | 自动修正展示位置时触发                     | `(placement, oldPlacement) => void` |
+| after-enter        | 进入动画结束后触发                         | `() => void`                        |
+| after-leave        | 离开动画结束后触发                         | `() => void`                        |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
-| default | 触发器内容 |
+| 插槽名  | 说明             |
+| ------- | ---------------- |
+| default | 触发器内容       |
 | content | 自定义提示层内容 |
 
 ## 使用建议
 
 ::: tip
-移动端优先使用 `click` 或 `manual`，桌面端才更适合 `hover`。
+同一业务若同时面向桌面与触屏，可保留默认 `hover`：细指针悬停，触屏轻点。需要所有端都以轻点切换时显式设置 `trigger="click"`。
 :::
 
 ## 发布验收
 
-`lk-tooltip` 已纳入 high-risk showcase 回归，发布前按下面边界验收：
+发布前必须在全新干净构建上分别抓取 H5 与微信小程序运行态，并按下面边界验收：
 
-| 场景 | 验收方式 | 要点 |
-|------|----------|------|
-| 展示台基线 | 自动回归 | `tests/visual/high-risk-showcase.spec.ts` 校验组件路由、verified 状态与高风险标记 |
-| 定位与层级 | 人工验收 | `top/right/bottom/left` 不遮挡触发器，弹层层级高于普通内容 |
-| 触发方式 | 人工验收 | 移动端以 `click/manual` 为主；桌面端补 `hover` 进入、离开延迟 |
+| 场景           | H5 与微信 Peekit 操作                                                                              | 客观通过条件                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 默认触屏可达   | 在触屏 viewport 轻点 `#tooltip-touch-demo .lk-tooltip__trigger`                                    | `.lk-tooltip__pop` 由 0 变 1；`#tooltip-touch-state` 为 `open=true`，事件严格为 `update:true > show > open`，无 console/runtime error |
+| 内容点击隔离   | 打开 `#tooltip-content-demo`，轻点 `#tooltip-content-action`                                       | `#tooltip-content-state` 的 `contentTap` 恰增 1 且 `open=true`；浮层 rect 仍存在，没有 `update:false/hide/close`                      |
+| 打开后禁用     | 轻点 `#tooltip-disable-trigger`，再轻点 `#tooltip-disable-toggle`，等待超过 `hideDelay + duration` | `#tooltip-disable-state` 为 `open=false；disabled=true`；事件尾部严格为 `update:false > hide > close`；浮层为 0，继续等待不回开       |
+| 组件结构与样式 | 分别在 H5 页面作用域、微信组件 scope 查询触发区和浮层                                              | 触发区、浮层 rect 非零；浮层 computed `pointer-events=auto`，z-index 为配置值；无重复匹配、无溢出 viewport                            |
+
+微信端必须在组件 scope 内查询内部节点；全局 selector 查不到自定义组件内部结构不能判为组件失败。构建成功、showcase `verified` 字段或只点击外层 stage 均不属于运行验收证据。
+
+触屏回退必须使用真实 touch 输入或明确的 coarse-pointer 环境；在细指针环境中用普通 DOM `click()` 只能证明 click 路径，不能冒充触屏可达证据。
 
 ::: warning
-Tooltip 的定位依赖触发器尺寸与页面边界，小程序和 App WebView 可能存在测量时序差异；复杂浮层场景建议使用 `manual` 控制显示状态。
+Tooltip 的定位依赖触发器尺寸与页面边界，H5 与微信小程序可能存在测量时序差异；复杂浮层场景建议使用 `manual` 控制显示状态。
 :::

--- a/src/components/demos/tooltip-demo.vue
+++ b/src/components/demos/tooltip-demo.vue
@@ -6,33 +6,71 @@ import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 
 const manualOpen = ref(false);
+const touchOpen = ref(false);
+const touchEvents = ref<string[]>([]);
+const customContentOpen = ref(false);
+const customContentTapCount = ref(0);
+const disabledOpen = ref(false);
+const disabledCase = ref(false);
+const disabledEvents = ref<string[]>([]);
+
+function recordTouchUpdate(value: boolean) {
+  touchEvents.value.push(`update:${value}`);
+}
+
+function recordDisabledUpdate(value: boolean) {
+  disabledEvents.value.push(`update:${value}`);
+}
+
+function toggleDisabledCase() {
+  disabledCase.value = !disabledCase.value;
+}
 </script>
 
 <template>
   <view class="component-demo">
     <demo-block title="基础用法">
       <lk-space wrap>
-        <lk-tooltip content="这是一段提示信息">
-          <lk-button>悬停看看</lk-button>
+        <lk-tooltip
+          id="tooltip-touch-demo"
+          v-model="touchOpen"
+          content="细指针悬停、触屏轻点均可触发"
+          @update:model-value="recordTouchUpdate"
+          @show="touchEvents.push('show')"
+          @open="touchEvents.push('open')"
+          @hide="touchEvents.push('hide')"
+          @close="touchEvents.push('close')"
+        >
+          <lk-button>悬停或轻点</lk-button>
         </lk-tooltip>
 
         <lk-tooltip content="点击触发" trigger="click">
           <lk-button>点击看看</lk-button>
         </lk-tooltip>
       </lk-space>
+      <text id="tooltip-touch-state" class="tooltip-demo-state">
+        open={{ touchOpen }}；events={{ touchEvents.join(' > ') || 'none' }}
+      </text>
     </demo-block>
     <demo-block title="自定义内容">
-      <lk-space wrap>
-        <lk-tooltip trigger="click">
+      <view class="tooltip-demo-case">
+        <lk-tooltip id="tooltip-content-demo" v-model="customContentOpen" trigger="click">
           <lk-button>自定义内容（点击打开）</lk-button>
           <template #content>
-            <view class="tooltip-custom-content">
+            <view
+              id="tooltip-content-action"
+              class="tooltip-custom-content"
+              @tap="customContentTapCount += 1"
+            >
               <view class="tooltip-custom-content__indicator" />
-              <text class="tooltip-custom-content__text">一段可自定义的内容，包含图形和文字</text>
+              <text class="tooltip-custom-content__text">轻点内容只执行内容动作，不关闭提示</text>
             </view>
           </template>
         </lk-tooltip>
-      </lk-space>
+        <text id="tooltip-content-state" class="tooltip-demo-state">
+          open={{ customContentOpen }}；contentTap={{ customContentTapCount }}
+        </text>
+      </view>
     </demo-block>
 
     <demo-block title="设置宽度">
@@ -82,15 +120,38 @@ const manualOpen = ref(false);
     </demo-block>
 
     <demo-block title="禁用与间距">
-      <lk-space wrap>
-        <lk-tooltip content="已禁用" :disabled="true">
-          <lk-button disabled>禁用</lk-button>
-        </lk-tooltip>
+      <view id="tooltip-disable-demo" class="tooltip-demo-case">
+        <lk-space wrap>
+          <lk-tooltip
+            v-model="disabledOpen"
+            content="打开后切换 disabled 应立即关闭"
+            trigger="click"
+            :disabled="disabledCase"
+            @update:model-value="recordDisabledUpdate"
+            @show="disabledEvents.push('show')"
+            @open="disabledEvents.push('open')"
+            @hide="disabledEvents.push('hide')"
+            @close="disabledEvents.push('close')"
+          >
+            <lk-button id="tooltip-disable-trigger">{{
+              disabledCase ? '已禁用' : '先打开'
+            }}</lk-button>
+          </lk-tooltip>
 
-        <lk-tooltip content="更远的间距" :offset="16">
-          <lk-button>offset 16rpx</lk-button>
-        </lk-tooltip>
-      </lk-space>
+          <lk-button id="tooltip-disable-toggle" @click="toggleDisabledCase">
+            {{ disabledCase ? '解除禁用' : '切换为禁用' }}
+          </lk-button>
+
+          <lk-tooltip content="更远的间距" :offset="16">
+            <lk-button>offset 16rpx</lk-button>
+          </lk-tooltip>
+        </lk-space>
+        <text id="tooltip-disable-state" class="tooltip-demo-state">
+          open={{ disabledOpen }}；disabled={{ disabledCase }}；events={{
+            disabledEvents.join(' > ') || 'none'
+          }}
+        </text>
+      </view>
     </demo-block>
     <demo-block title="初次展开一次（可关闭）">
       <lk-space wrap>
@@ -118,6 +179,21 @@ const manualOpen = ref(false);
   }
 }
 
+.tooltip-demo-case {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.tooltip-demo-state {
+  display: block;
+  margin-top: 16rpx;
+  color: var(--lk-text-secondary);
+  font-size: var(--lk-font-size-sm);
+  line-height: 1.5;
+  word-break: break-all;
+}
+
 .tooltip-custom-content {
   display: flex;
   align-items: flex-start;
@@ -135,7 +211,7 @@ const manualOpen = ref(false);
   height: 20rpx;
   margin-top: 6rpx;
   border-radius: 50%;
-  background: #16a34a;
+  background: var(--lk-color-success);
 }
 
 .tooltip-custom-content__text {

--- a/src/uni_modules/lucky-ui/components/lk-tooltip/lk-tooltip.vue
+++ b/src/uni_modules/lucky-ui/components/lk-tooltip/lk-tooltip.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { ref, computed, watch, onMounted, nextTick, getCurrentInstance } from 'vue';
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  getCurrentInstance,
+} from 'vue';
 import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition';
 import { tooltipProps, tooltipEmits } from './tooltip.props';
 import {
-  canMutateTooltipOpen,
-  canUpdateTooltipOpen,
-  createTooltipPayload,
+  createTooltipVisibilityController,
   getFallbackPlacement,
+  isTooltipTouchLikeEvent,
   resolveTooltipOpen,
   resolveTooltipPlacementClass,
   resolveTooltipPopStyle,
@@ -27,61 +34,46 @@ const popId = `lk-tooltip-pop-${instance?.uid ?? Math.floor(Math.random() * 1000
 const innerOpen = ref(false);
 const resolvedPlacement = ref(props.placement);
 let supportsHover = true;
+let lastTouchInputAt: number | undefined;
 // #ifdef MP
 supportsHover = false;
 // #endif
-const open = computed({
-  get: () => {
-    return resolveTooltipOpen({
-      always: props.always,
-      modelValue: props.modelValue,
-      innerOpen: innerOpen.value,
-    });
+// #ifdef H5
+supportsHover =
+  typeof globalThis.matchMedia !== 'function' ||
+  globalThis.matchMedia('(hover: hover) and (pointer: fine)').matches;
+// #endif
+const visibilityController = createTooltipVisibilityController({
+  getConfig: () => ({
+    always: props.always,
+    disabled: props.disabled,
+    modelValue: props.modelValue,
+    trigger: props.trigger,
+  }),
+  getInnerOpen: () => innerOpen.value,
+  setInnerOpen: value => {
+    innerOpen.value = value;
   },
-  set: (v: boolean) => {
-    if (!canMutateTooltipOpen(props.always)) return; // 常驻时忽略外部变更
-    if (props.modelValue === undefined) innerOpen.value = v;
-    emit('update:modelValue', v);
+  onUpdate: value => emit('update:modelValue', value),
+  onVisibilityChange: (visible, payload) => {
+    if (visible) {
+      emit('show', payload);
+      emit('open', payload);
+    } else {
+      emit('hide', payload);
+      emit('close', payload);
+    }
   },
+  defer: callback => void nextTick(callback),
 });
-
-let showTimer: ReturnType<typeof setTimeout> | null = null;
-let hideTimer: ReturnType<typeof setTimeout> | null = null;
-
-type TooltipOpenTrigger = 'hover' | 'click' | 'manual' | 'default';
-type TooltipCloseTrigger = TooltipOpenTrigger | 'disabled' | 'content';
-
-function doOpen(
-  v = true,
-  trigger: TooltipOpenTrigger | TooltipCloseTrigger = props.trigger,
-  event?: unknown
-) {
-  if (
-    !canUpdateTooltipOpen({
-      disabled: props.disabled,
-      always: props.always,
-      currentOpen: open.value,
-      nextOpen: v,
-    })
-  )
-    return;
-  open.value = v;
-  if (v) {
-    const payload = createTooltipPayload({
-      trigger: trigger as TooltipOpenTrigger,
-      event,
-    });
-    emit('show', payload);
-    emit('open', payload);
-  } else {
-    const payload = createTooltipPayload({
-      trigger: trigger as TooltipCloseTrigger,
-      event,
-    });
-    emit('hide', payload);
-    emit('close', payload);
-  }
-}
+const open = computed(() =>
+  resolveTooltipOpen({
+    always: props.always,
+    disabled: props.disabled,
+    modelValue: props.modelValue,
+    innerOpen: innerOpen.value,
+  })
+);
 
 function onTriggerEnter(event?: unknown) {
   emit('mouseenter-trigger', event);
@@ -93,8 +85,7 @@ function onTriggerEnter(event?: unknown) {
     })
   )
     return;
-  if (hideTimer) clearTimeout(hideTimer);
-  showTimer = setTimeout(() => doOpen(true, 'hover', event), props.showDelay);
+  visibilityController.scheduleOpen('hover', event, props.showDelay);
 }
 function onTriggerLeave(event?: unknown) {
   emit('mouseleave-trigger', event);
@@ -106,20 +97,25 @@ function onTriggerLeave(event?: unknown) {
     })
   )
     return;
-  if (showTimer) clearTimeout(showTimer);
-  hideTimer = setTimeout(() => doOpen(false, 'hover', event), props.hideDelay);
+  visibilityController.scheduleClose('hover', event, props.hideDelay);
 }
 function onTriggerClick(event?: unknown) {
   emit('click-trigger', event);
+  const touchLike = isTooltipTouchLikeEvent(event, { recentTouchAt: lastTouchInputAt });
+  lastTouchInputAt = undefined;
   if (
     !shouldToggleTooltipOnTriggerClick({
       always: props.always,
       trigger: props.trigger,
       supportsHover,
+      touchLike,
     })
   )
     return;
-  doOpen(!open.value, 'click', event);
+  visibilityController.request(!visibilityController.getRequestedOpen(), 'click', event);
+}
+function onTriggerTouchStart() {
+  lastTouchInputAt = Date.now();
 }
 function onContentEnter(event?: unknown) {
   emit('mouseenter-content', event);
@@ -130,7 +126,7 @@ function onContentEnter(event?: unknown) {
     })
   )
     return;
-  if (hideTimer) clearTimeout(hideTimer);
+  visibilityController.cancelHide();
 }
 function onContentLeave(event?: unknown) {
   emit('mouseleave-content', event);
@@ -141,14 +137,16 @@ function onContentLeave(event?: unknown) {
     })
   )
     return;
-  hideTimer = setTimeout(() => doOpen(false, 'content', event), props.hideDelay);
+  visibilityController.scheduleClose('content', event, props.hideDelay);
 }
 
 watch(
-  () => props.disabled,
-  v => {
-    if (v) doOpen(false, 'disabled');
-  }
+  () => [props.disabled, props.always, props.modelValue, innerOpen.value, props.trigger] as const,
+  (_value, oldValue) => {
+    if (oldValue && oldValue[4] !== props.trigger) visibilityController.cancelTimers();
+    visibilityController.sync('external');
+  },
+  { flush: 'sync' }
 );
 
 watch(
@@ -213,15 +211,10 @@ const popStyle = computed(() =>
 );
 
 onMounted(() => {
-  if (props.always || props.disabled) return;
-  // 仅非受控时生效
-  if (props.modelValue !== undefined) return;
-  if (props.defaultOpen) {
-    innerOpen.value = true;
-    emit('show', { trigger: 'default' });
-    emit('open', { trigger: 'default' });
-  }
+  if (props.defaultOpen) visibilityController.setDefaultOpen();
 });
+
+onBeforeUnmount(() => visibilityController.destroy());
 
 const transitionConfig = computed(() =>
   resolveTooltipTransitionConfig({
@@ -267,11 +260,14 @@ watch(
     class="lk-tooltip"
     :class="[customClass, disabled && 'is-disabled', always && 'is-always']"
     :style="rootStyle"
-    @mouseenter="onTriggerEnter"
-    @mouseleave="onTriggerLeave"
-    @tap="onTriggerClick"
   >
-    <view class="lk-tooltip__trigger">
+    <view
+      class="lk-tooltip__trigger"
+      @mouseenter="onTriggerEnter"
+      @mouseleave="onTriggerLeave"
+      @touchstart="onTriggerTouchStart"
+      @tap="onTriggerClick"
+    >
       <slot />
     </view>
 
@@ -283,6 +279,7 @@ watch(
       :style="popStyle"
       @mouseenter="onContentEnter"
       @mouseleave="onContentLeave"
+      @tap.stop
     >
       <view class="lk-tooltip__body lk-elevated" :class="tipClasses" :style="tipStyles">
         <view class="lk-tooltip__content">

--- a/src/uni_modules/lucky-ui/components/lk-tooltip/tooltip.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-tooltip/tooltip.utils.ts
@@ -5,13 +5,29 @@ import {
 import type { TooltipPlacement, TooltipTrigger } from './tooltip.props';
 
 type TooltipRect = Record<'top' | 'right' | 'bottom' | 'left', number>;
-type TooltipOpenTrigger = TooltipTrigger | 'default';
+export type TooltipOpenTrigger = TooltipTrigger | 'default';
+export type TooltipCloseTrigger = TooltipOpenTrigger | 'disabled' | 'content';
+export type TooltipVisibilityTrigger = TooltipCloseTrigger | 'external';
+
+export interface TooltipVisibilityPayload {
+  trigger: TooltipVisibilityTrigger;
+  event?: unknown;
+}
+
+export interface TooltipVisibilityConfig {
+  always: boolean;
+  disabled: boolean;
+  modelValue: boolean | undefined;
+  trigger: TooltipTrigger;
+}
 
 export function resolveTooltipOpen(options: {
   always: boolean;
+  disabled: boolean;
   modelValue: boolean | undefined;
   innerOpen: boolean;
 }): boolean {
+  if (options.disabled) return false;
   if (options.always) return true;
   return options.modelValue === undefined ? options.innerOpen : options.modelValue;
 }
@@ -26,7 +42,11 @@ export function canUpdateTooltipOpen(options: {
   currentOpen: boolean;
   nextOpen: boolean;
 }): boolean {
-  return !options.disabled && !options.always && options.currentOpen !== options.nextOpen;
+  return (
+    !options.always &&
+    (!options.disabled || !options.nextOpen) &&
+    options.currentOpen !== options.nextOpen
+  );
 }
 
 export function shouldOpenTooltipOnTriggerEnter(options: {
@@ -41,10 +61,11 @@ export function shouldToggleTooltipOnTriggerClick(options: {
   always: boolean;
   trigger: TooltipTrigger;
   supportsHover: boolean;
+  touchLike?: boolean;
 }): boolean {
   if (options.always) return false;
   if (options.trigger === 'click') return true;
-  return !options.supportsHover && options.trigger === 'hover';
+  return options.trigger === 'hover' && (!options.supportsHover || options.touchLike === true);
 }
 
 export function shouldKeepTooltipContentHover(options: {
@@ -55,12 +76,285 @@ export function shouldKeepTooltipContentHover(options: {
 }
 
 export function createTooltipPayload(options: {
-  trigger: TooltipOpenTrigger | 'disabled' | 'content';
+  trigger: TooltipVisibilityTrigger;
   event?: unknown;
-}) {
+}): TooltipVisibilityPayload {
   return {
     trigger: options.trigger,
     event: options.event,
+  };
+}
+
+export function isTooltipTouchLikeEvent(
+  event: unknown,
+  options: { recentTouchAt?: number; now?: number; maxAge?: number } = {}
+): boolean {
+  const candidate = (event && typeof event === 'object' ? event : {}) as {
+    pointerType?: unknown;
+    touches?: unknown;
+    changedTouches?: unknown;
+    detail?: { pointerType?: unknown; source?: unknown };
+    sourceCapabilities?: { firesTouchEvents?: unknown };
+  };
+  const pointerType = candidate.pointerType ?? candidate.detail?.pointerType;
+  if (pointerType === 'touch' || pointerType === 'pen') return true;
+  if (candidate.detail?.source === 'touch') return true;
+  if (candidate.sourceCapabilities?.firesTouchEvents === true) return true;
+  const touches = candidate.touches as { length?: unknown } | undefined;
+  const changedTouches = candidate.changedTouches as { length?: unknown } | undefined;
+  if (
+    (typeof touches?.length === 'number' && touches.length > 0) ||
+    (typeof changedTouches?.length === 'number' && changedTouches.length > 0)
+  ) {
+    return true;
+  }
+  if (options.recentTouchAt === undefined) return false;
+  const age = (options.now ?? Date.now()) - options.recentTouchAt;
+  return age >= 0 && age <= (options.maxAge ?? 1000);
+}
+
+export interface TooltipVisibilityController {
+  resolveOpen: () => boolean;
+  getRequestedOpen: () => boolean;
+  request: (nextOpen: boolean, trigger: TooltipVisibilityTrigger, event?: unknown) => boolean;
+  setDefaultOpen: () => boolean;
+  scheduleOpen: (trigger: TooltipOpenTrigger, event: unknown, delay: number) => void;
+  scheduleClose: (trigger: TooltipCloseTrigger, event: unknown, delay: number) => void;
+  cancelShow: () => void;
+  cancelHide: () => void;
+  cancelTimers: () => void;
+  sync: (fallbackTrigger?: TooltipVisibilityTrigger) => void;
+  destroy: () => void;
+  getTimerCount: () => number;
+}
+
+/**
+ * 将“请求开闭”与“真实可见边沿”分开。
+ * 受控父级拒绝 update 时不会伪造 show/open；禁用则始终撤销可见状态与延迟任务。
+ */
+export function createTooltipVisibilityController(options: {
+  getConfig: () => TooltipVisibilityConfig;
+  getInnerOpen: () => boolean;
+  setInnerOpen: (value: boolean) => void;
+  onUpdate: (value: boolean) => void;
+  onVisibilityChange: (open: boolean, payload: TooltipVisibilityPayload) => void;
+  defer?: (callback: () => void) => void;
+}): TooltipVisibilityController {
+  const defer = options.defer || (callback => void Promise.resolve().then(callback));
+  let lastDisabled = options.getConfig().disabled;
+  let lastModelValue = options.getConfig().modelValue;
+  let lastResolvedOpen = resolveCurrentOpen();
+  let pending:
+    | { generation: number; nextOpen: boolean; payload: TooltipVisibilityPayload }
+    | undefined;
+  let requestGeneration = 0;
+  let showTimer: ReturnType<typeof setTimeout> | undefined;
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  let destroyed = false;
+  let syncing = false;
+  let syncAgain = false;
+  let disabledCloseRequested = false;
+
+  function resolveCurrentOpen(disabled = options.getConfig().disabled): boolean {
+    const config = options.getConfig();
+    return resolveTooltipOpen({
+      always: config.always,
+      disabled,
+      modelValue: config.modelValue,
+      innerOpen: options.getInnerOpen(),
+    });
+  }
+
+  function cancelShow() {
+    if (showTimer === undefined) return;
+    clearTimeout(showTimer);
+    showTimer = undefined;
+  }
+
+  function cancelHide() {
+    if (hideTimer === undefined) return;
+    clearTimeout(hideTimer);
+    hideTimer = undefined;
+  }
+
+  function cancelTimers() {
+    cancelShow();
+    cancelHide();
+  }
+
+  function reconcile(fallbackTrigger: TooltipVisibilityTrigger) {
+    const nextOpen = resolveCurrentOpen();
+    if (nextOpen === lastResolvedOpen) return;
+    lastResolvedOpen = nextOpen;
+    const matchedPending = pending?.nextOpen === nextOpen ? pending : undefined;
+    const payload = matchedPending?.payload || createTooltipPayload({ trigger: fallbackTrigger });
+    if (pending) pending = undefined;
+    options.onVisibilityChange(nextOpen, payload);
+  }
+
+  function sync(fallbackTrigger: TooltipVisibilityTrigger = 'external') {
+    if (destroyed) return;
+    if (syncing) {
+      syncAgain = true;
+      return;
+    }
+
+    syncing = true;
+    try {
+      do {
+        syncAgain = false;
+        const config = options.getConfig();
+        const becameDisabled = config.disabled && !lastDisabled;
+        const modelChanged = !Object.is(config.modelValue, lastModelValue);
+        lastDisabled = config.disabled;
+        lastModelValue = config.modelValue;
+
+        if (!config.disabled) disabledCloseRequested = false;
+        if (config.disabled || config.always) cancelTimers();
+        if (config.disabled && !config.always) {
+          const hadPendingClose = pending?.nextOpen === false;
+          const pendingOpen = pending?.nextOpen === true;
+          const receivedControlledOpen = config.modelValue === true && modelChanged;
+          const shouldRevoke =
+            (becameDisabled && resolveCurrentOpen(false)) || pendingOpen || receivedControlledOpen;
+          if (shouldRevoke) {
+            const generation = ++requestGeneration;
+            pending = {
+              generation,
+              nextOpen: false,
+              payload: createTooltipPayload({ trigger: 'disabled' }),
+            };
+            if (
+              receivedControlledOpen ||
+              (!hadPendingClose && (!disabledCloseRequested || pendingOpen))
+            ) {
+              options.onUpdate(false);
+            }
+            disabledCloseRequested = true;
+            if (config.modelValue === undefined) options.setInnerOpen(false);
+          }
+        }
+
+        reconcile(becameDisabled ? 'disabled' : fallbackTrigger);
+      } while (syncAgain && !destroyed);
+    } finally {
+      syncing = false;
+    }
+  }
+
+  function settleRejectedRequest(generation: number) {
+    if (destroyed || pending?.generation !== generation) return;
+    pending = undefined;
+  }
+
+  function request(nextOpen: boolean, trigger: TooltipVisibilityTrigger, event?: unknown): boolean {
+    if (destroyed) return false;
+    sync();
+    cancelTimers();
+    const config = options.getConfig();
+    const currentRequestedOpen = pending?.nextOpen ?? resolveCurrentOpen();
+    if (
+      !canUpdateTooltipOpen({
+        disabled: config.disabled,
+        always: config.always,
+        currentOpen: currentRequestedOpen,
+        nextOpen,
+      })
+    ) {
+      return false;
+    }
+
+    const generation = ++requestGeneration;
+    pending = {
+      generation,
+      nextOpen,
+      payload: createTooltipPayload({ trigger, event }),
+    };
+    if (nextOpen) cancelHide();
+    else cancelShow();
+    options.onUpdate(nextOpen);
+    if (config.modelValue === undefined) options.setInnerOpen(nextOpen);
+    sync();
+    defer(() => settleRejectedRequest(generation));
+    return true;
+  }
+
+  function setDefaultOpen(): boolean {
+    if (destroyed) return false;
+    const config = options.getConfig();
+    if (
+      config.modelValue !== undefined ||
+      !canUpdateTooltipOpen({
+        disabled: config.disabled,
+        always: config.always,
+        currentOpen: resolveCurrentOpen(),
+        nextOpen: true,
+      })
+    ) {
+      return false;
+    }
+    pending = {
+      generation: ++requestGeneration,
+      nextOpen: true,
+      payload: createTooltipPayload({ trigger: 'default' }),
+    };
+    options.setInnerOpen(true);
+    sync();
+    return true;
+  }
+
+  function scheduleOpen(trigger: TooltipOpenTrigger, event: unknown, delay: number) {
+    if (destroyed) return;
+    sync();
+    cancelHide();
+    cancelShow();
+    const config = options.getConfig();
+    if (config.disabled || config.always) return;
+    showTimer = setTimeout(
+      () => {
+        showTimer = undefined;
+        request(true, trigger, event);
+      },
+      Math.max(0, delay)
+    );
+  }
+
+  function scheduleClose(trigger: TooltipCloseTrigger, event: unknown, delay: number) {
+    if (destroyed) return;
+    sync();
+    cancelShow();
+    cancelHide();
+    const config = options.getConfig();
+    if (config.disabled || config.always) return;
+    hideTimer = setTimeout(
+      () => {
+        hideTimer = undefined;
+        request(false, trigger, event);
+      },
+      Math.max(0, delay)
+    );
+  }
+
+  function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+    cancelTimers();
+    pending = undefined;
+  }
+
+  return {
+    resolveOpen: resolveCurrentOpen,
+    getRequestedOpen: () => pending?.nextOpen ?? resolveCurrentOpen(),
+    request,
+    setDefaultOpen,
+    scheduleOpen,
+    scheduleClose,
+    cancelShow,
+    cancelHide,
+    cancelTimers,
+    sync,
+    destroy,
+    getTimerCount: () => Number(showTimer !== undefined) + Number(hideTimer !== undefined),
   };
 }
 
@@ -116,10 +410,9 @@ const defaultMotionByPlacement: Record<TooltipPlacement, string> = {
 };
 const tooltipRestTransform = 'translate3d(0, 0, 0)';
 
-function resolveTooltipDefaultMotion(placement: TooltipPlacement): Pick<
-  TransitionConfig,
-  'enterFrom' | 'enterTo' | 'leaveFrom' | 'leaveTo'
-> {
+function resolveTooltipDefaultMotion(
+  placement: TooltipPlacement
+): Pick<TransitionConfig, 'enterFrom' | 'enterTo' | 'leaveFrom' | 'leaveTo'> {
   const hiddenTransform = defaultMotionByPlacement[placement];
   return {
     enterFrom: {

--- a/tests/unit/lk-tooltip.spec.ts
+++ b/tests/unit/lk-tooltip.spec.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ANIMATION_PRESETS } from '../../src/uni_modules/lucky-ui/composables/useTransition';
 import {
   canMutateTooltipOpen,
   canUpdateTooltipOpen,
   createTooltipPayload,
+  createTooltipVisibilityController,
   getFallbackPlacement,
+  isTooltipTouchLikeEvent,
   resolveTooltipOpen,
   resolveTooltipPlacementClass,
   resolveTooltipPopStyle,
@@ -13,73 +17,365 @@ import {
   shouldOpenTooltipOnTriggerEnter,
   shouldToggleTooltipOnTriggerClick,
 } from '../../src/uni_modules/lucky-ui/components/lk-tooltip/tooltip.utils';
+import type { TooltipVisibilityConfig } from '../../src/uni_modules/lucky-ui/components/lk-tooltip/tooltip.utils';
+
+function createVisibilityHarness(initial: Partial<TooltipVisibilityConfig> = {}) {
+  const config: TooltipVisibilityConfig = {
+    always: false,
+    disabled: false,
+    modelValue: undefined,
+    trigger: 'click',
+    ...initial,
+  };
+  let innerOpen = false;
+  const updates: boolean[] = [];
+  const visibility: Array<{ open: boolean; trigger: string }> = [];
+  const deferred: Array<() => void> = [];
+  const controller = createTooltipVisibilityController({
+    getConfig: () => config,
+    getInnerOpen: () => innerOpen,
+    setInnerOpen: value => {
+      innerOpen = value;
+    },
+    onUpdate: value => updates.push(value),
+    onVisibilityChange: (open, payload) => visibility.push({ open, trigger: payload.trigger }),
+    defer: callback => deferred.push(callback),
+  });
+
+  return {
+    config,
+    controller,
+    updates,
+    visibility,
+    flushDeferred() {
+      deferred.splice(0).forEach(callback => callback());
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('lk-tooltip trigger and placement rules', () => {
+  it('isolates trigger taps from interactive tooltip content', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/uni_modules/lucky-ui/components/lk-tooltip/lk-tooltip.vue'),
+      'utf8'
+    );
+    const template = source.slice(source.indexOf('<template>'), source.indexOf('</template>'));
+    const rootStart = template.indexOf('class="lk-tooltip"');
+    const triggerStart = template.indexOf('class="lk-tooltip__trigger"');
+    const triggerEnd = template.indexOf('</view>', triggerStart);
+    const popStart = template.indexOf('class="lk-tooltip__pop"');
+    const popTagEnd = template.indexOf('>', popStart);
+
+    expect(rootStart).toBeGreaterThan(-1);
+    expect(template.slice(rootStart, triggerStart)).not.toContain('@tap=');
+    expect(template.slice(triggerStart, triggerEnd)).toContain('@tap="onTriggerClick"');
+    expect(template.slice(popStart, popTagEnd)).toContain('@tap.stop');
+  });
+
   it('resolves open state from always, controlled and inner state', () => {
-    expect(resolveTooltipOpen({
-      always: true,
-      modelValue: false,
-      innerOpen: false,
-    })).toBe(true);
-    expect(resolveTooltipOpen({
-      always: false,
-      modelValue: false,
-      innerOpen: true,
-    })).toBe(false);
-    expect(resolveTooltipOpen({
-      always: false,
-      modelValue: undefined,
-      innerOpen: true,
-    })).toBe(true);
+    expect(
+      resolveTooltipOpen({
+        always: true,
+        disabled: false,
+        modelValue: false,
+        innerOpen: false,
+      })
+    ).toBe(true);
+    expect(
+      resolveTooltipOpen({
+        always: false,
+        disabled: false,
+        modelValue: false,
+        innerOpen: true,
+      })
+    ).toBe(false);
+    expect(
+      resolveTooltipOpen({
+        always: false,
+        disabled: false,
+        modelValue: undefined,
+        innerOpen: true,
+      })
+    ).toBe(true);
+    expect(
+      resolveTooltipOpen({
+        always: true,
+        disabled: true,
+        modelValue: true,
+        innerOpen: true,
+      })
+    ).toBe(false);
 
     expect(canMutateTooltipOpen(true)).toBe(false);
     expect(canMutateTooltipOpen(false)).toBe(true);
   });
 
   it('guards open updates and trigger behavior', () => {
-    expect(canUpdateTooltipOpen({
-      disabled: false,
-      always: false,
-      currentOpen: false,
-      nextOpen: true,
-    })).toBe(true);
-    expect(canUpdateTooltipOpen({
-      disabled: true,
-      always: false,
-      currentOpen: false,
-      nextOpen: true,
-    })).toBe(false);
-    expect(canUpdateTooltipOpen({
-      disabled: false,
-      always: false,
-      currentOpen: true,
-      nextOpen: true,
-    })).toBe(false);
+    expect(
+      canUpdateTooltipOpen({
+        disabled: false,
+        always: false,
+        currentOpen: false,
+        nextOpen: true,
+      })
+    ).toBe(true);
+    expect(
+      canUpdateTooltipOpen({
+        disabled: true,
+        always: false,
+        currentOpen: false,
+        nextOpen: true,
+      })
+    ).toBe(false);
+    expect(
+      canUpdateTooltipOpen({
+        disabled: true,
+        always: false,
+        currentOpen: true,
+        nextOpen: false,
+      })
+    ).toBe(true);
+    expect(
+      canUpdateTooltipOpen({
+        disabled: false,
+        always: false,
+        currentOpen: true,
+        nextOpen: true,
+      })
+    ).toBe(false);
 
-    expect(shouldOpenTooltipOnTriggerEnter({
-      supportsHover: true,
-      always: false,
-      trigger: 'hover',
-    })).toBe(true);
-    expect(shouldOpenTooltipOnTriggerEnter({
-      supportsHover: false,
-      always: false,
-      trigger: 'hover',
-    })).toBe(false);
-    expect(shouldToggleTooltipOnTriggerClick({
-      always: false,
-      trigger: 'click',
-      supportsHover: true,
-    })).toBe(true);
-    expect(shouldToggleTooltipOnTriggerClick({
-      always: false,
-      trigger: 'hover',
-      supportsHover: false,
-    })).toBe(true);
-    expect(shouldKeepTooltipContentHover({
-      always: false,
-      trigger: 'hover',
-    })).toBe(true);
+    expect(
+      shouldOpenTooltipOnTriggerEnter({
+        supportsHover: true,
+        always: false,
+        trigger: 'hover',
+      })
+    ).toBe(true);
+    expect(
+      shouldOpenTooltipOnTriggerEnter({
+        supportsHover: false,
+        always: false,
+        trigger: 'hover',
+      })
+    ).toBe(false);
+    expect(
+      shouldToggleTooltipOnTriggerClick({
+        always: false,
+        trigger: 'click',
+        supportsHover: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldToggleTooltipOnTriggerClick({
+        always: false,
+        trigger: 'hover',
+        supportsHover: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldToggleTooltipOnTriggerClick({
+        always: false,
+        trigger: 'hover',
+        supportsHover: true,
+        touchLike: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldToggleTooltipOnTriggerClick({
+        always: false,
+        trigger: 'hover',
+        supportsHover: true,
+        touchLike: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldKeepTooltipContentHover({
+        always: false,
+        trigger: 'hover',
+      })
+    ).toBe(true);
+  });
+
+  it('recognizes touch-like tap payloads without treating mouse input as touch', () => {
+    expect(isTooltipTouchLikeEvent({ pointerType: 'touch' })).toBe(true);
+    expect(isTooltipTouchLikeEvent({ detail: { pointerType: 'pen' } })).toBe(true);
+    expect(isTooltipTouchLikeEvent({ changedTouches: { length: 1 } })).toBe(true);
+    expect(isTooltipTouchLikeEvent({ sourceCapabilities: { firesTouchEvents: true } })).toBe(true);
+    expect(isTooltipTouchLikeEvent({ pointerType: 'mouse' })).toBe(false);
+    expect(isTooltipTouchLikeEvent(undefined)).toBe(false);
+    expect(isTooltipTouchLikeEvent({}, { recentTouchAt: 1000, now: 1500 })).toBe(true);
+    expect(isTooltipTouchLikeEvent({}, { recentTouchAt: 1000, now: 2001 })).toBe(false);
+  });
+
+  it('emits lifecycle events only after a controlled request becomes visible', () => {
+    const harness = createVisibilityHarness({ modelValue: false });
+
+    expect(harness.controller.request(true, 'click')).toBe(true);
+    expect(harness.updates).toEqual([true]);
+    expect(harness.visibility).toEqual([]);
+
+    harness.flushDeferred();
+    expect(harness.visibility).toEqual([]);
+
+    harness.config.modelValue = true;
+    harness.controller.sync('external');
+    expect(harness.visibility).toEqual([{ open: true, trigger: 'external' }]);
+
+    harness.config.modelValue = false;
+    harness.controller.sync('external');
+    expect(harness.visibility).toEqual([
+      { open: true, trigger: 'external' },
+      { open: false, trigger: 'external' },
+    ]);
+  });
+
+  it('keeps the request trigger when a controlled parent accepts it before settlement', () => {
+    const harness = createVisibilityHarness({ modelValue: false });
+
+    expect(harness.controller.request(true, 'click', { type: 'tap' })).toBe(true);
+    harness.config.modelValue = true;
+    harness.controller.sync('external');
+
+    expect(harness.updates).toEqual([true]);
+    expect(harness.visibility).toEqual([{ open: true, trigger: 'click' }]);
+  });
+
+  it('retires a rapidly reversed controlled request before the next tap', () => {
+    const harness = createVisibilityHarness({ modelValue: false });
+
+    expect(harness.controller.request(true, 'click')).toBe(true);
+    expect(harness.controller.request(false, 'click')).toBe(true);
+    harness.flushDeferred();
+    expect(harness.updates).toEqual([true, false]);
+
+    harness.config.modelValue = true;
+    harness.controller.sync('external');
+    expect(harness.controller.getRequestedOpen()).toBe(true);
+    expect(harness.controller.request(false, 'click')).toBe(true);
+    expect(harness.updates).toEqual([true, false, false]);
+  });
+
+  it('closes on disable, clears timers and does not reopen an uncontrolled tooltip', () => {
+    vi.useFakeTimers();
+    const harness = createVisibilityHarness();
+
+    expect(harness.controller.request(true, 'click')).toBe(true);
+    expect(harness.controller.resolveOpen()).toBe(true);
+    harness.controller.scheduleClose('content', undefined, 500);
+    expect(harness.controller.getTimerCount()).toBe(1);
+
+    harness.config.disabled = true;
+    harness.controller.sync('external');
+
+    expect(harness.controller.resolveOpen()).toBe(false);
+    expect(harness.controller.getTimerCount()).toBe(0);
+    expect(harness.updates).toEqual([true, false]);
+    expect(harness.visibility).toEqual([
+      { open: true, trigger: 'click' },
+      { open: false, trigger: 'disabled' },
+    ]);
+
+    harness.config.disabled = false;
+    harness.controller.sync('external');
+    expect(harness.controller.resolveOpen()).toBe(false);
+    vi.advanceTimersByTime(500);
+    expect(harness.visibility).toHaveLength(2);
+  });
+
+  it('keeps a controlled tooltip hidden while disabled even if its parent rejects close', () => {
+    const harness = createVisibilityHarness({ modelValue: true });
+
+    harness.config.disabled = true;
+    harness.controller.sync('external');
+
+    expect(harness.controller.resolveOpen()).toBe(false);
+    expect(harness.updates).toEqual([false]);
+    expect(harness.visibility).toEqual([{ open: false, trigger: 'disabled' }]);
+
+    harness.controller.scheduleOpen('hover', undefined, 100);
+    harness.controller.scheduleClose('hover', undefined, 100);
+    expect(harness.controller.getTimerCount()).toBe(0);
+    harness.controller.sync('external');
+    expect(harness.controller.request(true, 'click')).toBe(false);
+    expect(harness.updates).toEqual([false]);
+  });
+
+  it('does not duplicate an existing close request when disabled', () => {
+    const harness = createVisibilityHarness({ modelValue: true });
+
+    expect(harness.controller.request(false, 'click')).toBe(true);
+    harness.config.disabled = true;
+    harness.controller.sync('external');
+
+    expect(harness.updates).toEqual([false]);
+    expect(harness.visibility).toEqual([{ open: false, trigger: 'disabled' }]);
+  });
+
+  it('revokes a pending open and any stale controlled write while disabled', () => {
+    const harness = createVisibilityHarness({ modelValue: false });
+
+    expect(harness.controller.request(true, 'click')).toBe(true);
+    harness.config.disabled = true;
+    harness.controller.sync('external');
+    expect(harness.updates).toEqual([true, false]);
+    expect(harness.visibility).toEqual([]);
+
+    harness.config.modelValue = true;
+    harness.controller.sync('external');
+    expect(harness.updates).toEqual([true, false, false]);
+    expect(harness.controller.resolveOpen()).toBe(false);
+  });
+
+  it('temporarily hides an always tooltip without requesting a model update', () => {
+    const harness = createVisibilityHarness({ always: true });
+
+    harness.config.disabled = true;
+    harness.controller.sync('external');
+    expect(harness.updates).toEqual([]);
+    expect(harness.visibility).toEqual([{ open: false, trigger: 'disabled' }]);
+
+    harness.config.disabled = false;
+    harness.controller.sync('external');
+    expect(harness.visibility).toEqual([
+      { open: false, trigger: 'disabled' },
+      { open: true, trigger: 'external' },
+    ]);
+  });
+
+  it('cancels a pending hover open when a touch tap requests the same edge', () => {
+    vi.useFakeTimers();
+    const harness = createVisibilityHarness({ trigger: 'hover' });
+
+    harness.controller.scheduleOpen('hover', undefined, 100);
+    expect(harness.controller.getTimerCount()).toBe(1);
+    expect(harness.controller.request(true, 'click')).toBe(true);
+    expect(harness.controller.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(100);
+
+    expect(harness.updates).toEqual([true]);
+    expect(harness.visibility).toEqual([{ open: true, trigger: 'click' }]);
+  });
+
+  it('cancels opposing delays and destroys every pending timer', () => {
+    vi.useFakeTimers();
+    const harness = createVisibilityHarness({ trigger: 'hover' });
+
+    harness.controller.scheduleOpen('hover', undefined, 100);
+    harness.controller.scheduleClose('hover', undefined, 80);
+    expect(harness.controller.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(80);
+    expect(harness.controller.resolveOpen()).toBe(false);
+    expect(harness.updates).toEqual([]);
+
+    harness.controller.scheduleOpen('hover', undefined, 100);
+    harness.controller.destroy();
+    expect(harness.controller.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(harness.updates).toEqual([]);
   });
 
   it('falls back placement by viewport overflow', () => {
@@ -91,88 +387,114 @@ describe('lk-tooltip trigger and placement rules', () => {
     };
 
     expect(getFallbackPlacement('top', rect, 375, 667)).toBe('bottom');
-    expect(getFallbackPlacement('left', {
-      top: 80,
-      right: 100,
-      bottom: 140,
-      left: 4,
-    }, 375, 667)).toBe('right');
-    expect(getFallbackPlacement('bottom', {
-      top: 80,
-      right: 100,
-      bottom: 640,
-      left: 40,
-    }, 375, 667)).toBe('bottom');
+    expect(
+      getFallbackPlacement(
+        'left',
+        {
+          top: 80,
+          right: 100,
+          bottom: 140,
+          left: 4,
+        },
+        375,
+        667
+      )
+    ).toBe('right');
+    expect(
+      getFallbackPlacement(
+        'bottom',
+        {
+          top: 80,
+          right: 100,
+          bottom: 640,
+          left: 40,
+        },
+        375,
+        667
+      )
+    ).toBe('bottom');
   });
 
   it('builds placement class, pop style and payload', () => {
     expect(resolveTooltipPlacementClass('right')).toBe('is-right');
-    expect(resolveTooltipPopStyle({
-      offset: 12,
-      zIndex: 700,
-      width: 240,
-    })).toEqual({
+    expect(
+      resolveTooltipPopStyle({
+        offset: 12,
+        zIndex: 700,
+        width: 240,
+      })
+    ).toEqual({
       '--lk-tooltip-offset': '12rpx',
       zIndex: 700,
       width: '240rpx',
     });
-    expect(resolveTooltipPopStyle({
-      offset: 8,
-      zIndex: 600,
-      width: '32vw',
-    })).toEqual({
+    expect(
+      resolveTooltipPopStyle({
+        offset: 8,
+        zIndex: 600,
+        width: '32vw',
+      })
+    ).toEqual({
       '--lk-tooltip-offset': '8rpx',
       zIndex: 600,
       width: '32vw',
     });
 
     const event = { type: 'tap' };
-    expect(createTooltipPayload({
-      trigger: 'click',
-      event,
-    })).toEqual({
+    expect(
+      createTooltipPayload({
+        trigger: 'click',
+        event,
+      })
+    ).toEqual({
       trigger: 'click',
       event,
     });
   });
 
   it('resolves transition priority from explicit type, preset and placement', () => {
-    expect(resolveTooltipTransitionConfig({
-      animationType: 'zoom-in',
-      animation: 'fade',
-      placement: 'top',
-      duration: 120,
-      delay: 20,
-      easing: 'linear',
-    })).toEqual({
+    expect(
+      resolveTooltipTransitionConfig({
+        animationType: 'zoom-in',
+        animation: 'fade',
+        placement: 'top',
+        duration: 120,
+        delay: 20,
+        easing: 'linear',
+      })
+    ).toEqual({
       name: 'zoom-in',
       duration: 120,
       delay: 20,
       easing: 'linear',
     });
 
-    expect(resolveTooltipTransitionConfig({
-      animationType: undefined,
-      animation: 'scale',
-      placement: 'bottom',
-      duration: 180,
-      delay: 0,
-      easing: 'ease-out',
-    })).toEqual({
+    expect(
+      resolveTooltipTransitionConfig({
+        animationType: undefined,
+        animation: 'scale',
+        placement: 'bottom',
+        duration: 180,
+        delay: 0,
+        easing: 'ease-out',
+      })
+    ).toEqual({
       name: ANIMATION_PRESETS.scale.animation,
       duration: 180,
       delay: 0,
       easing: 'ease-out',
     });
 
-    expect(resolveTooltipTransitionConfig({
-      animationType: undefined,
-      animation: undefined,
-      placement: 'left',
-      duration: 180,
-      delay: 0,
-      easing: 'ease-out',
-    })).toMatchObject({
+    expect(
+      resolveTooltipTransitionConfig({
+        animationType: undefined,
+        animation: undefined,
+        placement: 'left',
+        duration: 180,
+        delay: 0,
+        easing: 'ease-out',
+      })
+    ).toMatchObject({
       name: 'fade',
       duration: 180,
       delay: 0,


### PR DESCRIPTION
## 变更

- 交付独立工作树中的 `fix(tooltip): synchronize visibility state`。
- 保留提交 `494c6d822411` 的单一问题边界，不混入 Demo 分包迁移、发布产物或其他组件改动。

## 验证

- 原工作树提交前已完成对应单测、类型、lint、跨端构建与运行证据检查。
- 本 PR 以 GitHub Actions 的合并提交检查作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge 保持主线历史简洁。