### PR TITLE
fix(toast): hold blocker through leave

### DIFF
--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -187,6 +187,19 @@ function onAfterLeave() {
 
 每个已交付给 Toast 的 `false → true` 边沿都会取消上一轮尚未到期的计时和离场完成信号，并为新一轮重新计时。若父组件在同一个 Vue 渲染批次内先写 `false` 再写 `true`，子组件只会收到最终的 `true`，因此这不构成一次关闭和重开；需要把 `false` 作为真实边沿交付时，应在写入 `false` 后等待一次 `nextTick()` 再重开。显示期间修改 `duration` 会从修改时刻重新计算：改为正数会按新时长调度，改为 `0` 会立即取消自动关闭。组件卸载时也会废弃计时，不会在卸载后继续发出更新或生命周期事件。`duration=0` 表示不自动关闭。
 
+## 遮罩与点击拦截
+
+直接使用 `LkToast` 时，`overlay` 只控制是否绘制遮罩底色，`forbidClick` 只控制是否拦截对底层页面的点击。两者彼此独立：需要“透明但禁止操作”的加载提示时只开启 `forbidClick`；需要展示底色但允许页面继续操作时只开启 `overlay`。
+
+| `overlay` | `forbidClick` | 遮罩底色 | 底层页面点击 |
+| --------- | ------------- | -------- | ------------ |
+| `false`   | `false`       | 无       | 允许         |
+| `true`    | `false`       | 有       | 允许         |
+| `false`   | `true`        | 无       | 拦截         |
+| `true`    | `true`        | 有       | 拦截         |
+
+关闭 Toast 后，拦截层会和 Toast 一起完成离场动画，再释放底层点击，避免动画仍可见时页面已经提前可操作。若父组件在关闭的同一个渲染批次内把 `overlay` 或 `forbidClick` 重置为 `false`，本轮离场仍冻结关闭前最后一次可见配置；显示期间修改这两个属性则会立即生效。离场途中快速重开时，新一轮使用重开时的当前配置，上一轮已取消的离场完成信号不得移除新一轮节点。
+
 ## API
 
 ### toastStore 方法
@@ -207,6 +220,13 @@ function onAfterLeave() {
 | duration    | 自动关闭时长（ms），0 表示不关闭 | `number`                    | `2000`     |
 | position    | 显示位置                         | `top \| center \| bottom`   | `center`   |
 | transition  | 动画效果                         | `slide-up \| fade \| zoom`  | `slide-up` |
+
+### LkToast 遮罩 Props
+
+| 参数        | 说明                     | 类型      | 默认值  |
+| ----------- | ------------------------ | --------- | ------- |
+| overlay     | 是否绘制遮罩底色         | `boolean` | `false` |
+| forbidClick | 是否拦截对底层页面的点击 | `boolean` | `false` |
 
 ### LkToastManager 组件
 
@@ -239,12 +259,19 @@ function onAfterLeave() {
 
 Toast 演练页提供了不依赖文案和 DOM 层级的稳定选择器：
 
-| 选择器                          | 用途                                                                                                         |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `#toast-lifecycle-fixture`      | 读取 `data-toast-visible`、`data-toast-open-count`、`data-toast-close-count`、`data-toast-after-leave-count` |
-| `#toast-lifecycle-open`         | 开始一轮新的受控 Toast                                                                                       |
-| `#toast-lifecycle-close`        | 在 duration 到期前手动关闭                                                                                   |
-| `#toast-lifecycle-rapid-reopen` | 触发一次关闭并在下一次响应式刷新后立即重开                                                                   |
+| 选择器                              | 用途                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `#toast-lifecycle-fixture`          | 读取 `data-toast-visible`、`data-toast-open-count`、`data-toast-close-count`、`data-toast-after-leave-count` |
+| `#toast-lifecycle-open`             | 开始一轮新的受控 Toast                                                                                       |
+| `#toast-lifecycle-close`            | 在 duration 到期前手动关闭                                                                                   |
+| `#toast-lifecycle-rapid-reopen`     | 触发一次关闭并在下一次响应式刷新后立即重开                                                                   |
+| `#toast-blocker-fixture`            | 读取四态模式、显隐状态与底层按钮点击计数                                                                     |
+| `#toast-blocker-mode-*`             | 切换 `none/visual/lock/visual-lock` 四种组合                                                                 |
+| `#toast-blocker-under-button`       | 在遮罩覆盖区域重放底层点击                                                                                   |
+| `#toast-blocker-close`              | 同批关闭并把两项配置重置为 `false`，验证离场仍冻结上一份配置                                                 |
+| `#toast-blocker-close-reset-forbid` | 同批关闭且只重置 `forbidClick`，验证离场期间仍维持点击拦截                                                   |
+| `#toast-blocker-rapid-none`         | 交付一次真实关闭边沿后立即重开为无视觉、无拦截                                                               |
+| `#toast-blocker-rapid-visual`       | 交付一次真实关闭边沿后立即重开为仅视觉遮罩                                                                   |
 
 H5 和微信小程序必须分别通过 Peekit 连接真实运行页并留存查询结果或快照，按同一套断言验收：
 
@@ -252,5 +279,7 @@ H5 和微信小程序必须分别通过 Peekit 连接真实运行页并留存查
 2. 点击 `#toast-lifecycle-open`，在 1600ms 内点击 `#toast-lifecycle-close`。本轮三个计数各只增加 1；继续等待超过原 duration，计数不得再次变化。
 3. 再次打开后点击 `#toast-lifecycle-rapid-reopen`。等待 300ms 时必须仍为 `visible=true`，上一轮的 `after-leave` 不得增加；新一轮到期后 `close` 与 `after-leave` 才各增加 1。
 4. 全流程页面错误与控制台错误均为 0，截图中 Toast 位置、文字和离场后的页面布局无跳动。
+
+遮罩与点击拦截还必须在同一页面逐一重放四种组合：只有 `overlay=true` 时 `.lk-toast__overlay` 的 computed background 才能为非透明；只有 `forbidClick=true` 时点击 `#toast-blocker-under-button` 不得增加 `data-under-click-count`。在 `visual-lock` 模式点击 `#toast-blocker-close` 后，fixture 必须立即显示两项配置都已重置，但离场动画结束前遮罩节点仍保留 `is-visible/is-lock` 且底层点击仍被拦截；动画结束后节点移除并恢复点击。`#toast-blocker-close-reset-forbid` 必须证明仅重置 `forbidClick` 也不会提前解锁。两种快速重开动作等待超过旧离场时限后，新 Toast 及其 `none/visual` 当前配置仍必须存在，并且 `data-after-leave-count` 不得被旧轮次增加。每一步都要保存 fixture 属性、遮罩节点数量、computed background/pointer-events、点击前后计数和页面错误。
 
 H5 构建、微信小程序构建和单元测试只是静态门禁，不能替代以上两端运行态证据；任一端未实际连接时，应明确记录为“未验收”，不能标记为通过。

--- a/src/components/demos/toast-demo.vue
+++ b/src/components/demos/toast-demo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
@@ -80,6 +80,53 @@ const rapidReopenLifecycleToast = async () => {
   await nextTick();
   lifecycleVisible.value = true;
 };
+
+type ToastBlockerMode = 'none' | 'visual' | 'lock' | 'visual-lock';
+
+const blockerMode = ref<ToastBlockerMode>('none');
+const blockerVisible = ref(false);
+const blockerUnderClickCount = ref(0);
+const blockerOpenCycle = ref(0);
+const blockerAfterLeaveCount = ref(0);
+const blockerOverlay = computed(
+  () => blockerMode.value === 'visual' || blockerMode.value === 'visual-lock'
+);
+const blockerForbidClick = computed(
+  () => blockerMode.value === 'lock' || blockerMode.value === 'visual-lock'
+);
+
+const openBlockerMode = (mode: ToastBlockerMode) => {
+  blockerMode.value = mode;
+  blockerVisible.value = true;
+  blockerOpenCycle.value += 1;
+};
+
+const closeAndResetBlockerToast = () => {
+  blockerVisible.value = false;
+  blockerMode.value = 'none';
+};
+
+const closeAndResetBlockerForbidClick = () => {
+  blockerVisible.value = false;
+  blockerMode.value = 'visual';
+};
+
+const rapidReopenBlockerToast = async (mode: Extract<ToastBlockerMode, 'none' | 'visual'>) => {
+  blockerVisible.value = false;
+  blockerMode.value = 'none';
+  await nextTick();
+  blockerMode.value = mode;
+  blockerVisible.value = true;
+  blockerOpenCycle.value += 1;
+};
+
+const resetBlockerUnderClickCount = () => {
+  blockerUnderClickCount.value = 0;
+};
+
+const onBlockerAfterLeave = () => {
+  blockerAfterLeaveCount.value += 1;
+};
 </script>
 
 <template>
@@ -122,6 +169,72 @@ const rapidReopenLifecycleToast = async () => {
       </view>
     </demo-block>
 
+    <demo-block title="遮罩与点击拦截演练">
+      <view
+        id="toast-blocker-fixture"
+        class="toast-blocker-fixture"
+        :data-blocker-mode="blockerMode"
+        :data-overlay="blockerOverlay ? 'true' : 'false'"
+        :data-forbid-click="blockerForbidClick ? 'true' : 'false'"
+        :data-toast-visible="blockerVisible ? 'true' : 'false'"
+        :data-under-click-count="blockerUnderClickCount"
+        :data-open-cycle="blockerOpenCycle"
+        :data-after-leave-count="blockerAfterLeaveCount"
+      >
+        <view id="toast-blocker-probe" class="toast-blocker-fixture__evidence">
+          mode={{ blockerMode }} / under-click={{ blockerUnderClickCount }}
+        </view>
+        <view class="toast-blocker-fixture__controls">
+          <lk-button id="toast-blocker-mode-none" @click="openBlockerMode('none')">
+            无遮罩 / 可点击
+          </lk-button>
+          <lk-button id="toast-blocker-mode-visual" @click="openBlockerMode('visual')">
+            有遮罩 / 可点击
+          </lk-button>
+          <lk-button id="toast-blocker-mode-lock" @click="openBlockerMode('lock')">
+            无遮罩 / 禁止点击
+          </lk-button>
+          <lk-button id="toast-blocker-mode-visual-lock" @click="openBlockerMode('visual-lock')">
+            有遮罩 / 禁止点击
+          </lk-button>
+          <lk-button id="toast-blocker-close" @click="closeAndResetBlockerToast">
+            关闭并同批重置
+          </lk-button>
+          <lk-button id="toast-blocker-close-reset-forbid" @click="closeAndResetBlockerForbidClick">
+            关闭并仅重置拦截
+          </lk-button>
+          <lk-button id="toast-blocker-rapid-none" @click="rapidReopenBlockerToast('none')">
+            快速重开为无遮罩
+          </lk-button>
+          <lk-button id="toast-blocker-rapid-visual" @click="rapidReopenBlockerToast('visual')">
+            快速重开为仅视觉遮罩
+          </lk-button>
+          <lk-button id="toast-blocker-reset" @click="resetBlockerUnderClickCount">
+            重置计数
+          </lk-button>
+        </view>
+        <view class="toast-blocker-fixture__underlay">
+          <lk-button
+            id="toast-blocker-under-button"
+            type="primary"
+            @click="blockerUnderClickCount += 1"
+          >
+            底层按钮
+          </lk-button>
+        </view>
+        <lk-toast
+          v-model="blockerVisible"
+          message="遮罩与点击拦截是两个独立状态"
+          :duration="0"
+          position="top"
+          :z-index="2200"
+          :overlay="blockerOverlay"
+          :forbid-click="blockerForbidClick"
+          @after-leave="onBlockerAfterLeave"
+        />
+      </view>
+    </demo-block>
+
     <demo-block title="动画效果">
       <lk-space wrap>
         <lk-button @click="showSlideUp">向上滑动</lk-button>
@@ -154,5 +267,35 @@ const rapidReopenLifecycleToast = async () => {
   color: var(--lk-text-secondary);
   font-size: 24rpx;
   line-height: 1.5;
+}
+
+.toast-blocker-fixture {
+  position: relative;
+}
+
+.toast-blocker-fixture__evidence {
+  margin-bottom: 20rpx;
+  color: var(--lk-text-secondary);
+  font-size: 24rpx;
+  line-height: 1.5;
+}
+
+.toast-blocker-fixture__controls {
+  position: relative;
+  z-index: 2202;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  padding: 16rpx;
+  border-radius: var(--lk-radius-md);
+  background: var(--lk-bg-page);
+}
+
+.toast-blocker-fixture__underlay {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  padding: 48rpx 0 16rpx;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.scss
+++ b/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.scss
@@ -76,8 +76,12 @@
     top: 0;
     right: 0;
     bottom: 0;
-    background: var(--lk-fill-quaternary);
-    pointer-events: auto;
+    background: transparent;
+    pointer-events: none;
+
+    @include when(visible) {
+      background: var(--lk-fill-quaternary);
+    }
 
     @include when(lock) {
       pointer-events: auto;

--- a/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue
+++ b/src/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import type { StyleValue } from 'vue';
 import { useTransition } from '@/uni_modules/lucky-ui/composables/useTransition';
 import { createToastLifecycle, watchToastLifecycle } from './toast.lifecycle';
 import { toastProps, toastEmits } from './toast.props';
 import {
+  createToastBlockerState,
   resolveToastOverlayClass,
   resolveToastOverlayStyle,
   resolveToastRootClass,
   resolveToastRootStyle,
   resolveToastTransition,
+  shouldRenderToastBlocker,
 } from './toast.utils';
 
 defineOptions({ name: 'LkToast' });
@@ -17,7 +19,6 @@ defineOptions({ name: 'LkToast' });
 const props = defineProps(toastProps);
 const emit = defineEmits(toastEmits);
 
-const show = computed(() => props.modelValue);
 const lifecycle = createToastLifecycle({
   getDuration: () => props.duration,
   onOpen: () => emit('open'),
@@ -38,10 +39,24 @@ const transitionName = computed(() => {
   });
 });
 
-const overlayClass = computed(() => resolveToastOverlayClass(props.forbidClick));
 const overlayStyle = computed(() => resolveToastOverlayStyle(props.zIndex));
 const rootClass = computed(() => resolveToastRootClass(props.position));
 const rootStyle = computed(() => resolveToastRootStyle(props.zIndex));
+const blockerState = createToastBlockerState();
+const blockerConfig = ref(
+  blockerState.sync({
+    visible: props.modelValue,
+    overlay: props.overlay,
+    forbidClick: props.forbidClick,
+  })
+);
+const stopBlockerWatch = watch(
+  [() => props.modelValue, () => props.overlay, () => props.forbidClick],
+  ([visible, overlay, forbidClick]) => {
+    blockerConfig.value = blockerState.sync({ visible, overlay, forbidClick });
+  },
+  { flush: 'pre' }
+);
 
 const {
   classes: transitionClasses,
@@ -52,8 +67,24 @@ const {
   () => props.modelValue,
   { name: transitionName.value, duration: 260, easing: 'ease-out' },
   {
-    onAfterLeave: () => lifecycle.finishLeave(),
+    onAfterLeave: () => {
+      blockerState.finishLeave();
+      lifecycle.finishLeave();
+    },
   }
+);
+const showBlocker = computed(() =>
+  shouldRenderToastBlocker({
+    display: display.value,
+    overlay: blockerConfig.value.overlay,
+    forbidClick: blockerConfig.value.forbidClick,
+  })
+);
+const overlayClass = computed(() =>
+  resolveToastOverlayClass({
+    overlay: blockerConfig.value.overlay,
+    forbidClick: blockerConfig.value.forbidClick,
+  })
 );
 const innerClass = computed(() => [transitionClasses.value, props.customClass]);
 const innerStyle = computed<StyleValue>(
@@ -61,6 +92,8 @@ const innerStyle = computed<StyleValue>(
 );
 
 onBeforeUnmount(() => {
+  stopBlockerWatch();
+  blockerState.dispose();
   stopLifecycleWatches();
   lifecycle.dispose();
   cancelTransition();
@@ -68,12 +101,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <view
-    v-if="overlay && show"
-    class="lk-toast__overlay"
-    :class="overlayClass"
-    :style="overlayStyle"
-  />
+  <view v-if="showBlocker" class="lk-toast__overlay" :class="overlayClass" :style="overlayStyle" />
   <view v-if="display" class="lk-toast" :class="rootClass" :style="rootStyle">
     <view class="lk-toast__inner" :class="innerClass" :style="innerStyle">
       <text class="lk-toast__text"

--- a/src/uni_modules/lucky-ui/components/lk-toast/toast.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-toast/toast.utils.ts
@@ -37,8 +37,61 @@ export function shouldScheduleToastClose(duration: number): boolean {
   return duration > 0;
 }
 
-export function resolveToastOverlayClass(forbidClick: boolean) {
-  return { 'is-lock': forbidClick };
+export interface ToastBlockerConfig {
+  overlay: boolean;
+  forbidClick: boolean;
+}
+
+export interface ToastBlockerState {
+  sync: (options: ToastBlockerConfig & { visible: boolean }) => ToastBlockerConfig;
+  finishLeave: () => void;
+  dispose: () => void;
+}
+
+export function createToastBlockerState(): ToastBlockerState {
+  let phase: 'hidden' | 'visible' | 'leaving' | 'disposed' = 'hidden';
+  let config: ToastBlockerConfig = { overlay: false, forbidClick: false };
+
+  const sync = (options: ToastBlockerConfig & { visible: boolean }) => {
+    if (phase === 'disposed') return config;
+
+    if (options.visible) {
+      phase = 'visible';
+      config = {
+        overlay: options.overlay,
+        forbidClick: options.forbidClick,
+      };
+    } else if (phase === 'visible') {
+      phase = 'leaving';
+    }
+
+    return config;
+  };
+
+  return {
+    sync,
+    finishLeave() {
+      if (phase === 'leaving') phase = 'hidden';
+    },
+    dispose() {
+      phase = 'disposed';
+    },
+  };
+}
+
+export function shouldRenderToastBlocker(options: {
+  display: boolean;
+  overlay: boolean;
+  forbidClick: boolean;
+}): boolean {
+  return options.display && (options.overlay || options.forbidClick);
+}
+
+export function resolveToastOverlayClass(options: { overlay: boolean; forbidClick: boolean }) {
+  return {
+    'is-visible': options.overlay,
+    'is-lock': options.forbidClick,
+  };
 }
 
 export function resolveToastOverlayStyle(zIndex: number): StyleValue {

--- a/tests/unit/lk-toast.spec.ts
+++ b/tests/unit/lk-toast.spec.ts
@@ -1,11 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRenderer, defineComponent, h, nextTick, ref, type App } from 'vue';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer as createHttpServer } from 'node:http';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { createServer as createViteServer } from 'vite';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent, h, nextTick, ref, type App, type Component } from 'vue';
 import {
   createToastLifecycle,
   watchToastLifecycle,
 } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.lifecycle';
 import { toastManagerProps } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.props';
 import {
+  createToastBlockerState,
   createToastItem,
   resolveToastManagerItemClass,
   resolveToastManagerStyle,
@@ -16,9 +24,209 @@ import {
   resolveToastRootStyle,
   resolveToastTransition,
   shouldScheduleToastClose,
+  shouldRenderToastBlocker,
 } from '../../src/uni_modules/lucky-ui/components/lk-toast/toast.utils';
 
+const nodeRequire = createRequire(import.meta.url);
+
+interface ToastTestNode {
+  type: string;
+  props: Record<string, unknown>;
+  children: ToastTestNode[];
+  parent: ToastTestNode | null;
+  text: string;
+}
+
+async function loadProductionToastSfc(): Promise<Component> {
+  const dependencyRequire = createRequire(
+    nodeRequire.resolve('@dcloudio/vite-plugin-uni/package.json')
+  );
+  const compiler = nodeRequire(dependencyRequire.resolve('@vue/compiler-sfc')) as {
+    parse: (
+      source: string,
+      options: { filename: string }
+    ) => { descriptor: unknown; errors: unknown[] };
+    compileScript: (
+      descriptor: unknown,
+      options: {
+        id: string;
+        inlineTemplate: boolean;
+        templateOptions: { compilerOptions: { isCustomElement: (tag: string) => boolean } };
+      }
+    ) => { content: string };
+  };
+  const sourcePath = resolve(
+    process.cwd(),
+    'src/uni_modules/lucky-ui/components/lk-toast/lk-toast.vue'
+  );
+  const source = readFileSync(sourcePath, 'utf8');
+  const parsed = compiler.parse(source, { filename: sourcePath });
+  expect(parsed.errors).toEqual([]);
+  const compiled = compiler.compileScript(parsed.descriptor, {
+    id: 'toast-production-test',
+    inlineTemplate: true,
+    templateOptions: {
+      compilerOptions: {
+        isCustomElement: tag => tag === 'view' || tag === 'text',
+      },
+    },
+  });
+  const sourceDirectory = dirname(sourcePath).replaceAll('\\', '/');
+  const executableSource = compiled.content.replace(
+    /from (['"])\.\/([^'"]+)\1/g,
+    (_match: string, quote: string, request: string) =>
+      `from ${quote}/@fs/${sourceDirectory}/${request}${quote}`
+  );
+  const temporaryDirectory = mkdtempSync(join(resolve(tmpdir()), 'lucky-ui-toast-sfc-'));
+  const modulePath = join(temporaryDirectory, 'lk-toast.compiled.ts');
+  writeFileSync(modulePath, executableSource, 'utf8');
+  const hmrServer = createHttpServer();
+  const server = await createViteServer({
+    appType: 'custom',
+    configFile: false,
+    root: process.cwd(),
+    resolve: {
+      alias: [
+        {
+          find: /^vue$/,
+          replacement: nodeRequire.resolve('vue/dist/vue.runtime.esm-bundler.js'),
+        },
+        { find: '@', replacement: resolve(process.cwd(), 'src') },
+      ],
+    },
+    server: { middlewareMode: true, hmr: { server: hmrServer } },
+  });
+
+  try {
+    const loaded = await server.ssrLoadModule(`/@fs/${modulePath.replaceAll('\\', '/')}`);
+    return loaded.default as Component;
+  } finally {
+    await server.close();
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function createToastTestRenderer() {
+  const createNode = (type: string, text = ''): ToastTestNode => ({
+    type,
+    props: {},
+    children: [],
+    parent: null,
+    text,
+  });
+  const renderer = createRenderer<ToastTestNode, ToastTestNode>({
+    patchProp(element, key, _previous, next) {
+      if (next == null) delete element.props[key];
+      else element.props[key] = next;
+    },
+    insert(child, parent, anchor) {
+      child.parent = parent;
+      const anchorIndex = anchor ? parent.children.indexOf(anchor) : -1;
+      if (anchorIndex < 0) parent.children.push(child);
+      else parent.children.splice(anchorIndex, 0, child);
+    },
+    remove(child) {
+      if (!child.parent) return;
+      const index = child.parent.children.indexOf(child);
+      if (index >= 0) child.parent.children.splice(index, 1);
+      child.parent = null;
+    },
+    createElement: type => createNode(type),
+    createText: text => createNode('#text', text),
+    createComment: text => createNode('#comment', text),
+    setText(node, text) {
+      node.text = text;
+    },
+    setElementText(element, text) {
+      element.text = text;
+      element.children = [];
+    },
+    parentNode: node => node.parent,
+    nextSibling(node) {
+      if (!node.parent) return null;
+      const index = node.parent.children.indexOf(node);
+      return node.parent.children[index + 1] ?? null;
+    },
+  });
+
+  return { renderer, createRoot: () => createNode('#root') };
+}
+
+function findToastTestNode(root: ToastTestNode, className: string): ToastTestNode | null {
+  const classes = String(root.props.class ?? '').split(/\s+/);
+  if (classes.includes(className)) return root;
+  for (const child of root.children) {
+    const match = findToastTestNode(child, className);
+    if (match) return match;
+  }
+  return null;
+}
+
 describe('lk-toast display and manager rules', () => {
+  it('compiles orthogonal blocker state into the WeChat component', () => {
+    const uniBin = nodeRequire.resolve('@dcloudio/vite-plugin-uni/bin/uni.js');
+    const temporaryParent = resolve(tmpdir());
+    const outputDirectory = mkdtempSync(join(temporaryParent, 'lucky-ui-toast-blocker-mp-'));
+    const componentDirectory = join(outputDirectory, 'uni_modules/lucky-ui/components/lk-toast');
+    const wxmlPath = join(componentDirectory, 'lk-toast.wxml');
+    const scriptPath = join(componentDirectory, 'lk-toast.js');
+    const stylePath = join(componentDirectory, 'lk-toast.wxss');
+
+    expect(dirname(outputDirectory)).toBe(temporaryParent);
+    expect(existsSync(wxmlPath)).toBe(false);
+
+    try {
+      execFileSync(process.execPath, [uniBin, 'build', '-p', 'mp-weixin'], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          UNI_OUTPUT_DIR: outputDirectory,
+        },
+        stdio: 'pipe',
+      });
+
+      const wxml = readFileSync(wxmlPath, 'utf8');
+      const script = readFileSync(scriptPath, 'utf8');
+      const style = readFileSync(stylePath, 'utf8');
+      const blockerTagPattern =
+        /<view wx:if="\{\{([A-Za-z_$][\w$]*)\}\}" class="\{\{\['lk-toast__overlay', ([A-Za-z_$][\w$]*)\]\}\}" style="\{\{([A-Za-z_$][\w$]*)\}\}"\/>/;
+      const blockerTag = wxml.match(blockerTagPattern);
+      const blockerComputed = script.match(
+        /([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.computed\(\(\)=>[A-Za-z_$][\w$]*\.shouldRenderToastBlocker\(\{display:[A-Za-z_$][\w$]*\.value,overlay:([A-Za-z_$][\w$]*)\.value\.overlay,forbidClick:\2\.value\.forbidClick\}\)\)/
+      );
+      const blockerClassComputed = script.match(
+        /([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.computed\(\(\)=>[A-Za-z_$][\w$]*\.resolveToastOverlayClass\(\{overlay:([A-Za-z_$][\w$]*)\.value\.overlay,forbidClick:\2\.value\.forbidClick\}\)\)/
+      );
+
+      expect(blockerTag?.[0]).toContain('lk-toast__overlay');
+      expect(blockerComputed?.[1]).toBeTruthy();
+      expect(blockerClassComputed?.[1]).toBeTruthy();
+      expect(script).toContain('flush:"pre"');
+      expect(script).not.toContain('flush:"sync"');
+      expect(script).toContain(`${blockerTag?.[1]}:${blockerComputed?.[1]}.value`);
+      expect(script).toMatch(
+        new RegExp(
+          `${blockerTag?.[2]}:[A-Za-z_$][\\w$]*\\.n\\(${blockerClassComputed?.[1]}\\.value\\)`
+        )
+      );
+      expect(style).toContain(
+        '.lk-toast__overlay{position:fixed;left:0;top:0;right:0;bottom:0;background:transparent;pointer-events:none}'
+      );
+      expect(style).toContain(
+        '.lk-toast__overlay.is-visible{background:var(--lk-fill-quaternary)}'
+      );
+      expect(style).toContain('.lk-toast__overlay.is-lock{pointer-events:auto}');
+      expect(blockerTag?.[0].replace(/\s+wx:if="\{\{[A-Za-z_$][\w$]*\}\}"/, '')).not.toMatch(
+        blockerTagPattern
+      );
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+
+    expect(existsSync(outputDirectory)).toBe(false);
+  }, 60_000);
+
   it('uses the public toast layer for the global manager', () => {
     const customStyle = { top: '24rpx', zIndex: 3000 };
 
@@ -52,13 +260,58 @@ describe('lk-toast display and manager rules', () => {
     ).toBe('fade');
   });
 
-  it('builds overlay and root classes/styles', () => {
+  it('keeps visual overlay and click blocking orthogonal for every combination', () => {
     expect(shouldScheduleToastClose(2000)).toBe(true);
     expect(shouldScheduleToastClose(0)).toBe(false);
-    expect(resolveToastOverlayClass(true)).toEqual({ 'is-lock': true });
+
+    const combinations = [
+      { overlay: false, forbidClick: false },
+      { overlay: true, forbidClick: false },
+      { overlay: false, forbidClick: true },
+      { overlay: true, forbidClick: true },
+    ];
+
+    for (const combination of combinations) {
+      expect(resolveToastOverlayClass(combination)).toEqual({
+        'is-visible': combination.overlay,
+        'is-lock': combination.forbidClick,
+      });
+      expect(shouldRenderToastBlocker({ display: true, ...combination })).toBe(
+        combination.overlay || combination.forbidClick
+      );
+      expect(shouldRenderToastBlocker({ display: false, ...combination })).toBe(false);
+    }
+
     expect(resolveToastOverlayStyle(2000)).toEqual({ zIndex: 2000 });
     expect(resolveToastRootClass('bottom')).toEqual(['lk-toast--bottom']);
     expect(resolveToastRootStyle(2000)).toEqual({ zIndex: 2001 });
+  });
+
+  it('freezes the last visible blocker config until leave completes', () => {
+    const state = createToastBlockerState();
+
+    expect(state.sync({ visible: true, overlay: true, forbidClick: true })).toEqual({
+      overlay: true,
+      forbidClick: true,
+    });
+    expect(state.sync({ visible: false, overlay: false, forbidClick: false })).toEqual({
+      overlay: true,
+      forbidClick: true,
+    });
+    expect(state.sync({ visible: true, overlay: true, forbidClick: false })).toEqual({
+      overlay: true,
+      forbidClick: false,
+    });
+    state.finishLeave();
+    expect(state.sync({ visible: true, overlay: false, forbidClick: false })).toEqual({
+      overlay: false,
+      forbidClick: false,
+    });
+    state.dispose();
+    expect(state.sync({ visible: true, overlay: true, forbidClick: true })).toEqual({
+      overlay: false,
+      forbidClick: false,
+    });
   });
 
   it('normalizes manager transition and item class', () => {
@@ -113,6 +366,172 @@ describe('lk-toast display and manager rules', () => {
       position: 'top',
       visible: true,
     });
+  });
+});
+
+describe('lk-toast production SFC blocker lifecycle', () => {
+  const mountedApps: App[] = [];
+  let ProductionToast: Component;
+  let consoleWarnings: unknown[][];
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(async () => {
+    ProductionToast = await loadProductionToastSfc();
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    consoleWarnings = [];
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      consoleWarnings.push(args);
+    });
+  });
+
+  afterEach(() => {
+    for (const app of mountedApps.splice(0).reverse()) app.unmount();
+    expect(consoleWarnings).toEqual([]);
+    warnSpy.mockRestore();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  function mountToast(options: { overlay: boolean; forbidClick: boolean }) {
+    const { renderer, createRoot } = createToastTestRenderer();
+    const root = createRoot();
+    const visible = ref(true);
+    const overlay = ref(options.overlay);
+    const forbidClick = ref(options.forbidClick);
+    const afterLeave = vi.fn();
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(ProductionToast, {
+            overlay: overlay.value,
+            forbidClick: forbidClick.value,
+            // Keep modelValue last to prove same-batch resets cannot depend on
+            // the order in which a renderer patches sibling props.
+            modelValue: visible.value,
+            duration: 0,
+            onAfterLeave: afterLeave,
+          });
+      },
+    });
+    const app = renderer.createApp(Parent);
+    app.mount(root);
+    mountedApps.push(app);
+    return { app, root, visible, overlay, forbidClick, afterLeave };
+  }
+
+  async function settleTransition(milliseconds = 320) {
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(milliseconds);
+    await nextTick();
+  }
+
+  async function startTransitionFrame() {
+    await nextTick();
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(16);
+    await nextTick();
+  }
+
+  it('holds visual-lock when the parent closes and resets both props in one render', async () => {
+    const harness = mountToast({ overlay: true, forbidClick: true });
+    await settleTransition();
+
+    harness.visible.value = false;
+    harness.overlay.value = false;
+    harness.forbidClick.value = false;
+    await startTransitionFrame();
+
+    let blocker = findToastTestNode(harness.root, 'lk-toast__overlay');
+    expect(String(blocker?.props.class)).toContain('is-visible');
+    expect(String(blocker?.props.class)).toContain('is-lock');
+
+    await vi.advanceTimersByTimeAsync(259);
+    await nextTick();
+    blocker = findToastTestNode(harness.root, 'lk-toast__overlay');
+    expect(String(blocker?.props.class)).toContain('is-visible');
+    expect(String(blocker?.props.class)).toContain('is-lock');
+
+    await vi.advanceTimersByTimeAsync(1);
+    await nextTick();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).toBeNull();
+    expect(harness.afterLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds a transparent lock when forbidClick is reset on the close edge', async () => {
+    const harness = mountToast({ overlay: false, forbidClick: true });
+    await settleTransition();
+
+    harness.visible.value = false;
+    harness.forbidClick.value = false;
+    await startTransitionFrame();
+
+    const blocker = findToastTestNode(harness.root, 'lk-toast__overlay');
+    expect(String(blocker?.props.class)).not.toContain('is-visible');
+    expect(String(blocker?.props.class)).toContain('is-lock');
+
+    await vi.advanceTimersByTimeAsync(260);
+    await nextTick();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).toBeNull();
+    expect(harness.afterLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses current config on rapid reopen and rejects the old leave completion', async () => {
+    const harness = mountToast({ overlay: true, forbidClick: true });
+    await settleTransition();
+
+    harness.visible.value = false;
+    harness.overlay.value = false;
+    harness.forbidClick.value = false;
+    await startTransitionFrame();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(80);
+    harness.visible.value = true;
+    await nextTick();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).toBeNull();
+
+    await settleTransition(400);
+    expect(findToastTestNode(harness.root, 'lk-toast')).not.toBeNull();
+    expect(harness.afterLeave).not.toHaveBeenCalled();
+
+    harness.visible.value = false;
+    await startTransitionFrame();
+    await vi.advanceTimersByTimeAsync(80);
+    harness.overlay.value = true;
+    harness.visible.value = true;
+    await nextTick();
+    const blocker = findToastTestNode(harness.root, 'lk-toast__overlay');
+    expect(String(blocker?.props.class)).toContain('is-visible');
+    expect(String(blocker?.props.class)).not.toContain('is-lock');
+
+    await settleTransition(400);
+    expect(findToastTestNode(harness.root, 'lk-toast')).not.toBeNull();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).not.toBeNull();
+    expect(harness.afterLeave).not.toHaveBeenCalled();
+  });
+
+  it('cancels blocker and transition work when the component unmounts mid-leave', async () => {
+    const harness = mountToast({ overlay: true, forbidClick: true });
+    await settleTransition();
+
+    harness.visible.value = false;
+    harness.overlay.value = false;
+    harness.forbidClick.value = false;
+    await startTransitionFrame();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).not.toBeNull();
+
+    harness.app.unmount();
+    mountedApps.splice(mountedApps.indexOf(harness.app), 1);
+    await vi.advanceTimersByTimeAsync(1000);
+    await nextTick();
+
+    expect(findToastTestNode(harness.root, 'lk-toast')).toBeNull();
+    expect(findToastTestNode(harness.root, 'lk-toast__overlay')).toBeNull();
+    expect(harness.afterLeave).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## 变更

- 在已合并的同组件前置修复上交付 `fix(toast): hold blocker through leave`。
- 保留提交 `91ddb789d234` 的独立行为边界，不混入 Demo 分包迁移或其他组件改动。

## 验证

- 重放到最新 `develop` 后，定向组件测试通过。
- GitHub Actions 作为最终远端门禁。

## 合并方式

- 目标分支：`develop`。
- 使用 Squash merge。