### PR TITLE
fix(action-sheet): honor empty cancel text

### DIFF
--- a/docs/components/action-sheet.md
+++ b/docs/components/action-sheet.md
@@ -98,6 +98,14 @@ function handleSelect() {
 />
 ```
 
+## 取消按钮显隐
+
+不传 `cancelText` 时使用当前语言的默认取消文案；显式传入空字符串时不渲染取消按钮。
+
+```vue
+<lk-action-sheet v-model="visible" :actions="actions" cancel-text="" />
+```
+
 ## 底部安全区
 
 `safeArea` 默认开启。ActionSheet 自身是底部安全区的唯一所有者，内部 Popup 不会再叠加第二层空白；关闭后两层都不会保留安全区节点。
@@ -130,21 +138,21 @@ import ActionSheetDemo from '@/components/demos/action-sheet-demo.vue';
 
 ### Props
 
-| 参数               | 说明                                    | 类型                                                   | 默认值      |
-| ------------------ | --------------------------------------- | ------------------------------------------------------ | ----------- |
-| modelValue         | 是否显示，支持 `v-model`                | `boolean`                                              | `false`     |
-| zIndex             | 弹层层级                                | `number`                                               | `1000`      |
-| title              | 标题                                    | `string`                                               | `''`        |
-| description        | 描述文案                                | `string`                                               | `''`        |
-| actions            | 操作项列表                              | `Action[]`                                             | `[]`        |
-| cancelText         | 取消按钮文字；传空字符串可隐藏取消按钮  | `string`                                               | `'取消'`    |
-| closeOnClickAction | 点击选项后是否自动关闭                  | `boolean`                                              | `true`      |
-| safeArea           | 是否适配底部安全区                      | `boolean`                                              | `true`      |
-| animation          | 动画预设名称                            | `keyof ANIMATION_PRESETS`                              | `undefined` |
-| animationType      | 内置动画类型，支持全部 `TransitionName` | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined` |
-| duration           | 动画时长                                | `number`                                               | `undefined` |
-| delay              | 动画延迟                                | `number`                                               | `undefined` |
-| easing             | 动画缓动函数                            | `TransitionConfig['easing']`                           | `undefined` |
+| 参数               | 说明                                                   | 类型                                                   | 默认值           |
+| ------------------ | ------------------------------------------------------ | ------------------------------------------------------ | ---------------- |
+| modelValue         | 是否显示，支持 `v-model`                               | `boolean`                                              | `false`          |
+| zIndex             | 弹层层级                                               | `number`                                               | `1000`           |
+| title              | 标题                                                   | `string`                                               | `''`             |
+| description        | 描述文案                                               | `string`                                               | `''`             |
+| actions            | 操作项列表                                             | `Action[]`                                             | `[]`             |
+| cancelText         | 取消按钮文字；不传时使用当前语言文案，空字符串隐藏按钮 | `string`                                               | 当前语言的“取消” |
+| closeOnClickAction | 点击选项后是否自动关闭                                 | `boolean`                                              | `true`           |
+| safeArea           | 是否适配底部安全区                                     | `boolean`                                              | `true`           |
+| animation          | 动画预设名称                                           | `keyof ANIMATION_PRESETS`                              | `undefined`      |
+| animationType      | 内置动画类型，支持全部 `TransitionName`                | [`TransitionConfig['name']`](./animation#内置动画类型) | `undefined`      |
+| duration           | 动画时长                                               | `number`                                               | `undefined`      |
+| delay              | 动画延迟                                               | `number`                                               | `undefined`      |
+| easing             | 动画缓动函数                                           | `TransitionConfig['easing']`                           | `undefined`      |
 
 ### Action
 
@@ -187,3 +195,10 @@ Demo 提供 `#action-sheet-safe-area-probe`、`#action-sheet-safe-area-toggle`�
 
 - H5：开启并打开后，面板内 `[data-testid="lk-action-sheet-safe-area"]` 数量必须为 1、computed height 必须为 24px，`.lk-popup__safe` 为 0；关闭安全区再打开，两者数量都必须为 0，目标面板高度必须恰好减少 24px。每次记录 rect、computed height、页面与 console errors。
 - 微信小程序：在真实开发者工具中重放相同步骤，读取 WXML、节点数量与 bounding box；开启时合计 1，关闭时合计 0。构建成功或 WXML 字符串只能证明模板结构，不能替代运行态验收。
+
+取消按钮显隐探针：
+
+Demo 提供 `#action-sheet-cancel-probe`、`#action-sheet-cancel-toggle`、`#action-sheet-cancel-open` 与 `#action-sheet-cancel-target`。
+
+- H5：默认模式打开后，目标面板内 `.lk-action-sheet__cancel` 必须恰好为 1 且文案为当前语言的取消文案；关闭面板、切换为 hidden 再打开后，该节点必须为 0。每步记录 probe 属性、目标 rect、节点数量、console 与 runtime errors。
+- 微信小程序：在真实开发者工具中重放相同步骤并读取节点数量与 bounding box；默认模式为 1、hidden 为 0。构建成功或 WXML 条件节点只能证明编译结构，不能代替运行态验收。

--- a/src/components/demos/action-sheet-demo.vue
+++ b/src/components/demos/action-sheet-demo.vue
@@ -14,6 +14,8 @@ const safeAreaEnabled = ref(true);
 const safeAreaProbeStyle = {
   '--lk-action-sheet-safe-area-bottom': '24px',
 };
+const cancelProbeVisible = ref(false);
+const cancelProbeText = ref<string | undefined>(undefined);
 
 const actions1 = [
   { name: '选项一', value: 1 },
@@ -45,6 +47,14 @@ const showActionSheet4 = () => {
 
 const showSafeAreaProbe = () => {
   safeAreaVisible.value = true;
+};
+
+const showCancelProbe = () => {
+  cancelProbeVisible.value = true;
+};
+
+const toggleCancelProbe = () => {
+  cancelProbeText.value = cancelProbeText.value === '' ? undefined : '';
 };
 
 const handleSelect = (payload: { action: Action }) => {
@@ -111,6 +121,28 @@ const handleSelect = (payload: { action: Action }) => {
         :actions="actions1"
         :custom-style="safeAreaProbeStyle"
         :safe-area="safeAreaEnabled"
+      />
+    </demo-block>
+
+    <demo-block title="取消按钮显隐">
+      <view
+        id="action-sheet-cancel-probe"
+        :data-cancel-mode="cancelProbeText === '' ? 'hidden' : 'default'"
+        :data-visible="cancelProbeVisible ? 'true' : 'false'"
+      >
+        未传 cancelText 使用当前语言文案；空字符串隐藏取消按钮。
+      </view>
+      <lk-button id="action-sheet-cancel-toggle" @click="toggleCancelProbe">
+        {{ cancelProbeText === '' ? '恢复取消按钮' : '隐藏取消按钮' }}
+      </lk-button>
+      <lk-button id="action-sheet-cancel-open" type="primary" @click="showCancelProbe">
+        打开取消按钮探针
+      </lk-button>
+      <lk-action-sheet
+        id="action-sheet-cancel-target"
+        v-model="cancelProbeVisible"
+        :actions="actions1"
+        :cancel-text="cancelProbeText"
       />
     </demo-block>
   </view>

--- a/src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.props.ts
@@ -34,8 +34,11 @@ export const actionSheetProps = {
     default: () => [],
   },
 
-  /** 取消按钮文字 */
-  cancelText: LkProp.string(''),
+  /** 取消按钮文字；不传时使用当前语言文案，空字符串隐藏按钮 */
+  cancelText: {
+    type: String,
+    default: undefined,
+  },
 
   /** 点击选项后是否关闭 */
   closeOnClickAction: LkProp.boolean(true),

--- a/src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.utils.ts
@@ -6,10 +6,14 @@ export function resolveActionSheetRootStyle(customStyle: StyleValue): StyleValue
 }
 
 export function resolveActionSheetCancelText(options: {
-  cancelText: string;
+  cancelText?: string | null;
   fallback: string;
 }): string {
-  return options.cancelText || options.fallback;
+  return options.cancelText == null ? options.fallback : options.cancelText;
+}
+
+export function shouldRenderActionSheetCancel(cancelText: string): boolean {
+  return cancelText.length > 0;
 }
 
 export function shouldRenderActionSheetHead(options: {

--- a/src/uni_modules/lucky-ui/components/lk-action-sheet/lk-action-sheet.vue
+++ b/src/uni_modules/lucky-ui/components/lk-action-sheet/lk-action-sheet.vue
@@ -15,6 +15,7 @@ import {
   resolveActionSheetListClass,
   resolveActionSheetRootStyle,
   shouldCloseAfterAction,
+  shouldRenderActionSheetCancel,
 } from './action-sheet.utils';
 
 defineOptions({ name: 'LkActionSheet' });
@@ -88,6 +89,7 @@ const resolvedCancelText = computed(() =>
     fallback: t('cancel'),
   })
 );
+const showCancel = computed(() => shouldRenderActionSheetCancel(resolvedCancelText.value));
 </script>
 
 <template>
@@ -140,7 +142,7 @@ const resolvedCancelText = computed(() =>
       </view>
 
       <view
-        v-if="cancelText || t('cancel')"
+        v-if="showCancel"
         class="lk-action-sheet__cancel lk-ripple"
         :class="resolveActionSheetCancelClass({ rippleActive, activeIndex })"
         @tap="cancel"

--- a/tests/unit/lk-action-sheet.spec.ts
+++ b/tests/unit/lk-action-sheet.spec.ts
@@ -3,8 +3,15 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
-import {
+import * as VueRuntime from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import * as RippleModule from '../../src/uni_modules/lucky-ui/composables/useRipple';
+import * as LocaleComposableModule from '../../src/uni_modules/lucky-ui/composables/useLocale';
+import { Locale } from '../../src/uni_modules/lucky-ui/locale';
+import * as ActionSheetPropsModule from '../../src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.props';
+import * as ActionSheetUtilsModule from '../../src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.utils';
+
+const {
   canSelectAction,
   createActionSheetPayload,
   resolveActionSheetCancelClass,
@@ -14,10 +21,168 @@ import {
   resolveActionSheetListClass,
   resolveActionSheetRootStyle,
   shouldCloseAfterAction,
+  shouldRenderActionSheetCancel,
   shouldRenderActionSheetHead,
-} from '../../src/uni_modules/lucky-ui/components/lk-action-sheet/action-sheet.utils';
+} = ActionSheetUtilsModule;
 
 const nodeRequire = createRequire(import.meta.url);
+const actionSheetSfcUrl = new URL(
+  '../../src/uni_modules/lucky-ui/components/lk-action-sheet/lk-action-sheet.vue',
+  import.meta.url
+);
+
+type HostNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: HostNode[];
+  parent: HostNode | null;
+  text?: string;
+};
+
+type CompilerSfc = {
+  parse: (
+    source: string,
+    options: { filename: string }
+  ) => { descriptor: unknown; errors: unknown[] };
+  compileScript: (
+    descriptor: unknown,
+    options: {
+      id: string;
+      inlineTemplate: boolean;
+      templateOptions: { compilerOptions: { isCustomElement: (tag: string) => boolean } };
+    }
+  ) => { content: string };
+};
+
+type Babel = {
+  transformSync: (
+    source: string,
+    options: {
+      babelrc: boolean;
+      configFile: boolean;
+      filename: string;
+      plugins: unknown[];
+    }
+  ) => { code?: string | null } | null;
+};
+
+type CommonJsModule = {
+  exports: Record<string, unknown>;
+};
+
+const actionSheetRenderer = VueRuntime.createRenderer<HostNode, HostNode>({
+  patchProp(element, key, _previousValue, nextValue) {
+    element.props[key] = nextValue;
+  },
+  insert(child, parent, anchor) {
+    child.parent = parent;
+    const anchorIndex = anchor ? parent.children.indexOf(anchor) : -1;
+    if (anchorIndex === -1) parent.children.push(child);
+    else parent.children.splice(anchorIndex, 0, child);
+  },
+  remove(child) {
+    if (!child.parent) return;
+    const index = child.parent.children.indexOf(child);
+    if (index >= 0) child.parent.children.splice(index, 1);
+    child.parent = null;
+  },
+  createElement(type) {
+    return { type, props: {}, children: [], parent: null };
+  },
+  createText(text) {
+    return { type: 'text', props: {}, children: [], parent: null, text };
+  },
+  createComment(text) {
+    return { type: 'comment', props: {}, children: [], parent: null, text };
+  },
+  setText(node, text) {
+    node.text = text;
+  },
+  setElementText(node, text) {
+    node.text = text;
+    node.children = [];
+  },
+  parentNode(node) {
+    return node.parent;
+  },
+  nextSibling(node) {
+    if (!node.parent) return null;
+    const index = node.parent.children.indexOf(node);
+    return node.parent.children[index + 1] ?? null;
+  },
+});
+
+function compileProductionActionSheet(): VueRuntime.Component {
+  const uniPluginManifest = nodeRequire.resolve('@dcloudio/vite-plugin-uni/package.json');
+  const dependencyRequire = createRequire(uniPluginManifest);
+  const compiler = dependencyRequire('@vue/compiler-sfc') as CompilerSfc;
+  const babel = dependencyRequire('@babel/core') as Babel;
+  const typeScriptPlugin = (
+    dependencyRequire('@babel/plugin-transform-typescript') as { default: unknown }
+  ).default;
+  const commonJsPlugin = (
+    dependencyRequire('@babel/plugin-transform-modules-commonjs') as { default: unknown }
+  ).default;
+  const source = readFileSync(actionSheetSfcUrl, 'utf8');
+  const { descriptor, errors } = compiler.parse(source, {
+    filename: actionSheetSfcUrl.pathname,
+  });
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to parse lk-action-sheet.vue: ${String(errors[0])}`);
+  }
+
+  const compiledScript = compiler.compileScript(descriptor, {
+    id: 'lk-action-sheet-cancel-production-wire',
+    inlineTemplate: true,
+    templateOptions: {
+      compilerOptions: {
+        isCustomElement: tag => tag === 'view' || tag === 'text',
+      },
+    },
+  });
+  const transformed = babel.transformSync(compiledScript.content, {
+    babelrc: false,
+    configFile: false,
+    filename: 'lk-action-sheet.vue.ts',
+    plugins: [typeScriptPlugin, commonJsPlugin],
+  });
+
+  if (!transformed?.code) {
+    throw new Error('Failed to transform compiled lk-action-sheet.vue script');
+  }
+
+  const PopupStub = VueRuntime.defineComponent({
+    setup(_props, { slots }) {
+      return () => VueRuntime.h('popup-stub', {}, slots.default?.());
+    },
+  });
+  const popupModule = { __esModule: true, default: PopupStub };
+  const requireFromActionSheet = (request: string): unknown => {
+    if (request === 'vue') return VueRuntime;
+    if (request === '../lk-popup/lk-popup.vue') return popupModule;
+    if (request === './action-sheet.props') return ActionSheetPropsModule;
+    if (request === '@/uni_modules/lucky-ui/composables/useRipple') return RippleModule;
+    if (request === '../../composables/useLocale') return LocaleComposableModule;
+    if (request === './action-sheet.utils') return ActionSheetUtilsModule;
+    throw new Error(`Unexpected lk-action-sheet.vue import: ${request}`);
+  };
+  const compiledModule: CommonJsModule = { exports: {} };
+  const executeModule = new Function('require', 'module', 'exports', transformed.code);
+  executeModule(requireFromActionSheet, compiledModule, compiledModule.exports);
+
+  return compiledModule.exports.default as VueRuntime.Component;
+}
+
+function nodesByClass(node: HostNode, className: string): HostNode[] {
+  const classes = typeof node.props.class === 'string' ? node.props.class.split(' ') : [];
+  const matches = classes.includes(className) ? [node] : [];
+  return matches.concat(node.children.flatMap(child => nodesByClass(child, className)));
+}
+
+function hostText(node: HostNode): string {
+  return `${node.text ?? ''}${node.children.map(hostText).join('')}`;
+}
 
 describe('lk-action-sheet selection rules', () => {
   it('compiles exactly one conditional safe-area owner for WeChat', () => {
@@ -87,6 +252,136 @@ describe('lk-action-sheet selection rules', () => {
     expect(existsSync(outputDirectory)).toBe(false);
   }, 60_000);
 
+  it('executes the production SFC cancel fallback and hide contract reactively', async () => {
+    type CancelMode = 'omitted' | 'undefined' | 'null' | 'empty' | 'custom';
+
+    const ActionSheet = compileProductionActionSheet();
+    const mode = VueRuntime.ref<CancelMode>('omitted');
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const originalLocale = Locale.locale;
+    const App = VueRuntime.defineComponent({
+      render() {
+        const props: Record<string, unknown> = {
+          modelValue: true,
+          actions: [],
+          safeArea: false,
+        };
+        if (mode.value === 'undefined') props.cancelText = undefined;
+        if (mode.value === 'null') props.cancelText = null;
+        if (mode.value === 'empty') props.cancelText = '';
+        if (mode.value === 'custom') props.cancelText = 'Close';
+        return VueRuntime.h(ActionSheet, props);
+      },
+    });
+    const root: HostNode = { type: 'root', props: {}, children: [], parent: null };
+    const app = actionSheetRenderer.createApp(App);
+
+    const expectCancel = (expectedText: string) => {
+      const cancelNodes = nodesByClass(root, 'lk-action-sheet__cancel');
+      expect(cancelNodes).toHaveLength(1);
+      expect(hostText(cancelNodes[0])).toBe(expectedText);
+    };
+
+    try {
+      Locale.use('zh-Hans');
+      app.mount(root);
+      await VueRuntime.nextTick();
+      expectCancel('取消');
+
+      mode.value = 'undefined';
+      await VueRuntime.nextTick();
+      expectCancel('取消');
+
+      mode.value = 'null';
+      await VueRuntime.nextTick();
+      expectCancel('取消');
+
+      Locale.use('en');
+      await VueRuntime.nextTick();
+      expectCancel('Cancel');
+
+      mode.value = 'custom';
+      await VueRuntime.nextTick();
+      expectCancel('Close');
+
+      Locale.use('ja');
+      await VueRuntime.nextTick();
+      expectCancel('Close');
+
+      mode.value = 'empty';
+      await VueRuntime.nextTick();
+      expect(nodesByClass(root, 'lk-action-sheet__cancel')).toHaveLength(0);
+
+      Locale.use('fr');
+      await VueRuntime.nextTick();
+      expect(nodesByClass(root, 'lk-action-sheet__cancel')).toHaveLength(0);
+
+      mode.value = 'omitted';
+      await VueRuntime.nextTick();
+      expectCancel('Annuler');
+      expect(warning).not.toHaveBeenCalled();
+    } finally {
+      app.unmount();
+      Locale.use(originalLocale);
+      warning.mockRestore();
+    }
+  });
+
+  it('compiles omitted and empty cancel text as distinct WeChat states', () => {
+    const uniBin = nodeRequire.resolve('@dcloudio/vite-plugin-uni/bin/uni.js');
+    const temporaryParent = resolve(tmpdir());
+    const outputDirectory = mkdtempSync(join(temporaryParent, 'lucky-ui-action-sheet-cancel-mp-'));
+    const componentDirectory = join(
+      outputDirectory,
+      'uni_modules/lucky-ui/components/lk-action-sheet'
+    );
+    const wxmlPath = join(componentDirectory, 'lk-action-sheet.wxml');
+    const scriptPath = join(componentDirectory, 'lk-action-sheet.js');
+    const propsPath = join(componentDirectory, 'action-sheet.props.js');
+
+    expect(dirname(outputDirectory)).toBe(temporaryParent);
+    expect(existsSync(wxmlPath)).toBe(false);
+
+    try {
+      execFileSync(process.execPath, [uniBin, 'build', '-p', 'mp-weixin'], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          UNI_OUTPUT_DIR: outputDirectory,
+        },
+        stdio: 'pipe',
+      });
+
+      const wxml = readFileSync(wxmlPath, 'utf8');
+      const script = readFileSync(scriptPath, 'utf8');
+      const props = readFileSync(propsPath, 'utf8');
+      const cancelTagPattern =
+        /<view(?=[^>]*\blk-action-sheet__cancel\b)(?=[^>]*\bwx:if="\{\{([A-Za-z_$][\w$]*)\}\}")[^>]*>/;
+      const cancelTag = wxml.match(cancelTagPattern);
+      const showCancelComputed = script.match(
+        /([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.computed\(\(\)=>[A-Za-z_$][\w$]*\.shouldRenderActionSheetCancel\(/
+      );
+
+      expect(cancelTag?.[0]).toContain('lk-action-sheet__cancel');
+      expect(cancelTag?.[0]).toContain('wx:if=');
+      expect(showCancelComputed?.[1]).toBeTruthy();
+      expect(
+        script.match(
+          new RegExp(`\\b${cancelTag?.[1]}\\s*:\\s*${showCancelComputed?.[1]}\\.value\\b`)
+        )
+      ).not.toBeNull();
+      expect(props).toContain('cancelText:{type:String,default:void 0}');
+      expect(
+        cancelTag?.[0].replace(/\s+wx:if="\{\{[A-Za-z_$][\w$]*\}\}"/, '').match(cancelTagPattern)
+      ).toBeNull();
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+
+    expect(existsSync(outputDirectory)).toBe(false);
+  }, 60_000);
+
   it('resolves title, description and cancel text fallback', () => {
     expect(
       shouldRenderActionSheetHead({
@@ -107,18 +402,22 @@ describe('lk-action-sheet selection rules', () => {
       })
     ).toEqual({ 'is-no-head': true });
 
+    expect(resolveActionSheetCancelText({ fallback: '取消' })).toBe('取消');
+    expect(resolveActionSheetCancelText({ cancelText: null, fallback: '取消' })).toBe('取消');
     expect(
       resolveActionSheetCancelText({
         cancelText: '',
         fallback: '取消',
       })
-    ).toBe('取消');
+    ).toBe('');
     expect(
       resolveActionSheetCancelText({
         cancelText: '关闭',
         fallback: '取消',
       })
     ).toBe('关闭');
+    expect(shouldRenderActionSheetCancel('取消')).toBe(true);
+    expect(shouldRenderActionSheetCancel('')).toBe(false);
   });
 
   it('guards disabled and loading actions before select emit', () => {


### PR DESCRIPTION
## 变更

- 在已合并的同组件前置修复上交付 `fix(action-sheet): honor empty cancel text`。
- 保留提交 `2607159f6cfc` 的独立行为边界，不混入 Demo 分包迁移或其他组件改动。

## 验证

- 重放到最新 `develop` 后，定向组件测试通过。
- GitHub Actions 作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge。