### PR TITLE
fix(form): enforce interaction ownership

### DIFF
--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -24,9 +24,9 @@ phone: checkbox
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const checked = ref(false)
+const checked = ref(false);
 </script>
 
 <template>
@@ -40,9 +40,9 @@ const checked = ref(false)
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const hobbies = ref(['reading'])
+const hobbies = ref(['reading']);
 </script>
 
 <template>
@@ -71,11 +71,7 @@ const hobbies = ref(['reading'])
 
 ```vue
 <template>
-  <lk-checkbox-group
-    v-model="value"
-    :max="2"
-    @overlimit="(name, max) => console.log(name, max)"
-  >
+  <lk-checkbox-group v-model="value" :max="2" @overlimit="(name, max) => console.log(name, max)">
     <lk-checkbox name="a">选项 A</lk-checkbox>
     <lk-checkbox name="b">选项 B</lk-checkbox>
     <lk-checkbox name="c">选项 C</lk-checkbox>
@@ -89,25 +85,21 @@ const hobbies = ref(['reading'])
 
 ```vue
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref } from 'vue';
 
-const items = ['1', '2', '3']
-const checkedList = ref(['1'])
+const items = ['1', '2', '3'];
+const checkedList = ref(['1']);
 
-const isAllChecked = computed(() => checkedList.value.length === items.length)
-const isIndeterminate = computed(() => checkedList.value.length > 0 && !isAllChecked.value)
+const isAllChecked = computed(() => checkedList.value.length === items.length);
+const isIndeterminate = computed(() => checkedList.value.length > 0 && !isAllChecked.value);
 
 function toggleAll(checked: boolean) {
-  checkedList.value = checked ? [...items] : []
+  checkedList.value = checked ? [...items] : [];
 }
 </script>
 
 <template>
-  <lk-checkbox
-    :model-value="isAllChecked"
-    :indeterminate="isIndeterminate"
-    @change="toggleAll"
-  >
+  <lk-checkbox :model-value="isAllChecked" :indeterminate="isIndeterminate" @change="toggleAll">
     全选
   </lk-checkbox>
 
@@ -140,7 +132,7 @@ function toggleAll(checked: boolean) {
 
 ```vue
 <script setup lang="ts">
-import CheckboxDemo from '@/components/demos/checkbox-demo.vue'
+import CheckboxDemo from '@/components/demos/checkbox-demo.vue';
 </script>
 
 <template>
@@ -162,63 +154,67 @@ import CheckboxDemo from '@/components/demos/checkbox-demo.vue'
 
 ### Checkbox Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 单独使用时的绑定值，建议绑定 `boolean` | `boolean / string / number` | — | `false` |
-| name | 在 Group 中的唯一标识；未传时回退为 `label` | `string / number / boolean` | — | `''` |
-| shape | 图标形状；不传时继承 Group | `string` | `'' / square / circle` | `''` |
-| iconType | 图标类型；不传时继承 Group | `string` | `'' / check / dot` | `''` |
-| disabled | 是否禁用 | `boolean` | — | `false` |
-| activeColor | 选中颜色；不传时继承 Group | `string` | — | `''` |
-| iconSize | 图标尺寸，支持数字或单位字符串 | `string / number` | — | `''` |
-| label | 文本标签；在 Group 中也可作为值回退 | `string` | — | `''` |
-| labelDisabled | 是否禁用点击文本区域切换 | `boolean` | — | `false` |
-| indeterminate | 是否显示半选状态 | `boolean` | — | `false` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数          | 说明                                                      | 类型                        | 可选值                 | 默认值  |
+| ------------- | --------------------------------------------------------- | --------------------------- | ---------------------- | ------- |
+| modelValue    | 单独使用时的绑定值，建议绑定 `boolean`                    | `boolean / string / number` | —                      | `false` |
+| name          | 在 Group 中的唯一标识；未传时回退为 `label`               | `string / number / boolean` | —                      | `''`    |
+| shape         | 图标形状；不传时继承 Group                                | `string`                    | `'' / square / circle` | `''`    |
+| iconType      | 图标类型；不传时继承 Group                                | `string`                    | `'' / check / dot`     | `''`    |
+| disabled      | 是否禁用                                                  | `boolean`                   | —                      | `false` |
+| activeColor   | 选中颜色；不传时继承 Group                                | `string`                    | —                      | `''`    |
+| iconSize      | 图标尺寸，支持数字或单位字符串                            | `string / number`           | —                      | `''`    |
+| label         | 文本标签；在 Group 中也可作为值回退                       | `string`                    | —                      | `''`    |
+| labelDisabled | 是否禁用点击文本区域切换                                  | `boolean`                   | —                      | `false` |
+| indeterminate | 是否显示半选状态                                          | `boolean`                   | —                      | `false` |
+| prop          | 单独使用时的 Form 字段名；组内验证以 Group 的 `prop` 为准 | `string`                    | —                      | `''`    |
+| validateEvent | 单独使用时值变更是否触发 Form 验证；组内由 Group 控制     | `boolean`                   | —                      | `true`  |
+| id            | 根节点 id                                                 | `string`                    | —                      | `''`    |
+| customClass   | 自定义类名                                                | `string / object / array`   | —                      | `''`    |
+| customStyle   | 自定义样式                                                | `string / object`           | —                      | `''`    |
 
 ### Checkbox Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 单独使用时的值变化 | `(value: boolean)` |
-| change | 单独使用时的值变化回调 | `(value: boolean)` |
-| click | 点击复选框时触发，禁用态不触发 | `(event: Event, checked: boolean, value: string \| number \| boolean)` |
+| 事件名            | 说明                           | 回调参数                                                               |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------- |
+| update:modelValue | 单独使用时的值变化             | `(value: boolean)`                                                     |
+| change            | 单独使用时的值变化回调         | `(value: boolean)`                                                     |
+| click             | 点击复选框时触发，禁用态不触发 | `(event: Event, checked: boolean, value: string \| number \| boolean)` |
 
 ### Checkbox Slots
 
-| 插槽名 | 说明 | 作用域参数 |
-|--------|------|-----------|
-| default | 标签内容 | — |
-| icon | 自定义图标区域 | `{ checked, disabled, indeterminate }` |
+| 插槽名  | 说明           | 作用域参数                             |
+| ------- | -------------- | -------------------------------------- |
+| default | 标签内容       | —                                      |
+| icon    | 自定义图标区域 | `{ checked, disabled, indeterminate }` |
 
 ### CheckboxGroup Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 当前选中值数组 | `Array<string / number / boolean>` | — | `[]` |
-| size | 统一尺寸 | `string` | `sm / md / lg` | `md` |
-| disabled | 是否禁用全部子项 | `boolean` | — | `false` |
-| direction | 排列方向 | `string` | `row / column` | `row` |
-| shape | 统一形状 | `string` | `square / circle` | `square` |
-| iconType | 统一图标类型 | `string` | `check / dot` | `check` |
-| activeColor | 统一选中颜色 | `string` | — | `''` |
-| max | 最大可选数量，`0` 表示不限制 | `number` | — | `0` |
-| prop | 表单字段名，配合 `lk-form` 联动校验 | `string` | — | `''` |
-| validateEvent | 值变更时是否触发表单校验 | `boolean` | — | `true` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+Checkbox 位于 Group 内时，只由 Group 的 `prop` / `validateEvent` 触发一次字段验证；子项的同名 props 不重复上报。
+
+| 参数          | 说明                                | 类型                               | 可选值            | 默认值   |
+| ------------- | ----------------------------------- | ---------------------------------- | ----------------- | -------- |
+| modelValue    | 当前选中值数组                      | `Array<string / number / boolean>` | —                 | `[]`     |
+| size          | 统一尺寸                            | `string`                           | `sm / md / lg`    | `md`     |
+| disabled      | 是否禁用全部子项                    | `boolean`                          | —                 | `false`  |
+| direction     | 排列方向                            | `string`                           | `row / column`    | `row`    |
+| shape         | 统一形状                            | `string`                           | `square / circle` | `square` |
+| iconType      | 统一图标类型                        | `string`                           | `check / dot`     | `check`  |
+| activeColor   | 统一选中颜色                        | `string`                           | —                 | `''`     |
+| max           | 最大可选数量，`0` 表示不限制        | `number`                           | —                 | `0`      |
+| prop          | 表单字段名，配合 `lk-form` 联动校验 | `string`                           | —                 | `''`     |
+| validateEvent | 值变更时是否触发表单校验            | `boolean`                          | —                 | `true`   |
+| id            | 根节点 id                           | `string`                           | —                 | `''`     |
+| customClass   | 自定义类名                          | `string / object / array`          | —                 | `''`     |
+| customStyle   | 自定义样式                          | `string / object`                  | —                 | `''`     |
 
 ### CheckboxGroup Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 选中值数组变化 | `(value: Array<string \| number \| boolean>)` |
-| change | 选中值数组变化回调 | `(value: Array<string \| number \| boolean>)` |
-| item-change | 单个选项变化时触发 | `(value: string \| number \| boolean, checked: boolean, list: Array<string \| number \| boolean>)` |
-| overlimit | 选中数量超过 `max` 时触发 | `(value: string \| number \| boolean, max: number)` |
+| 事件名            | 说明                      | 回调参数                                                                                           |
+| ----------------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
+| update:modelValue | 选中值数组变化            | `(value: Array<string \| number \| boolean>)`                                                      |
+| change            | 选中值数组变化回调        | `(value: Array<string \| number \| boolean>)`                                                      |
+| item-change       | 单个选项变化时触发        | `(value: string \| number \| boolean, checked: boolean, list: Array<string \| number \| boolean>)` |
+| overlimit         | 选中数量超过 `max` 时触发 | `(value: string \| number \| boolean, max: number)`                                                |
 
 ### 使用建议
 

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -19,14 +19,14 @@ phone: form
 
 ```vue
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { reactive, ref } from 'vue';
 
-const formRef = ref()
+const formRef = ref();
 
 const form = reactive({
   username: '',
   phone: '',
-})
+});
 
 const rules = {
   username: [{ required: true, message: '请输入用户名' }],
@@ -34,13 +34,13 @@ const rules = {
     { required: true, message: '请输入手机号' },
     { pattern: /^1[3-9]\d{9}$/, message: '手机号格式不正确' },
   ],
-}
+};
 
 async function submit() {
   try {
-    await formRef.value?.validate()
+    await formRef.value?.validate();
   } catch (errors) {
-    console.log(errors)
+    console.log(errors);
   }
 }
 </script>
@@ -48,11 +48,11 @@ async function submit() {
 <template>
   <lk-form ref="formRef" :model="form" :rules="rules" label-width="160rpx">
     <lk-form-item label="用户名" prop="username">
-      <lk-input v-model="form.username" prop="username" placeholder="请输入用户名" />
+      <lk-input v-model="form.username" placeholder="请输入用户名" />
     </lk-form-item>
 
     <lk-form-item label="手机号" prop="phone">
-      <lk-input v-model="form.phone" prop="phone" type="tel" placeholder="请输入手机号" />
+      <lk-input v-model="form.phone" type="tel" placeholder="请输入手机号" />
     </lk-form-item>
 
     <lk-button @click="submit">提交</lk-button>
@@ -76,7 +76,7 @@ async function submit() {
     @clear-validate="fields => console.log(fields)"
   >
     <lk-form-item label="用户名" prop="username">
-      <lk-input v-model="form.username" prop="username" />
+      <lk-input v-model="form.username" />
     </lk-form-item>
   </lk-form>
 </template>
@@ -120,13 +120,13 @@ const rules = {
   confirmPassword: [
     {
       validator: (value, _rule, model) => {
-        if (value !== model?.password) return '两次输入的密码不一致'
-        return true
+        if (value !== model?.password) return '两次输入的密码不一致';
+        return true;
       },
       trigger: ['blur', 'change'],
     },
   ],
-}
+};
 </script>
 ```
 
@@ -136,20 +136,20 @@ const rules = {
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const formRef = ref()
+const formRef = ref();
 
 async function validateUsername() {
-  await formRef.value?.validateField('username')
+  await formRef.value?.validateField('username');
 }
 
 function resetUsername() {
-  formRef.value?.resetFields(['username'])
+  formRef.value?.resetFields(['username']);
 }
 
 function clearUsernameError() {
-  formRef.value?.clearValidate(['username'])
+  formRef.value?.clearValidate(['username']);
 }
 </script>
 ```
@@ -172,7 +172,7 @@ function clearUsernameError() {
 
 ```vue
 <script setup lang="ts">
-import FormDemo from '@/components/demos/form-demo.vue'
+import FormDemo from '@/components/demos/form-demo.vue';
 </script>
 
 <template>
@@ -184,9 +184,9 @@ import FormDemo from '@/components/demos/form-demo.vue'
 
 ```vue
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { reactive } from 'vue';
 
-const form = reactive({ name: '' })
+const form = reactive({ name: '' });
 </script>
 
 <template>
@@ -200,102 +200,163 @@ const form = reactive({ name: '' })
 </template>
 ```
 
+## 字段状态与验证契约
+
+- `lk-form-item` 的单一 `prop` 会被内部 `lk-input` / `lk-textarea` 自动继承；控件显式传入的 `prop` 优先。多字段 FormItem 必须在各控件上显式指定 `prop`，避免歧义。
+- `resetFields()` 恢复 FormItem 注册时的初始快照，不按当前值类型清空。普通对象/数组（含循环引用）及 Date、RegExp、Map、Set 会被深拷贝；其他自定义类实例保留原身份，因此表单模型应优先使用 JSON-like 普通数据。Form 的 `model` 对象身份或 FormItem 的 `prop` 改变后，会以新字段当前值重建快照。
+- `validate({ fields })` 只校验、更新并报告目标字段。`validate({ silent: true })` 仍 resolve/reject 校验结果，但只抑制验证状态、`validate` / `validate-field` 事件与滚动，不放宽结果的新鲜度要求。
+- 所有命令式 `validate()` / `validateField()`（包括 `silent`）进行中若被新校验、输入、reset、clear、禁用或 model/prop/rules 切换取代，都会 reject `{ code: 'FORM_VALIDATION_SUPERSEDED' }`；该旧轮次不写状态、不发验证事件、不滚动。调用方必须把它当作“无有效结论”，不能继续提交。
+- `field-change` / `field-blur` 后会先等待父 Form 状态交付，再决定是否启动自动验证；`validate-field` / `validate` 后也会跨 `nextTick` 保留本轮状态所有权。监听器交付 disabled、改模型、reset 或重入验证时，旧提交会回滚，命令式旧 Promise 按上条契约 reject。
+- Input/Textarea 接受一次正常原生输入时，恰好触发一次 `change` 规则；失焦只触发 `blur` 规则。无匹配 trigger 时保留原验证状态。
+- Form `disabled` 会合并到文档“表单控件”分类中的所有可编辑控件：Input、Textarea、Radio（单独/组）、Checkbox（单独/组）、SelectList、Switch、Stepper、Slider、Rate、Upload、Picker、Calendar、CalendarPicker、Keyboard、VerifyCode。禁用会同步阻断用户触发的值更新、业务交互与表单验证；已经开始但尚未提交的异步/手势/定时交互也会失效。Picker、CalendarPicker 与 Keyboard 的关闭/取消仍可用；Upload 会取消正在上传的任务并按 `uid` 恢复该文件上传前状态。组件公开的程序化方法不等同于用户交互，按各组件 API 契约执行。
+- 只有 Input/Textarea 自动继承单字段 FormItem 的 `prop`（显式 `prop` 可覆盖）。Checkbox/Radio（单独或 Group）、Switch、Stepper、Slider、Rate 支持显式 `prop` / `validateEvent` 并可触发表单字段验证。SelectList、Upload、Picker、Calendar、CalendarPicker、Keyboard、VerifyCode 仅继承 Form disabled，不声明字段验证 API；合并 disabled 不会扩大既有验证范围。
+
+### disabled 的公开事件边界
+
+可编辑控件的多阶段交互在每个公开 proposal 或最终模型提交后都会等待一次 Vue `nextTick`，再读取真实父 `LkForm` 已交付的 `disabled`。监听器若在该事件中把 Form 设为 disabled，首个已经发出的最终 `update:modelValue` 不会被伪装成可撤回，但后续业务事件、表单验证、定时器和异步提交必须停止。同一调用栈内 `true → false`、且未被 Vue 交付给子组件的脉冲不属于可观察契约。关闭/取消链同样等待交付边沿并在组件卸载时停止，但不以 disabled 阻断关闭。
+
+| 控件                             | 公开顺序（`→` 表示进入下一阶段前检查真实 Form 状态）                                                                                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Input                            | `update:modelValue → input → change（需要时）→ Form field-change`；`blur → change → Form field-blur`；compositionend 复用同一交互代际后进入输入链                                                                                |
+| Textarea                         | `update:modelValue → input → Form field-change`；延迟的 `blur → change → Form field-blur`；compositionend 复用同一交互代际                                                                                                       |
+| Checkbox / Radio（单独或 Group） | 子项 `click → update:modelValue → change → item-change（Group）→ Form field-change（显式 prop）`                                                                                                                                 |
+| SelectList                       | `update:modelValue → change → select`                                                                                                                                                                                            |
+| Switch                           | `click → before-change → beforeChange 回调 → update:modelValue → change → Form field-change`                                                                                                                                     |
+| Stepper                          | 按钮：`before-change → beforeChange 回调 → update:modelValue → change → plus/minus → Form field-change`；输入框：`blur → before-change → beforeChange 回调 → update:modelValue → change → Form field-change`                     |
+| Slider                           | 轨道点击：`update:modelValue → input → click → change → Form field-change`；拖拽：`update:modelValue/input → dragstart → change → Form field-change → dragend → drag-release`                                                    |
+| Rate                             | `click → clear（需要时）→ update:modelValue → change → Form field-change`                                                                                                                                                        |
+| Upload                           | `clickUpload/oversize/afterRead/retry/progress → 后续选择或上传阶段`；`update:modelValue → change`；`clickPreview → 原生 previewImage`。disabled 中止上传时只发修复性的 `update:modelValue`，不发 `change`，并关闭待确认删除弹窗 |
+| Picker                           | `pick → 草稿归一化`；确认时 `update:modelValue → change → confirm → update:visible(false)`；取消时 `cancel → update:visible(false)`，disabled 时仍可关闭                                                                         |
+| Calendar                         | 选择时 `update:modelValue → select → change`；翻页时 `update:viewDate → month/week/panel-change`                                                                                                                                 |
+| CalendarPicker                   | `update:modelValue → change → reset/confirm → 关闭（若配置）`；`update:show → open/close`，disabled 时 close 仍可用                                                                                                              |
+| Keyboard                         | `key-press → input/delete/confirm → update:modelValue 或关闭`；关闭时 `update:visible(false) → close`，disabled 时仍可关闭                                                                                                       |
+| VerifyCode                       | `update:modelValue → finish`；`send/resend → 启动倒计时 → countdown-end`                                                                                                                                                         |
+
+## Form 契约演练探针
+
+组件 Demo 内置 `#form-contract-probe`，状态同时输出到 dataset 与 `#form-contract-probe-state`。输入控件只在 FormItem 声明 `prop`，用于验证继承链。以下步骤是 Peekit 的客观验收合同，不代表文档构建或单测已完成真实运行态验收。
+
+### H5 Peekit
+
+1. 打开 Form Demo，查询 `#form-contract-probe`、`#form-contract-probe-input .lk-input__inner`、`#form-contract-probe-textarea .lk-textarea__inner`；所有 rect 必须非零，console/page errors 必须为空。
+2. 对 Input 派发一次原生 input（固定值 `x`）。`data-change-count` 与 `data-validation-count` 各增加 1，`#form-contract-probe-title-item` 为 `data-validation-status="error"`；不得出现第二次 change 验证。
+3. 点击 `#form-contract-probe-silent`。结果为 `data-silent-result="rejected"`、`data-silent-event-delta="0"`，title item 的状态和消息与点击前完全一致。
+4. 编辑两字段后点击 `#form-contract-probe-reset`。`data-title="Initial title"`、`data-notes="Initial notes"`，reset 计数只增加 1，两项状态均回到 `idle`。
+5. 输入固定值 `pending-invalid` 后立即点击 reset；等待至少 800ms。`data-async-started="1"` 与 `data-async-settled="1"` 证明旧异步规则确实完成，但 title 仍为初始值、item 仍为 `idle`，`data-validation-count` 不得因旧结果增加。
+6. 基础控件必须先做启用态正向对照，不能点击没有 handler 的组件根来证明禁用。依次操作：`#form-contract-probe-checkbox-action`、`#form-contract-probe-radio-action`、`#form-contract-probe-switch`、`#form-contract-probe-stepper .lk-stepper__plus`、`#form-contract-probe-slider .lk-slider__track-container`（在非零 rect 的 75% 横坐标点击）、`#form-contract-probe-rate .lk-rate__item` 查询结果的固定索引 1、`#form-contract-probe-select .lk-select-list__item` 查询结果的固定索引 1。启用态必须分别得到 checkbox=`['a']`、radio=`'b'`、switch=`true`、stepper=`2`、slider 大于 20、rate=`2`、select=`'b'`。随后点击 `#form-contract-probe-advanced-reset`，确认七项精确恢复为 `[]/'a'/false/1/20/1/'a'`；再点击 `#form-contract-probe-disable`，对同一目标、同一坐标或固定索引重放动作，七项值与输入/验证计数必须全部不变。Input/Textarea 的启用态正向对照沿用第 2 步，禁用后也要对同一原生节点重放固定输入并确认值、事件与验证计数不变。
+7. 下面 6 组复杂交互也集中在同一个 Form Demo。每组开始前点击 `#form-contract-probe-advanced-reset`，并确认 `data-disabled="false"`：
+   - Upload：点击 `#form-contract-probe-upload-start` 后，`#form-contract-probe-upload-state` 必须为 `data-status="uploading"`；记录 `data-change-count`，点击总开关 disable，再点击 `#form-contract-probe-upload-stale-success`。最终必须恢复 `data-status="fail"`、`data-progress="20"`、`data-success-count="0"`，且禁用清理不能增加 `data-change-count`；旧成功回调不得改写状态。
+   - Picker：点击 `#form-contract-probe-picker-open`，确认 `data-visible="true"` 后点击遮罩之上的 `#form-contract-probe-overlay-disable`。点击 `#form-contract-probe-picker .lk-picker__item` 的第二项及 `.lk-picker__btn--confirm`，`data-value="a"`、pick/confirm 计数均为 0；再点 `.lk-picker__btn--cancel`，必须 `data-visible="false"`、`data-cancel-count="1"`。
+   - Calendar：disable 后点击 `#form-contract-probe-calendar [data-date="2026-08-14"]`；`#form-contract-probe-calendar-state` 必须保持 `data-value="2026-08-13"`、`data-change-count="0"`。
+   - CalendarPicker：先点 `#form-contract-probe-calendar-picker-open`，确认 `data-show="true"` 后点击 `#form-contract-probe-overlay-disable`；只在 `#form-contract-probe-calendar-picker` 根内点击 `[data-date="2026-08-14"]`、`.lk-calendar-picker__footer .lk-button` 与 `.lk-calendar-picker__close`，不得使用页面级裸 `[data-date]`。value 仍为 `2026-08-13` 且 change/confirm 均为 0；关闭后必须 `data-show="false"`、`data-close-count="1"`。
+   - Keyboard：先点 `#form-contract-probe-keyboard-open`，确认 `data-visible="true"` 后点击 `#form-contract-probe-overlay-disable`；点击 `#form-contract-probe-keyboard [data-key="1"]` 与 `.lk-keyboard__done`，value 仍为空且 input/confirm 均为 0；点击 `.lk-keyboard__close` 后必须 `data-visible="false"`、`data-close-count="1"`。
+   - VerifyCode：点击 `#form-contract-probe-verify .lk-verify-code__countdown-btn`，确认 `data-send-count="1"` 后立即 disable；等待至少 1200ms，`#form-contract-probe-verify-state` 必须保持 `data-countdown-end-count="0"`、value 为空。
+8. 每个单节点 selector 在执行前必须断言只解析到 1 个非零 rect。Rate 的 `.lk-rate__item` 必须恰好 5 个、SelectList 的 `.lk-select-list__item` 必须恰好 2 个，再读取约定的固定索引及其非零 rect；数量、索引或尺寸不符即失败。每一步都同时读取对应 state dataset 与 `#form-contract-probe-state` 的结构化 JSON，并保存动作前/动作后/旧回调等待后的截图与 console/page errors。当前文档只定义验收合同；未保存这些真实证据前不得标记 H5 通过。
+
+### 微信小程序 Peekit
+
+1. 在同一 Demo route 查询上述稳定 id 及其原生 `input` / `textarea` 节点，记录 WXML、properties、dataset、rect 与错误日志。
+2. 用一次 `{ detail: { value: 'x' } }` 原生 input 事件执行第 2 步；事件计数、错误状态和单次触发约束必须与 H5 一致。
+3. 依次复验 silent、reset 与 `pending-invalid → 立即 reset → 等待旧异步完成`，再 tap disable；禁用后 Input/Textarea 原生节点 `disabled=true`，其余控件 `aria-disabled=true` 或呈现等价平台属性，状态 JSON 与计数不变。
+4. 不得把 H5 的复合 selector 直接用于页面 SelectorQuery。先从页面按稳定 id 精确取得 `lk-*` 自定义组件宿主（恰好 1 个且 rect 非零），再用该组件实例创建 `createSelectorQuery().in(component)` 查询它的内部目标；CalendarPicker 还需先进入其 `lk-calendar` 子组件实例，再在该实例内查询 `[data-date="2026-08-14"]`。Picker、Keyboard 同理在各自宿主实例内查询 item/button/key；关闭/取消必须在所属组件实例内真实 tap，不能只看属性。每一层宿主与最终目标都必须分别断言恰好 1 个非零 rect，无法取得组件实例或跨层 scope 即判失败，不得以页面级裸 selector 代替。
+5. H5 与微信证据需分别保存动作前后快照；只有两端均满足数值断言且 errors 为空，才可标记通过。构建成功不能替代该证据。
+
 ## API
 
 ### Form Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| model | 表单数据对象，必填 | `Record<string, unknown>` | — | — |
-| rules | 表单校验规则 | `FormRules` | — | `undefined` |
-| labelWidth | 默认标签宽度，支持数字或带单位字符串 | `string / number` | — | `''` |
-| labelAlign | 默认标签对齐方式 | `string` | `left / right / top` | `left` |
-| showMessage | 是否显示错误提示文本 | `boolean` | — | `true` |
-| scrollToError | 校验失败时是否自动滚动到第一个错误字段 | `boolean` | — | `false` |
-| disabled | 是否禁用表单内控件的业务状态传递 | `boolean` | — | `false` |
-| border | 是否显示单元格边框 | `boolean` | — | `false` |
-| card | 是否为圆角卡片布局 | `boolean` | — | `false` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数             | 说明                                       | 类型                                                                                   | 可选值               | 默认值      |
+| ---------------- | ------------------------------------------ | -------------------------------------------------------------------------------------- | -------------------- | ----------- |
+| model            | 表单数据对象，必填                         | `Record<string, unknown>`                                                              | —                    | —           |
+| rules            | 表单校验规则                               | `FormRules`                                                                            | —                    | `undefined` |
+| labelWidth       | 默认标签宽度，支持数字或带单位字符串       | `string / number`                                                                      | —                    | `''`        |
+| labelAlign       | 默认标签对齐方式                           | `string`                                                                               | `left / right / top` | `left`      |
+| showMessage      | 是否显示错误提示文本                       | `boolean`                                                                              | —                    | `true`      |
+| scrollToError    | 校验失败时是否自动滚动到第一个错误字段     | `boolean`                                                                              | —                    | `false`     |
+| disabled         | 是否禁用表单内控件的业务状态传递           | `boolean`                                                                              | —                    | `false`     |
+| border           | 是否显示单元格边框                         | `boolean`                                                                              | —                    | `false`     |
+| card             | 是否为圆角卡片布局                         | `boolean`                                                                              | —                    | `false`     |
+| customValidator  | 整表自定义校验器，返回字段到错误信息的映射 | `(model) => Record<string, string> \| null \| Promise<Record<string, string> \| null>` | —                    | `undefined` |
+| asteriskPosition | 必填星号默认位置                           | `string`                                                                               | `left / right`       | `left`      |
+| id               | 根节点 id                                  | `string`                                                                               | —                    | `''`        |
+| customClass      | 自定义类名                                 | `string / object / array`                                                              | —                    | `''`        |
+| customStyle      | 自定义样式                                 | `string / object`                                                                      | —                    | `''`        |
 
 ### Form Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| validate | 调用 `validate()` 后触发，表示整体验证结果 | `(ok: boolean, errors: ValidateError[] \| null)` |
-| validate-field | 单个字段完成校验后触发 | `(prop: string, ok: boolean, errors: ValidateError[] \| null)` |
-| field-blur | 字段触发 blur 校验前触发 | `(prop: string)` |
-| field-change | 字段触发 change 校验前触发 | `(prop: string, value?: unknown)` |
-| reset | 调用 `resetFields()` 后触发 | `(fields?: string[])` |
-| clear-validate | 调用 `clearValidate()` 后触发 | `(fields?: string[])` |
+| 事件名         | 说明                                       | 回调参数                                                       |
+| -------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| validate       | 调用 `validate()` 后触发，表示整体验证结果 | `(ok: boolean, errors: ValidateError[] \| null)`               |
+| validate-field | 单个字段完成校验后触发                     | `(prop: string, ok: boolean, errors: ValidateError[] \| null)` |
+| field-blur     | 字段触发 blur 校验前触发                   | `(prop: string)`                                               |
+| field-change   | 字段触发 change 校验前触发                 | `(prop: string, value?: unknown)`                              |
+| reset          | 调用 `resetFields()` 后触发                | `(fields?: string[])`                                          |
+| clear-validate | 调用 `clearValidate()` 后触发              | `(fields?: string[])`                                          |
 
 ### Form Methods
 
-| 方法名 | 说明 | 参数 |
-|--------|------|------|
-| validate() | 校验全部字段，失败时返回 `Promise.reject(errors)` | `opts?: { fields?: string[]; silent?: boolean }` |
-| validateField() | 校验单个字段 | `(prop: string)` |
-| resetFields() | 重置全部或指定字段的值与校验状态 | `(fields?: string[])` |
-| clearValidate() | 清除全部或指定字段的校验状态，不重置值 | `(fields?: string[])` |
-| scrollToField() | 滚动到指定字段 | `(prop: string)` |
+| 方法名          | 说明                                                                                 | 参数                                             |
+| --------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| validate()      | 校验全部字段；失败 reject errors，被新状态取代时 reject `FORM_VALIDATION_SUPERSEDED` | `opts?: { fields?: string[]; silent?: boolean }` |
+| validateField() | 校验单个字段；被新状态取代时同样 reject                                              | `(prop: string)`                                 |
+| resetFields()   | 重置全部或指定字段的值与校验状态                                                     | `(fields?: string[])`                            |
+| clearValidate() | 清除全部或指定字段的校验状态，不重置值                                               | `(fields?: string[])`                            |
+| scrollToField() | 滚动到指定字段                                                                       | `(prop: string)`                                 |
 
 ### FormItem Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| prop | 对应 `model` 中的字段名 | `string` | — | `''` |
-| label | 标签文本 | `string` | — | `''` |
-| required | 是否强制显示必填星号；不传时根据规则自动推断 | `boolean` | — | `undefined` |
-| labelWidth | 当前项标签宽度，优先级高于 Form | `string / number` | — | `''` |
-| labelAlign | 当前项标签对齐方式，优先级高于 Form | `string` | `left / right / top` | `''` |
-| showMessage | 当前项是否显示错误信息，优先级高于 Form | `boolean` | — | `undefined` |
-| isLink | 是否显示右侧箭头，常用于选择器跳转场景 | `boolean` | — | `false` |
-| vertical | 是否垂直布局，标签居上内容居下 | `boolean` | — | `false` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数             | 说明                                         | 类型                      | 可选值               | 默认值      |
+| ---------------- | -------------------------------------------- | ------------------------- | -------------------- | ----------- |
+| prop             | 对应 `model` 中的一个或多个字段名            | `string / string[]`       | —                    | `''`        |
+| label            | 标签文本                                     | `string`                  | —                    | `''`        |
+| required         | 是否强制显示必填星号；不传时根据规则自动推断 | `boolean`                 | —                    | `undefined` |
+| labelWidth       | 当前项标签宽度，优先级高于 Form              | `string / number`         | —                    | `''`        |
+| labelAlign       | 当前项标签对齐方式，优先级高于 Form          | `string`                  | `left / right / top` | `''`        |
+| showMessage      | 当前项是否显示错误信息，优先级高于 Form      | `boolean`                 | —                    | `undefined` |
+| isLink           | 是否显示右侧箭头，常用于选择器跳转场景       | `boolean`                 | —                    | `false`     |
+| vertical         | 是否垂直布局，标签居上内容居下               | `boolean`                 | —                    | `false`     |
+| asteriskPosition | 当前项必填星号位置，未传时继承 Form          | `string`                  | `'' / left / right`  | `''`        |
+| border           | 是否显示当前项底部边框，未传时继承 Form      | `boolean`                 | —                    | `undefined` |
+| id               | 根节点 id                                    | `string`                  | —                    | `''`        |
+| customClass      | 自定义类名                                   | `string / object / array` | —                    | `''`        |
+| customStyle      | 自定义样式                                   | `string / object`         | —                    | `''`        |
 
 ### FormItem Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| click | 点击表单项时触发 | `(event: Event)` |
-| tap | UniApp `tap` 兼容事件 | `(event: Event)` |
+| 事件名 | 说明                  | 回调参数         |
+| ------ | --------------------- | ---------------- |
+| click  | 点击表单项时触发      | `(event: Event)` |
+| tap    | UniApp `tap` 兼容事件 | `(event: Event)` |
 
 ### FormItem Slots
 
-| 插槽名 | 说明 |
-|--------|------|
-| default | 表单控件内容 |
-| label | 自定义标签区域 |
+| 插槽名  | 说明           |
+| ------- | -------------- |
+| default | 表单控件内容   |
+| label   | 自定义标签区域 |
 
 ### FormItem Methods
 
-| 方法名 | 说明 | 参数 |
-|--------|------|------|
-| validate() | 手动校验当前表单项 | `(trigger?: 'blur' \| 'change')` |
-| resetField() | 重置当前字段值并清除校验状态 | — |
-| clearValidate() | 清除当前字段校验状态 | — |
+| 方法名          | 说明                                                                                | 参数                             |
+| --------------- | ----------------------------------------------------------------------------------- | -------------------------------- |
+| validate()      | 手动校验当前表单项；失败 reject `ValidateError[]`，被新状态取代时 resolve `'stale'` | `(trigger?: 'blur' \| 'change')` |
+| resetField()    | 重置当前字段值并清除校验状态                                                        | —                                |
+| clearValidate() | 清除当前字段校验状态                                                                | —                                |
 
 ### Rule 结构
 
-| 字段 | 说明 | 类型 |
-|------|------|------|
-| required | 是否必填 | `boolean` |
-| message | 失败提示文案 | `string` |
-| trigger | 触发时机 | `'blur' \| 'change' \| Array<'blur' \| 'change'>` |
-| min | 最小长度或最小值 | `number` |
-| max | 最大长度或最大值 | `number` |
-| pattern | 正则校验 | `RegExp` |
-| validator | 自定义校验函数 | `(value, rule, model) => boolean \| string \| Promise<boolean \| string>` |
+| 字段      | 说明             | 类型                                                                      |
+| --------- | ---------------- | ------------------------------------------------------------------------- |
+| required  | 是否必填         | `boolean`                                                                 |
+| message   | 失败提示文案     | `string`                                                                  |
+| trigger   | 触发时机         | `'blur' \| 'change' \| Array<'blur' \| 'change'>`                         |
+| min       | 最小长度或最小值 | `number`                                                                  |
+| max       | 最大长度或最大值 | `number`                                                                  |
+| pattern   | 正则校验         | `RegExp`                                                                  |
+| validator | 自定义校验函数   | `(value, rule, model) => boolean \| string \| Promise<boolean \| string>` |
 
 ## 使用建议
 
 ::: tip
-输入类组件如果需要联动表单 `blur/change` 校验，建议同时传入与 `lk-form-item` 一致的 `prop`。
-:::
-
-::: warning
-`resetFields()` 会按照字段当前类型恢复为 `''`、`0`、`false`、`[]` 或 `null`，使用前建议确保初始模型结构稳定。
+单字段 FormItem 内的 Input/Textarea 无需重复传 `prop`；`resetFields()` 始终恢复注册时初始值。需要清空业务数据时，请显式修改 model，不要把 reset 当作 clear。
 :::

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -26,8 +26,8 @@ phone: input
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const val = ref('')
+import { ref } from 'vue';
+const val = ref('');
 </script>
 
 <template>
@@ -79,8 +79,8 @@ const val = ref('')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const bio = ref('')
+import { ref } from 'vue';
+const bio = ref('');
 </script>
 
 <template>
@@ -88,12 +88,7 @@ const bio = ref('')
   <lk-input v-model="bio" placeholder="请输入昵称" clearable />
 
   <!-- 字数统计（配合 maxlength） -->
-  <lk-input
-    v-model="bio"
-    placeholder="一句话介绍自己"
-    :maxlength="50"
-    show-count
-  />
+  <lk-input v-model="bio" placeholder="一句话介绍自己" :maxlength="50" show-count />
 </template>
 ```
 
@@ -102,8 +97,8 @@ const bio = ref('')
 ```vue
 <template>
   <view class="demo-col">
-    <lk-input value="禁用状态" disabled />
-    <lk-input value="只读状态" readonly />
+    <lk-input model-value="禁用状态" disabled />
+    <lk-input model-value="只读状态" readonly />
   </view>
 </template>
 ```
@@ -112,16 +107,16 @@ const bio = ref('')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const keyword = ref('')
+const keyword = ref('');
 
 function onInput(value: string | number) {
-  keyword.value = String(value)
+  keyword.value = String(value);
 }
 
 function onConfirm(event: any) {
-  console.log('confirm value:', event.detail?.value)
+  console.log('confirm value:', event.detail?.value);
 }
 </script>
 
@@ -143,12 +138,7 @@ function onConfirm(event: any) {
 
 ```vue
 <template>
-  <lk-input
-    fake
-    prefix-icon="search"
-    placeholder="搜索商品"
-    @click="goSearch"
-  />
+  <lk-input fake prefix-icon="search" placeholder="搜索商品" @click="goSearch" />
 </template>
 ```
 
@@ -156,32 +146,28 @@ function onConfirm(event: any) {
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const formRef = ref()
-const form = ref({ username: '', phone: '' })
+import { reactive, ref } from 'vue';
+const formRef = ref();
+const form = reactive({ username: '', phone: '' });
+const rules = {
+  username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
+  phone: [
+    { required: true, message: '请输入手机号', trigger: 'blur' },
+    { pattern: /^1[3-9]\d{9}$/, message: '手机号格式不正确', trigger: 'change' },
+  ],
+};
 
 async function submit() {
-  await formRef.value.validate()
+  await formRef.value.validate();
 }
 </script>
 
 <template>
-  <lk-form ref="formRef" :model="form">
-    <lk-form-item
-      label="用户名"
-      prop="username"
-      :rules="[{ required: true, message: '请输入用户名' }]"
-    >
+  <lk-form ref="formRef" :model="form" :rules="rules">
+    <lk-form-item label="用户名" prop="username">
       <lk-input v-model="form.username" prefix-icon="person" placeholder="请输入用户名" />
     </lk-form-item>
-    <lk-form-item
-      label="手机号"
-      prop="phone"
-      :rules="[
-        { required: true, message: '请输入手机号' },
-        { pattern: /^1[3-9]\d{9}$/, message: '手机号格式不正确' }
-      ]"
-    >
+    <lk-form-item label="手机号" prop="phone">
       <lk-input v-model="form.phone" type="tel" prefix-icon="phone" placeholder="请输入手机号" />
     </lk-form-item>
     <lk-button block @click="submit">提交</lk-button>
@@ -189,78 +175,81 @@ async function submit() {
 </template>
 ```
 
+每次被接受的原生 input 只触发一次 Form `change` 规则，blur 只触发 `blur` 规则。H5 只读输入仍可聚焦和选择文本，并可发公共 `focus` / `blur`，但失焦不发 `change`，也不触发 Form blur 校验；微信小程序将 readonly 映射为原生 `disabled` 以可靠阻断键盘，因此不承诺只读态的 `focus` / `blur`。`validate-event="false"` 可关闭两类自动联动。祖先 Form disabled 与 Input 自身 disabled 取并集。
+
 ## API
 
 ### Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 绑定值，支持 `v-model` | `string / number` | — | `''` |
-| type | 输入类型 | `string` | `text / password / number / tel / email / digit / idcard` | `text` |
-| size | 尺寸 | `string` | `sm / md / lg` | `md` |
-| placeholder | 占位文字 | `string` | — | `''` |
-| placeholderStyle | 占位符样式 | `string` | — | `''` |
-| placeholderClass | 占位符样式类 | `string` | — | `input-placeholder` |
-| name | 原生表单字段名 | `string` | — | `''` |
-| disabled | 是否禁用 | `boolean` | — | `false` |
-| readonly | 是否只读 | `boolean` | — | `false` |
-| clearable | 是否显示清空按钮 | `boolean` | — | `true` |
-| maxlength | 最大长度，`-1` 表示不限制 | `number` | — | `-1` |
-| showCount | 是否显示字数统计 | `boolean` | — | `false` |
-| showWordLimit | 是否显示输入字数限制 | `boolean` | — | `false` |
-| prop | 表单字段名，用于 Form 校验联动 | `string` | — | `''` |
-| autofocus | 首次渲染时是否自动聚焦 | `boolean` | — | `false` |
-| focus | 是否聚焦，受控聚焦状态 | `boolean` | — | `false` |
-| prefixIcon | 前缀图标名 | `string` | — | `''` |
-| suffixIcon | 后缀图标名 | `string` | — | `''` |
-| showPassword | 密码输入时是否显示明暗切换按钮 | `boolean` | — | `false` |
-| borderless | 是否无边框，常用于表单列表内 | `boolean` | — | `false` |
-| inputAlign | 输入内容对齐方式 | `string` | `left / center / right` | `left` |
-| confirmType | 键盘右下角按钮文字 | `string` | `send / search / next / go / done / return` | `done` |
-| confirmHold | 点击键盘右下角按钮时是否保持键盘不收起 | `boolean` | — | `false` |
-| cursorSpacing | 光标与键盘的距离，单位 px | `number` | — | `0` |
-| cursor | 指定聚焦时的光标位置 | `number` | — | `-1` |
-| selectionStart | 光标起始位置，需与 `selectionEnd` 搭配使用 | `number` | — | `-1` |
-| selectionEnd | 光标结束位置，需与 `selectionStart` 搭配使用 | `number` | — | `-1` |
-| adjustPosition | 键盘弹起时是否自动上推页面 | `boolean` | — | `true` |
-| holdKeyboard | 聚焦时点击页面是否保持键盘不收起 | `boolean` | — | `false` |
-| inputmode | H5/App 输入模式提示 | `string` | `none / text / decimal / numeric / tel / search / email / url` | `text` |
-| ignoreCompositionEvent | 是否忽略系统组合输入事件 | `boolean` | — | `true` |
-| fake | 是否为假输入框模式 | `boolean` | — | `false` |
-| fakeText | 假输入框显示文本，不设置时使用 `placeholder` | `string` | — | `''` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数                   | 说明                                         | 类型                      | 可选值                                                         | 默认值              |
+| ---------------------- | -------------------------------------------- | ------------------------- | -------------------------------------------------------------- | ------------------- |
+| modelValue             | 绑定值，支持 `v-model`                       | `string / number`         | —                                                              | `''`                |
+| type                   | 输入类型                                     | `string`                  | `text / password / number / tel / email / digit / idcard`      | `text`              |
+| size                   | 尺寸                                         | `string`                  | `sm / md / lg`                                                 | `md`                |
+| placeholder            | 占位文字                                     | `string`                  | —                                                              | `''`                |
+| placeholderStyle       | 占位符样式                                   | `string`                  | —                                                              | `''`                |
+| placeholderClass       | 占位符样式类                                 | `string`                  | —                                                              | `input-placeholder` |
+| name                   | 原生表单字段名                               | `string`                  | —                                                              | `''`                |
+| disabled               | 是否禁用                                     | `boolean`                 | —                                                              | `false`             |
+| readonly               | 是否只读；平台焦点行为见上方说明             | `boolean`                 | —                                                              | `false`             |
+| clearable              | 是否显示清空按钮                             | `boolean`                 | —                                                              | `true`              |
+| maxlength              | 最大长度，`-1` 表示不限制                    | `number`                  | —                                                              | `-1`                |
+| showCount              | 是否显示字数统计                             | `boolean`                 | —                                                              | `false`             |
+| showWordLimit          | 是否显示输入字数限制                         | `boolean`                 | —                                                              | `false`             |
+| prop                   | 表单字段名，用于 Form 校验联动               | `string`                  | —                                                              | `''`                |
+| validateEvent          | 是否自动触发 Form change/blur 校验           | `boolean`                 | —                                                              | `true`              |
+| autofocus              | 首次渲染时是否自动聚焦                       | `boolean`                 | —                                                              | `false`             |
+| focus                  | 是否聚焦，受控聚焦状态                       | `boolean`                 | —                                                              | `false`             |
+| prefixIcon             | 前缀图标名                                   | `string`                  | —                                                              | `''`                |
+| suffixIcon             | 后缀图标名                                   | `string`                  | —                                                              | `''`                |
+| showPassword           | 密码输入时是否显示明暗切换按钮               | `boolean`                 | —                                                              | `false`             |
+| borderless             | 是否无边框，常用于表单列表内                 | `boolean`                 | —                                                              | `false`             |
+| inputAlign             | 输入内容对齐方式                             | `string`                  | `left / center / right`                                        | `left`              |
+| confirmType            | 键盘右下角按钮文字                           | `string`                  | `send / search / next / go / done / return`                    | `done`              |
+| confirmHold            | 点击键盘右下角按钮时是否保持键盘不收起       | `boolean`                 | —                                                              | `false`             |
+| cursorSpacing          | 光标与键盘的距离，单位 px                    | `number`                  | —                                                              | `0`                 |
+| cursor                 | 指定聚焦时的光标位置                         | `number`                  | —                                                              | `-1`                |
+| selectionStart         | 光标起始位置，需与 `selectionEnd` 搭配使用   | `number`                  | —                                                              | `-1`                |
+| selectionEnd           | 光标结束位置，需与 `selectionStart` 搭配使用 | `number`                  | —                                                              | `-1`                |
+| adjustPosition         | 键盘弹起时是否自动上推页面                   | `boolean`                 | —                                                              | `true`              |
+| holdKeyboard           | 聚焦时点击页面是否保持键盘不收起             | `boolean`                 | —                                                              | `false`             |
+| inputmode              | H5/App 输入模式提示                          | `string`                  | `none / text / decimal / numeric / tel / search / email / url` | `text`              |
+| ignoreCompositionEvent | 是否忽略系统组合输入事件                     | `boolean`                 | —                                                              | `true`              |
+| fake                   | 是否为假输入框模式                           | `boolean`                 | —                                                              | `false`             |
+| fakeText               | 假输入框显示文本，不设置时使用 `placeholder` | `string`                  | —                                                              | `''`                |
+| id                     | 根节点 id                                    | `string`                  | —                                                              | `''`                |
+| customClass            | 自定义类名                                   | `string / object / array` | —                                                              | `''`                |
+| customStyle            | 自定义样式                                   | `string / object`         | —                                                              | `''`                |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 输入值变化时触发，用于 `v-model` | `(value: string \| number)` |
-| input | 键盘输入时触发，组合输入中默认等 `compositionend` 后触发 | `(value: string \| number)` |
-| change | 清空或失焦提交最终值时触发 | `(value: string \| number)` |
-| focus | 输入框聚焦时触发 | `(event: Event)` |
-| blur | 输入框失焦时触发 | `(event: Event)` |
-| confirm | 点击键盘右下角按钮时触发 | `(event: Event)` |
-| keyboardheightchange | 键盘高度变化时触发 | `(event: Event)` |
-| clear | 点击清空按钮时触发 | `()` |
-| click | `fake=true` 时点击假输入框触发 | `(event: Event)` |
-| compositionstart | 组合输入开始时触发 | `(event: Event)` |
-| compositionupdate | 组合输入更新时触发 | `(event: Event)` |
-| compositionend | 组合输入结束时触发 | `(event: Event)` |
+| 事件名               | 说明                                                     | 回调参数                    |
+| -------------------- | -------------------------------------------------------- | --------------------------- |
+| update:modelValue    | 输入值变化时触发，用于 `v-model`                         | `(value: string \| number)` |
+| input                | 键盘输入时触发，组合输入中默认等 `compositionend` 后触发 | `(value: string \| number)` |
+| change               | 清空或失焦提交最终值时触发                               | `(value: string \| number)` |
+| focus                | 输入框聚焦时触发                                         | `(event: Event)`            |
+| blur                 | 输入框失焦时触发                                         | `(event: Event)`            |
+| confirm              | 点击键盘右下角按钮时触发                                 | `(event: Event)`            |
+| keyboardheightchange | 键盘高度变化时触发                                       | `(event: Event)`            |
+| clear                | 点击清空按钮时触发                                       | `()`                        |
+| click                | `fake=true` 时点击假输入框触发                           | `(event: Event)`            |
+| compositionstart     | 组合输入开始时触发                                       | `(event: Event)`            |
+| compositionupdate    | 组合输入更新时触发                                       | `(event: Event)`            |
+| compositionend       | 组合输入结束时触发                                       | `(event: Event)`            |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
+| 插槽名 | 说明           |
+| ------ | -------------- |
 | prefix | 前缀自定义内容 |
 | suffix | 后缀自定义内容 |
-| notice | 内嵌通知内容 |
+| notice | 内嵌通知内容   |
 
 ## 注意事项
 
 ::: tip
-`update:modelValue` 与 `input` 会在输入值变化时同步触发；`change` 主要用于失焦提交与清空场景，适合触发表单校验。
+一次被接受的输入先触发 `update:modelValue`，组件在下一次 Vue 状态交付后再触发 `input`；若父级监听器在前一阶段交付了 Form disabled、readonly 或卸载，后续事件会停止。`change` 主要用于失焦提交与清空场景，适合触发表单校验。
 :::
 
 ::: warning

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -21,8 +21,8 @@ phone: radio
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const checked = ref('A')
+import { ref } from 'vue';
+const checked = ref('A');
 </script>
 
 <template>
@@ -41,9 +41,9 @@ const checked = ref('A')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const answer = ref('yes')
+const answer = ref('yes');
 </script>
 
 <template>
@@ -55,8 +55,8 @@ const answer = ref('yes')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const plan = ref('lite')
+import { ref } from 'vue';
+const plan = ref('lite');
 </script>
 
 <template>
@@ -131,9 +131,9 @@ const plan = ref('lite')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-const gender = ref('male')
-const agree = ref(false)
+import { ref } from 'vue';
+const gender = ref('male');
+const agree = ref(false);
 </script>
 
 <template>
@@ -152,57 +152,61 @@ const agree = ref(false)
 
 ### RadioGroup Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 绑定值，支持 `v-model` | `string / number / boolean` | — | `''` |
-| direction | 排列方向 | `string` | `row / column` | `row` |
-| shape | 外观形状 | `string` | `circle / square` | `circle` |
-| iconType | 图标样式 | `string` | `dot / check` | `dot` |
-| size | 尺寸 | `string` | `sm / md / lg` | `md` |
-| disabled | 是否全部禁用 | `boolean` | — | `false` |
-| activeColor | 选中颜色 | `string` | — | `''` |
-| prop | 表单字段名，配合 `lk-form` 联动校验 | `string` | — | `''` |
-| validateEvent | 值变更时是否触发表单校验 | `boolean` | — | `true` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+Radio 位于 Group 内时，只由 Group 的 `prop` / `validateEvent` 触发一次字段验证；子项的同名 props 不重复上报。
+
+| 参数          | 说明                                | 类型                        | 可选值            | 默认值   |
+| ------------- | ----------------------------------- | --------------------------- | ----------------- | -------- |
+| modelValue    | 绑定值，支持 `v-model`              | `string / number / boolean` | —                 | `''`     |
+| direction     | 排列方向                            | `string`                    | `row / column`    | `row`    |
+| shape         | 外观形状                            | `string`                    | `circle / square` | `circle` |
+| iconType      | 图标样式                            | `string`                    | `dot / check`     | `dot`    |
+| size          | 尺寸                                | `string`                    | `sm / md / lg`    | `md`     |
+| disabled      | 是否全部禁用                        | `boolean`                   | —                 | `false`  |
+| activeColor   | 选中颜色                            | `string`                    | —                 | `''`     |
+| prop          | 表单字段名，配合 `lk-form` 联动校验 | `string`                    | —                 | `''`     |
+| validateEvent | 值变更时是否触发表单校验            | `boolean`                   | —                 | `true`   |
+| id            | 根节点 id                           | `string`                    | —                 | `''`     |
+| customClass   | 自定义类名                          | `string / object / array`   | —                 | `''`     |
+| customStyle   | 自定义样式                          | `string / object`           | —                 | `''`     |
 
 ### RadioGroup Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 绑定值变化 | `(value: string \| number \| boolean)` |
-| change | 选项改变 | `(value: string \| number \| boolean)` |
-| item-change | 单个选项选中时触发 | `(value: string \| number \| boolean)` |
+| 事件名            | 说明               | 回调参数                               |
+| ----------------- | ------------------ | -------------------------------------- |
+| update:modelValue | 绑定值变化         | `(value: string \| number \| boolean)` |
+| change            | 选项改变           | `(value: string \| number \| boolean)` |
+| item-change       | 单个选项选中时触发 | `(value: string \| number \| boolean)` |
 
 ### Radio Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 单独使用时的绑定值 | `string / number / boolean` | — | `''` |
-| name | 唯一标识符，作为选中值 | `string / number / boolean` | — | `''` |
-| label | 标签文字，也可作为值回退 | `string` | — | `''` |
-| disabled | 是否禁用该项 | `boolean` | — | `false` |
-| labelDisabled | 点击文字是否触发选择 | `boolean` | — | `false` |
-| shape | 覆盖 Group 的形状 | `string` | `'' / circle / square` | `''` |
-| iconType | 覆盖 Group 的图标类型 | `string` | `'' / dot / check` | `''` |
-| activeColor | 覆盖 Group 的选中色 | `string` | — | `''` |
-| iconSize | 图标尺寸 | `string / number` | — | `''` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数          | 说明                                                      | 类型                        | 可选值                 | 默认值  |
+| ------------- | --------------------------------------------------------- | --------------------------- | ---------------------- | ------- |
+| modelValue    | 单独使用时的绑定值                                        | `string / number / boolean` | —                      | `''`    |
+| name          | 唯一标识符，作为选中值                                    | `string / number / boolean` | —                      | `''`    |
+| label         | 标签文字，也可作为值回退                                  | `string`                    | —                      | `''`    |
+| disabled      | 是否禁用该项                                              | `boolean`                   | —                      | `false` |
+| labelDisabled | 点击文字是否触发选择                                      | `boolean`                   | —                      | `false` |
+| shape         | 覆盖 Group 的形状                                         | `string`                    | `'' / circle / square` | `''`    |
+| iconType      | 覆盖 Group 的图标类型                                     | `string`                    | `'' / dot / check`     | `''`    |
+| activeColor   | 覆盖 Group 的选中色                                       | `string`                    | —                      | `''`    |
+| iconSize      | 图标尺寸                                                  | `string / number`           | —                      | `''`    |
+| prop          | 单独使用时的 Form 字段名；组内验证以 Group 的 `prop` 为准 | `string`                    | —                      | `''`    |
+| validateEvent | 单独使用时值变更是否触发 Form 验证；组内由 Group 控制     | `boolean`                   | —                      | `true`  |
+| id            | 根节点 id                                                 | `string`                    | —                      | `''`    |
+| customClass   | 自定义类名                                                | `string / object / array`   | —                      | `''`    |
+| customStyle   | 自定义样式                                                | `string / object`           | —                      | `''`    |
 
 ### Radio Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 单独使用时的绑定值变化 | `(value: string \| number \| boolean)` |
-| change | 单独使用时的值变化回调 | `(value: string \| number \| boolean)` |
-| click | 点击单选框时触发，禁用态不触发 | `(event: Event, checked: boolean, value: string \| number \| boolean)` |
+| 事件名            | 说明                           | 回调参数                                                               |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------- |
+| update:modelValue | 单独使用时的绑定值变化         | `(value: string \| number \| boolean)`                                 |
+| change            | 单独使用时的值变化回调         | `(value: string \| number \| boolean)`                                 |
+| click             | 点击单选框时触发，禁用态不触发 | `(event: Event, checked: boolean, value: string \| number \| boolean)` |
 
 ### Radio Slots
 
-| 插槽名 | 说明 |
-|--------|------|
-| default | 标签内容 |
-| icon | 自定义选中图标（参数：`{ checked, disabled }`） |
+| 插槽名  | 说明                                            |
+| ------- | ----------------------------------------------- |
+| default | 标签内容                                        |
+| icon    | 自定义选中图标（参数：`{ checked, disabled }`） |

--- a/docs/components/rate.md
+++ b/docs/components/rate.md
@@ -23,9 +23,9 @@ phone: rate
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const score = ref(3)
+const score = ref(3);
 </script>
 
 <template>
@@ -55,13 +55,7 @@ const score = ref(3)
 ## 自定义图标与颜色
 
 ```vue
-<lk-rate
-  v-model="score"
-  icon="star-fill"
-  icon-void="star"
-  color="#f5a623"
-  color-void="#d4d4d8"
-/>
+<lk-rate v-model="score" icon="star-fill" icon-void="star" color="#f5a623" color-void="#d4d4d8" />
 ```
 
 ## 自定义数量与尺寸
@@ -78,7 +72,7 @@ const score = ref(3)
 
 ```vue
 <script setup lang="ts">
-import RateDemo from '@/components/demos/rate-demo.vue'
+import RateDemo from '@/components/demos/rate-demo.vue';
 </script>
 
 <template>
@@ -100,32 +94,33 @@ import RateDemo from '@/components/demos/rate-demo.vue'
 
 ### Props
 
-| 参数 | 说明 | 类型 | 默认值 |
-|------|------|------|--------|
-| modelValue | 当前评分值 | `number` | `0` |
-| count | 图标总数量 | `number` | `5` |
-| disabled | 是否禁用 | `boolean` | `false` |
-| readonly | 是否只读 | `boolean` | `false` |
-| allowClear | 点击当前值时是否允许清零 | `boolean` | `true` |
-| size | 图标尺寸，数字按 `rpx` 处理 | `string \| number` | `48` |
-| color | 选中颜色 | `string` | `''` |
-| colorVoid | 未选中颜色 | `string` | `''` |
-| icon | 选中图标名 | `string` | `''` |
-| iconVoid | 未选中图标名 | `string` | `''` |
-| prop | 表单字段名 | `string` | `''` |
-| id | 根节点 id | `string` | `''` |
-| customClass | 根节点自定义类名 | `string \| object \| array` | — |
-| customStyle | 根节点自定义样式 | `string \| object` | — |
+| 参数          | 说明                        | 类型                        | 默认值  |
+| ------------- | --------------------------- | --------------------------- | ------- |
+| modelValue    | 当前评分值                  | `number`                    | `0`     |
+| count         | 图标总数量                  | `number`                    | `5`     |
+| disabled      | 是否禁用                    | `boolean`                   | `false` |
+| readonly      | 是否只读                    | `boolean`                   | `false` |
+| allowClear    | 点击当前值时是否允许清零    | `boolean`                   | `true`  |
+| size          | 图标尺寸，数字按 `rpx` 处理 | `string \| number`          | `48`    |
+| color         | 选中颜色                    | `string`                    | `''`    |
+| colorVoid     | 未选中颜色                  | `string`                    | `''`    |
+| icon          | 选中图标名                  | `string`                    | `''`    |
+| iconVoid      | 未选中图标名                | `string`                    | `''`    |
+| prop          | 表单字段名                  | `string`                    | `''`    |
+| validateEvent | 值变化时是否触发 Form 校验  | `boolean`                   | `true`  |
+| id            | 根节点 id                   | `string`                    | `''`    |
+| customClass   | 根节点自定义类名            | `string \| object \| array` | —       |
+| customStyle   | 根节点自定义样式            | `string \| object`          | —       |
 
 ### Events
 
-| 事件名 | 说明 | 参数 |
-|--------|------|------|
-| update:modelValue | 评分变化 | `(value: number) => void` |
-| change | 评分变化后的回调 | `(value: number, oldValue?: number) => void` |
-| click | 点击可交互图标时触发，早于 `change` | `({ value, oldValue, index, event }) => void` |
-| clear | 点击当前评分并清零时触发 | `({ oldValue, index, event }) => void` |
-| click-disabled | 点击禁用或只读评分时触发 | `({ value, index, disabled, readonly, event }) => void` |
+| 事件名            | 说明                                | 参数                                                    |
+| ----------------- | ----------------------------------- | ------------------------------------------------------- |
+| update:modelValue | 评分变化                            | `(value: number) => void`                               |
+| change            | 评分变化后的回调                    | `(value: number, oldValue?: number) => void`            |
+| click             | 点击可交互图标时触发，早于 `change` | `({ value, oldValue, index, event }) => void`           |
+| clear             | 点击当前评分并清零时触发            | `({ oldValue, index, event }) => void`                  |
+| click-disabled    | 点击禁用或只读评分时触发            | `({ value, index, disabled, readonly, event }) => void` |
 
 ### Slots
 
@@ -136,4 +131,3 @@ import RateDemo from '@/components/demos/rate-demo.vue'
 ::: tip
 展示历史评分或服务评分结果时，优先使用 `readonly`，避免用户误以为仍可编辑。
 :::
-

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -26,9 +26,9 @@ phone: textarea
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const content = ref('')
+const content = ref('');
 </script>
 
 <template>
@@ -52,19 +52,13 @@ const content = ref('')
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 
-const bio = ref('')
+const bio = ref('');
 </script>
 
 <template>
-  <lk-textarea
-    v-model="bio"
-    auto-height
-    :maxlength="200"
-    show-count
-    placeholder="请输入个人简介"
-  />
+  <lk-textarea v-model="bio" auto-height :maxlength="200" show-count placeholder="请输入个人简介" />
 </template>
 ```
 
@@ -97,7 +91,7 @@ const bio = ref('')
 <template>
   <lk-form :model="form" :rules="rules">
     <lk-form-item label="备注" prop="remark">
-      <lk-textarea v-model="form.remark" prop="remark" show-count :maxlength="100" />
+      <lk-textarea v-model="form.remark" show-count :maxlength="100" />
     </lk-form-item>
   </lk-form>
 </template>
@@ -128,7 +122,7 @@ const bio = ref('')
 
 ```vue
 <script setup lang="ts">
-import TextareaDemo from '@/components/demos/textarea-demo.vue'
+import TextareaDemo from '@/components/demos/textarea-demo.vue';
 </script>
 
 <template>
@@ -146,70 +140,84 @@ import TextareaDemo from '@/components/demos/textarea-demo.vue'
 </template>
 ```
 
+## Form 联动契约（以本节为准）
+
+Textarea 会继承最近单字段 FormItem 的 `prop`，因此常规写法不需要重复字段名。每次被接受的原生 input 恰好触发一次 Form `change` 规则，失焦只触发 `blur` 规则。H5 只读 Textarea 仍可聚焦、选择复制并发公共 `focus` / `blur`，但不发 `change` 或 Form blur 校验；微信小程序把 readonly 映射为原生 `disabled` 以可靠阻断键盘，因此不承诺只读态的 `focus` / `blur`。`validate-event="false"` 可关闭自动联动。祖先 Form disabled 与 Textarea 自身 disabled 取并集。
+
+```vue
+<template>
+  <lk-form :model="form" :rules="rules">
+    <lk-form-item label="备注" prop="remark">
+      <lk-textarea v-model="form.remark" :maxlength="100" />
+    </lk-form-item>
+  </lk-form>
+</template>
+```
+
 ## API
 
 ### Props
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-|------|------|------|--------|--------|
-| modelValue | 绑定值，支持 `v-model` | `string` | — | `''` |
-| label | 顶部标签文本 | `string` | — | `''` |
-| placeholder | 占位内容 | `string` | — | `请输入内容` |
-| placeholderStyle | 占位符样式 | `string` | — | `''` |
-| placeholderClass | 占位样式类名 | `string` | — | `lk-textarea__placeholder` |
-| name | 原生表单字段名 | `string` | — | `''` |
-| variant | 风格变体 | `string` | `outline / filled / flush` | `outline` |
-| disabled | 是否禁用 | `boolean` | — | `false` |
-| readonly | 是否只读，只读时禁用原生输入与清空 | `boolean` | — | `false` |
-| maxlength | 最大输入长度，`-1` 表示不限制 | `number` | — | `-1` |
-| autoHeight | 是否自动增高 | `boolean` | — | `false` |
-| showCount | 是否显示字数统计 | `boolean` | — | `false` |
-| clearable | 是否显示清空按钮 | `boolean` | — | `false` |
-| autofocus | 首次渲染时是否自动聚焦 | `boolean` | — | `false` |
-| focus | 是否聚焦，受控聚焦状态 | `boolean` | — | `false` |
-| confirmType | 键盘右下角按钮文字 | `string` | `send / search / next / go / done / return` | `return` |
-| confirmHold | 点击键盘右下角按钮时是否保持键盘不收起 | `boolean` | — | `false` |
-| adjustPosition | 键盘弹起时是否自动上推页面 | `boolean` | — | `true` |
-| cursorSpacing | 光标与键盘距离，单位 px | `number` | — | `0` |
-| cursor | 指定聚焦时的光标位置 | `number` | — | `-1` |
-| selectionStart | 光标起始位置，需与 `selectionEnd` 搭配使用 | `number` | — | `-1` |
-| selectionEnd | 光标结束位置，需与 `selectionStart` 搭配使用 | `number` | — | `-1` |
-| fixed | 是否展示在键盘上方 | `boolean` | — | `false` |
-| showConfirmBar | 是否显示键盘上方完成栏 | `boolean` | — | `true` |
-| disableDefaultPadding | 是否去掉 iOS 默认内边距 | `boolean` | — | `true` |
-| holdKeyboard | 聚焦时点击页面是否保持键盘不收起 | `boolean` | — | `false` |
-| autoBlur | 键盘收起时是否自动失焦 | `boolean` | — | `false` |
-| inputmode | H5/App 输入模式提示 | `string` | `none / text / decimal / numeric / tel / search / email / url` | `text` |
-| ignoreCompositionEvent | 是否忽略系统组合输入事件 | `boolean` | — | `true` |
-| prop | 表单字段名 | `string` | — | `''` |
-| validateEvent | 是否触发表单验证联动 | `boolean` | — | `true` |
-| id | 根节点 id | `string` | — | `''` |
-| customClass | 自定义类名 | `string / object / array` | — | `''` |
-| customStyle | 自定义样式 | `string / object` | — | `''` |
+| 参数                   | 说明                                         | 类型                      | 可选值                                                         | 默认值                     |
+| ---------------------- | -------------------------------------------- | ------------------------- | -------------------------------------------------------------- | -------------------------- |
+| modelValue             | 绑定值，支持 `v-model`                       | `string`                  | —                                                              | `''`                       |
+| label                  | 顶部标签文本                                 | `string`                  | —                                                              | `''`                       |
+| placeholder            | 占位内容                                     | `string`                  | —                                                              | `请输入内容`               |
+| placeholderStyle       | 占位符样式                                   | `string`                  | —                                                              | `''`                       |
+| placeholderClass       | 占位样式类名                                 | `string`                  | —                                                              | `lk-textarea__placeholder` |
+| name                   | 原生表单字段名                               | `string`                  | —                                                              | `''`                       |
+| variant                | 风格变体                                     | `string`                  | `outline / filled / flush`                                     | `outline`                  |
+| disabled               | 是否禁用                                     | `boolean`                 | —                                                              | `false`                    |
+| readonly               | 是否只读；跨端焦点行为见上方说明             | `boolean`                 | —                                                              | `false`                    |
+| maxlength              | 最大输入长度，`-1` 表示不限制                | `number`                  | —                                                              | `-1`                       |
+| autoHeight             | 是否自动增高                                 | `boolean`                 | —                                                              | `false`                    |
+| showCount              | 是否显示字数统计                             | `boolean`                 | —                                                              | `false`                    |
+| clearable              | 是否显示清空按钮                             | `boolean`                 | —                                                              | `false`                    |
+| autofocus              | 首次渲染时是否自动聚焦                       | `boolean`                 | —                                                              | `false`                    |
+| focus                  | 是否聚焦，受控聚焦状态                       | `boolean`                 | —                                                              | `false`                    |
+| confirmType            | 键盘右下角按钮文字                           | `string`                  | `send / search / next / go / done / return`                    | `return`                   |
+| confirmHold            | 点击键盘右下角按钮时是否保持键盘不收起       | `boolean`                 | —                                                              | `false`                    |
+| adjustPosition         | 键盘弹起时是否自动上推页面                   | `boolean`                 | —                                                              | `true`                     |
+| cursorSpacing          | 光标与键盘距离，单位 px                      | `number`                  | —                                                              | `0`                        |
+| cursor                 | 指定聚焦时的光标位置                         | `number`                  | —                                                              | `-1`                       |
+| selectionStart         | 光标起始位置，需与 `selectionEnd` 搭配使用   | `number`                  | —                                                              | `-1`                       |
+| selectionEnd           | 光标结束位置，需与 `selectionStart` 搭配使用 | `number`                  | —                                                              | `-1`                       |
+| fixed                  | 是否展示在键盘上方                           | `boolean`                 | —                                                              | `false`                    |
+| showConfirmBar         | 是否显示键盘上方完成栏                       | `boolean`                 | —                                                              | `true`                     |
+| disableDefaultPadding  | 是否去掉 iOS 默认内边距                      | `boolean`                 | —                                                              | `true`                     |
+| holdKeyboard           | 聚焦时点击页面是否保持键盘不收起             | `boolean`                 | —                                                              | `false`                    |
+| autoBlur               | 键盘收起时是否自动失焦                       | `boolean`                 | —                                                              | `false`                    |
+| inputmode              | H5/App 输入模式提示                          | `string`                  | `none / text / decimal / numeric / tel / search / email / url` | `text`                     |
+| ignoreCompositionEvent | 是否忽略系统组合输入事件                     | `boolean`                 | —                                                              | `true`                     |
+| prop                   | 表单字段名                                   | `string`                  | —                                                              | `''`                       |
+| validateEvent          | 是否触发表单验证联动                         | `boolean`                 | —                                                              | `true`                     |
+| id                     | 根节点 id                                    | `string`                  | —                                                              | `''`                       |
+| customClass            | 自定义类名                                   | `string / object / array` | —                                                              | `''`                       |
+| customStyle            | 自定义样式                                   | `string / object`         | —                                                              | `''`                       |
 
 ### Events
 
-| 事件名 | 说明 | 回调参数 |
-|--------|------|----------|
-| update:modelValue | 输入值变化时触发，用于 `v-model` | `(value: string)` |
-| input | 键盘输入时触发 | `(value: string)` |
-| change | 失焦或清空后的最终值变化 | `(value: string)` |
-| focus | 聚焦时触发 | `(event: Event)` |
-| blur | 失焦时触发 | `(event: Event)` |
-| confirm | 点击键盘确认按钮时触发 | `(event: Event)` |
-| clear | 点击清空按钮时触发 | `()` |
-| linechange | 行数变化时触发，`event.detail` 含 `height / heightRpx / lineCount` | `(event: Event)` |
-| keyboardheightchange | 键盘高度变化时触发，`event.detail` 含 `height / duration` | `(event: Event)` |
-| compositionstart | 组合输入开始时触发 | `(event: Event)` |
-| compositionupdate | 组合输入更新时触发 | `(event: Event)` |
-| compositionend | 组合输入结束时触发 | `(event: Event)` |
+| 事件名               | 说明                                                               | 回调参数          |
+| -------------------- | ------------------------------------------------------------------ | ----------------- |
+| update:modelValue    | 输入值变化时触发，用于 `v-model`                                   | `(value: string)` |
+| input                | 键盘输入时触发                                                     | `(value: string)` |
+| change               | 失焦或清空后的最终值变化                                           | `(value: string)` |
+| focus                | 聚焦时触发                                                         | `(event: Event)`  |
+| blur                 | 失焦时触发                                                         | `(event: Event)`  |
+| confirm              | 点击键盘确认按钮时触发                                             | `(event: Event)`  |
+| clear                | 点击清空按钮时触发                                                 | `()`              |
+| linechange           | 行数变化时触发，`event.detail` 含 `height / heightRpx / lineCount` | `(event: Event)`  |
+| keyboardheightchange | 键盘高度变化时触发，`event.detail` 含 `height / duration`          | `(event: Event)`  |
+| compositionstart     | 组合输入开始时触发                                                 | `(event: Event)`  |
+| compositionupdate    | 组合输入更新时触发                                                 | `(event: Event)`  |
+| compositionend       | 组合输入结束时触发                                                 | `(event: Event)`  |
 
 ### Slots
 
-| 插槽名 | 说明 |
-|--------|------|
+| 插槽名 | 说明                               |
+| ------ | ---------------------------------- |
 | suffix | 右侧扩展区域，常用于表情、附件按钮 |
-| footer | 底部扩展区域，位于计数左侧 |
+| footer | 底部扩展区域，位于计数左侧         |
 
 ## 使用建议
 

--- a/docs/components/upload.md
+++ b/docs/components/upload.md
@@ -123,26 +123,22 @@ const onCancel = () => {
 
 ## 自定义上传函数
 
-通过 `customRequest` 接入外部请求工具（如项目中的 `Request` 类），替代内置 `uni.uploadFile`。
+通过 `customRequest` 接管上传过程。下面直接返回原生 `UploadTask` 的取消句柄，因此删除、清空、Form disabled 或卸载都能主动终止传输；若外部请求封装只返回 Promise，就不能伪装成可取消任务。
 
 ```vue
 <script setup lang="ts">
-import { createRequest } from '@/uni_modules/lucky-ui/core/src';
-
-const request = createRequest({ baseURL: 'https://api.example.com' });
-
 const customRequest = ({ file, action, name, headers, data, onProgress, onSuccess, onFail }) => {
-  request
-    .upload({
-      url: action,
-      filePath: file.url,
-      name,
-      header: headers,
-      formData: data,
-      onProgress: res => onProgress(res.progress),
-    })
-    .then(res => onSuccess(res))
-    .catch(err => onFail(err));
+  const task = uni.uploadFile({
+    url: action,
+    filePath: file.url,
+    name,
+    header: headers,
+    formData: data,
+    success: onSuccess,
+    fail: onFail,
+  });
+  task.onProgressUpdate(result => onProgress(result.progress));
+  return { abort: () => task.abort() };
 };
 </script>
 
@@ -243,21 +239,21 @@ import UploadDemo from '@/components/demos/upload-demo.vue';
 
 ### Events
 
-| 事件名         | 说明             | 回调参数                                        |
-| -------------- | ---------------- | ----------------------------------------------- |
-| `update:modelValue` | 文件列表变化，支持 `v-model` | `(fileList: UploadFile[])` |
-| `change`       | 文件列表变化     | `(fileList: UploadFile[])`                      |
-| `afterRead`    | 文件读取完毕     | `(file: UploadFile \| UploadFile[], { index })` |
-| `oversize`     | 文件超出大小限制 | `(file: UploadFile \| UploadFile[])`            |
-| `overcount`    | 文件数量超出限制 | `({ maxCount, currentCount })`                  |
-| `delete`       | 删除文件         | `(file: UploadFile, { index })`                 |
-| `clear`        | 清空文件         | `()`                                            |
-| `clickPreview` | 点击预览         | `(file: UploadFile, { index })`                 |
-| `clickUpload`  | 点击上传区域     | `(event)`                                       |
-| `retry`        | 点击失败遮罩重新上传前触发 | `(file: UploadFile, { index })`       |
-| `progress`     | 上传进度         | `(file: UploadFile, { progress })`              |
-| `success`      | 上传成功         | `(file: UploadFile, { response })`              |
-| `fail`         | 上传失败         | `(file: UploadFile, { error })`                 |
+| 事件名              | 说明                         | 回调参数                                        |
+| ------------------- | ---------------------------- | ----------------------------------------------- |
+| `update:modelValue` | 文件列表变化，支持 `v-model` | `(fileList: UploadFile[])`                      |
+| `change`            | 文件列表变化                 | `(fileList: UploadFile[])`                      |
+| `afterRead`         | 文件读取完毕                 | `(file: UploadFile \| UploadFile[], { index })` |
+| `oversize`          | 文件超出大小限制             | `(file: UploadFile \| UploadFile[])`            |
+| `overcount`         | 文件数量超出限制             | `({ maxCount, currentCount })`                  |
+| `delete`            | 删除文件                     | `(file: UploadFile, { index })`                 |
+| `clear`             | 清空文件                     | `()`                                            |
+| `clickPreview`      | 点击预览                     | `(file: UploadFile, { index })`                 |
+| `clickUpload`       | 点击上传区域                 | `(event)`                                       |
+| `retry`             | 点击失败遮罩重新上传前触发   | `(file: UploadFile, { index })`                 |
+| `progress`          | 上传进度                     | `(file: UploadFile, { progress })`              |
+| `success`           | 上传成功                     | `(file: UploadFile, { response })`              |
+| `fail`              | 上传失败                     | `(file: UploadFile, { error })`                 |
 
 ### Slots
 
@@ -267,10 +263,10 @@ import UploadDemo from '@/components/demos/upload-demo.vue';
 
 ### Methods（通过 ref 调用）
 
-| 方法名          | 说明                          | 参数              |
-| --------------- | ----------------------------- | ----------------- |
-| `chooseFile`    | 手动触发文件选择              | —                 |
-| `retryUpload`   | 重新上传指定文件              | `(index: number)` |
-| `removeFile`    | 删除指定文件（直接删除）      | `(index: number)` |
-| `confirmRemove` | 确认删除文件（弹出 lk-modal） | `(index: number)` |
-| `clearFiles`    | 清空所有文件                  | —                 |
+| 方法名          | 说明                                                               | 参数              |
+| --------------- | ------------------------------------------------------------------ | ----------------- |
+| `chooseFile`    | 手动触发文件选择；组件或祖先 Form disabled 时不执行                | —                 |
+| `retryUpload`   | 重新上传指定文件；程序化维护方法，Form disabled 时仍可执行         | `(index: number)` |
+| `removeFile`    | 直接删除指定文件；程序化维护方法，Form disabled 时仍可执行         | `(index: number)` |
+| `confirmRemove` | 弹出删除确认；程序化维护方法，Form disabled 时仍可执行             | `(index: number)` |
+| `clearFiles`    | 清空全部文件并取消活动任务；程序化维护方法，Form disabled 时仍执行 | —                 |

--- a/src/components/demos/form-demo.vue
+++ b/src/components/demos/form-demo.vue
@@ -6,15 +6,249 @@ import LkFormItem from '@/uni_modules/lucky-ui/components/lk-form/lk-form-item.v
 import LkFormGroup from '@/uni_modules/lucky-ui/components/lk-form-group/lk-form-group.vue';
 import LkInput from '@/uni_modules/lucky-ui/components/lk-input/lk-input.vue';
 import LkTextarea from '@/uni_modules/lucky-ui/components/lk-textarea/lk-textarea.vue';
+import LkCheckbox from '@/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue';
+import LkCheckboxGroup from '@/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox-group.vue';
+import LkRadio from '@/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue';
+import LkRadioGroup from '@/uni_modules/lucky-ui/components/lk-radio/lk-radio-group.vue';
+import LkRate from '@/uni_modules/lucky-ui/components/lk-rate/lk-rate.vue';
+import LkSelectList from '@/uni_modules/lucky-ui/components/lk-select-list/lk-select-list.vue';
+import LkSlider from '@/uni_modules/lucky-ui/components/lk-slider/lk-slider.vue';
 import LkSwitch from '@/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue';
 import LkStepper from '@/uni_modules/lucky-ui/components/lk-stepper/lk-stepper.vue';
+import LkUpload from '@/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue';
+import LkCalendar from '@/uni_modules/lucky-ui/components/lk-calendar/lk-calendar.vue';
+import LkCalendarPicker from '@/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.vue';
+import LkKeyboard from '@/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue';
+import LkVerifyCode from '@/uni_modules/lucky-ui/components/lk-verify-code/lk-verify-code.vue';
 import LkPicker from '@/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import type { FormRules } from '@/uni_modules/lucky-ui/components/lk-form/context';
+import type {
+  CustomRequestFn,
+  UploadFile,
+} from '@/uni_modules/lucky-ui/components/lk-upload/upload.props';
 
 // 表单引用
 const formRef = ref();
+
+// Deterministic Form contract probe for H5 and WeChat runtime evidence.
+const contractFormRef = ref();
+const contractModel = reactive({
+  title: 'Initial title',
+  notes: 'Initial notes',
+  checkbox: [] as string[],
+  radio: 'a',
+  switch: false,
+  stepper: 1,
+  slider: 20,
+  rate: 1,
+  select: 'a',
+});
+const contractDisabled = ref(false);
+const contractUploadRef = ref();
+const contractUploadFiles = ref<UploadFile[]>([createContractUploadFile()]);
+let contractUploadRequest: Parameters<CustomRequestFn>[0] | null = null;
+const contractPickerValue = ref('a');
+const contractPickerVisible = ref(false);
+const contractCalendarValue = ref('2026-08-13');
+const contractCalendarViewDate = ref('2026-08-01');
+const contractCalendarPickerValue = ref('2026-08-13');
+const contractCalendarPickerShow = ref(false);
+const contractKeyboardValue = ref('');
+const contractKeyboardVisible = ref(false);
+const contractVerifyValue = ref('');
+const contractAdvancedCounts = reactive({
+  uploadUpdate: 0,
+  uploadChange: 0,
+  uploadSuccess: 0,
+  pickerPick: 0,
+  pickerConfirm: 0,
+  pickerCancel: 0,
+  calendarChange: 0,
+  calendarPickerChange: 0,
+  calendarPickerConfirm: 0,
+  calendarPickerClose: 0,
+  keyboardInput: 0,
+  keyboardConfirm: 0,
+  keyboardClose: 0,
+  verifySend: 0,
+  verifyCountdownEnd: 0,
+});
+const contractSilentResult = ref<'idle' | 'resolved' | 'rejected'>('idle');
+const contractSilentEventDelta = ref(0);
+const contractAsyncCounts = reactive({ started: 0, settled: 0 });
+const contractEventCounts = reactive({
+  fieldChange: 0,
+  fieldBlur: 0,
+  validateField: 0,
+  validate: 0,
+  reset: 0,
+});
+const contractRules: FormRules = {
+  title: [
+    { min: 4, message: 'Title needs at least 4 characters', trigger: 'change' },
+    {
+      message: 'Superseded async title error',
+      trigger: 'change',
+      validator: validateContractAsyncTitle,
+    },
+  ],
+  notes: [{ required: true, message: 'Notes are required', trigger: 'blur' }],
+};
+const contractEventTotal = computed(() =>
+  Object.values(contractEventCounts).reduce((total, count) => total + count, 0)
+);
+const contractCheckboxState = computed(() => JSON.stringify(contractModel.checkbox));
+const contractOverlayOpen = computed(
+  () =>
+    contractPickerVisible.value || contractCalendarPickerShow.value || contractKeyboardVisible.value
+);
+const contractState = computed(() =>
+  JSON.stringify({
+    title: contractModel.title,
+    notes: contractModel.notes,
+    controls: {
+      checkbox: contractModel.checkbox,
+      radio: contractModel.radio,
+      switch: contractModel.switch,
+      stepper: contractModel.stepper,
+      slider: contractModel.slider,
+      rate: contractModel.rate,
+      select: contractModel.select,
+    },
+    disabled: contractDisabled.value,
+    eventCounts: contractEventCounts,
+    silentResult: contractSilentResult.value,
+    silentEventDelta: contractSilentEventDelta.value,
+    asyncCounts: contractAsyncCounts,
+    advanced: {
+      upload: {
+        status: contractUploadFiles.value[0]?.status || 'missing',
+        progress: contractUploadFiles.value[0]?.progress ?? -1,
+        updateCount: contractAdvancedCounts.uploadUpdate,
+        changeCount: contractAdvancedCounts.uploadChange,
+        successCount: contractAdvancedCounts.uploadSuccess,
+      },
+      picker: {
+        value: contractPickerValue.value,
+        visible: contractPickerVisible.value,
+        pickCount: contractAdvancedCounts.pickerPick,
+        confirmCount: contractAdvancedCounts.pickerConfirm,
+        cancelCount: contractAdvancedCounts.pickerCancel,
+      },
+      calendar: {
+        value: contractCalendarValue.value,
+        changeCount: contractAdvancedCounts.calendarChange,
+      },
+      calendarPicker: {
+        value: contractCalendarPickerValue.value,
+        show: contractCalendarPickerShow.value,
+        changeCount: contractAdvancedCounts.calendarPickerChange,
+        confirmCount: contractAdvancedCounts.calendarPickerConfirm,
+        closeCount: contractAdvancedCounts.calendarPickerClose,
+      },
+      keyboard: {
+        value: contractKeyboardValue.value,
+        visible: contractKeyboardVisible.value,
+        inputCount: contractAdvancedCounts.keyboardInput,
+        confirmCount: contractAdvancedCounts.keyboardConfirm,
+        closeCount: contractAdvancedCounts.keyboardClose,
+      },
+      verify: {
+        value: contractVerifyValue.value,
+        sendCount: contractAdvancedCounts.verifySend,
+        countdownEndCount: contractAdvancedCounts.verifyCountdownEnd,
+      },
+    },
+  })
+);
+
+function createContractUploadFile(): UploadFile {
+  return {
+    uid: 'form-contract-upload',
+    name: 'contract.png',
+    url: '/static/logo.png',
+    status: 'fail',
+    progress: 20,
+    message: 'fixed initial failure',
+  };
+}
+
+function onContractUploadUpdate(files: UploadFile[]) {
+  contractUploadFiles.value = files.map(file => ({ ...file }));
+  contractAdvancedCounts.uploadUpdate += 1;
+}
+
+function runContractUploadRequest(options: Parameters<CustomRequestFn>[0]) {
+  contractUploadRequest = options;
+}
+
+function startContractUpload() {
+  contractUploadRef.value?.retryUpload(0);
+}
+
+function settleStaleContractUpload() {
+  contractUploadRequest?.onSuccess({ probe: 'stale-success' });
+}
+
+async function resetContractAdvancedProbe() {
+  contractDisabled.value = true;
+  await nextTick();
+  contractModel.checkbox = [];
+  contractModel.radio = 'a';
+  contractModel.switch = false;
+  contractModel.stepper = 1;
+  contractModel.slider = 20;
+  contractModel.rate = 1;
+  contractModel.select = 'a';
+  contractUploadRequest = null;
+  contractUploadFiles.value = [createContractUploadFile()];
+  contractPickerValue.value = 'a';
+  contractPickerVisible.value = false;
+  contractCalendarValue.value = '2026-08-13';
+  contractCalendarViewDate.value = '2026-08-01';
+  contractCalendarPickerValue.value = '2026-08-13';
+  contractCalendarPickerShow.value = false;
+  contractKeyboardValue.value = '';
+  contractKeyboardVisible.value = false;
+  contractVerifyValue.value = '';
+  Object.keys(contractAdvancedCounts).forEach(key => {
+    contractAdvancedCounts[key as keyof typeof contractAdvancedCounts] = 0;
+  });
+  contractDisabled.value = false;
+}
+
+function validateContractAsyncTitle(value: unknown) {
+  if (value !== 'pending-invalid') return true;
+  contractAsyncCounts.started += 1;
+  return new Promise<boolean>(resolve => {
+    setTimeout(() => {
+      contractAsyncCounts.settled += 1;
+      resolve(false);
+    }, 750);
+  });
+}
+
+function resetContractProbe() {
+  contractFormRef.value?.resetFields();
+}
+
+function toggleContractDisabled() {
+  contractDisabled.value = !contractDisabled.value;
+}
+
+async function runContractSilentValidation() {
+  const before = contractEventTotal.value;
+  try {
+    await contractFormRef.value?.validate({ fields: ['title'], silent: true });
+    contractSilentResult.value = 'resolved';
+  } catch {
+    contractSilentResult.value = 'rejected';
+  }
+  await nextTick();
+  contractSilentEventDelta.value = contractEventTotal.value - before;
+}
 
 // 交互状态控制
 const isVerticalLayout = ref(false); // 是否开启上下布局
@@ -301,6 +535,272 @@ const onLaunchTimeConfirm = async (value: unknown) => {
       <text class="form-header__title">创意项目申报</text>
       <text class="form-header__subtitle">PROJECT DECLARATION</text>
       <view class="form-header__line" />
+    </view>
+
+    <view
+      id="form-contract-probe"
+      class="form-contract-probe"
+      :data-title="contractModel.title"
+      :data-notes="contractModel.notes"
+      :data-disabled="contractDisabled ? 'true' : 'false'"
+      :data-event-total="contractEventTotal"
+      :data-change-count="contractEventCounts.fieldChange"
+      :data-blur-count="contractEventCounts.fieldBlur"
+      :data-validation-count="contractEventCounts.validateField"
+      :data-reset-count="contractEventCounts.reset"
+      :data-silent-result="contractSilentResult"
+      :data-silent-event-delta="contractSilentEventDelta"
+      :data-async-started="contractAsyncCounts.started"
+      :data-async-settled="contractAsyncCounts.settled"
+      :data-checkbox="contractCheckboxState"
+      :data-radio="contractModel.radio"
+      :data-switch="String(contractModel.switch)"
+      :data-stepper="contractModel.stepper"
+      :data-slider="contractModel.slider"
+      :data-rate="contractModel.rate"
+      :data-select="contractModel.select"
+    >
+      <text class="form-contract-probe__title">FORM CONTRACT PROBE</text>
+      <lk-form
+        id="form-contract-probe-form"
+        ref="contractFormRef"
+        :model="contractModel"
+        :rules="contractRules"
+        :disabled="contractDisabled"
+        @field-change="contractEventCounts.fieldChange += 1"
+        @field-blur="contractEventCounts.fieldBlur += 1"
+        @validate-field="contractEventCounts.validateField += 1"
+        @validate="contractEventCounts.validate += 1"
+        @reset="contractEventCounts.reset += 1"
+      >
+        <lk-form-item id="form-contract-probe-title-item" label="Title" prop="title">
+          <lk-input
+            id="form-contract-probe-input"
+            v-model="contractModel.title"
+            placeholder="Contract title"
+          />
+        </lk-form-item>
+        <lk-form-item id="form-contract-probe-notes-item" label="Notes" prop="notes" vertical>
+          <lk-textarea
+            id="form-contract-probe-textarea"
+            v-model="contractModel.notes"
+            placeholder="Contract notes"
+          />
+        </lk-form-item>
+        <view id="form-contract-probe-controls" class="form-contract-probe__controls">
+          <lk-checkbox-group id="form-contract-probe-checkbox" v-model="contractModel.checkbox">
+            <lk-checkbox id="form-contract-probe-checkbox-action" name="a">
+              Checkbox A
+            </lk-checkbox>
+          </lk-checkbox-group>
+          <lk-radio-group id="form-contract-probe-radio" v-model="contractModel.radio">
+            <lk-radio name="a">Radio A</lk-radio>
+            <lk-radio id="form-contract-probe-radio-action" name="b">Radio B</lk-radio>
+          </lk-radio-group>
+          <lk-switch id="form-contract-probe-switch" v-model="contractModel.switch" />
+          <lk-stepper id="form-contract-probe-stepper" v-model="contractModel.stepper" />
+          <lk-slider id="form-contract-probe-slider" v-model="contractModel.slider" />
+          <lk-rate id="form-contract-probe-rate" v-model="contractModel.rate" />
+          <lk-select-list
+            id="form-contract-probe-select"
+            v-model="contractModel.select"
+            :options="[
+              { label: 'Select A', value: 'a' },
+              { label: 'Select B', value: 'b' },
+            ]"
+          />
+        </view>
+
+        <view
+          id="form-contract-probe-upload-state"
+          class="form-contract-probe__case"
+          :data-status="contractUploadFiles[0]?.status || 'missing'"
+          :data-progress="contractUploadFiles[0]?.progress ?? -1"
+          :data-update-count="contractAdvancedCounts.uploadUpdate"
+          :data-change-count="contractAdvancedCounts.uploadChange"
+          :data-success-count="contractAdvancedCounts.uploadSuccess"
+        >
+          <text>UPLOAD ASYNC PROBE</text>
+          <lk-upload
+            id="form-contract-probe-upload"
+            ref="contractUploadRef"
+            :model-value="contractUploadFiles"
+            action="contract://pending"
+            :custom-request="runContractUploadRequest"
+            :show-upload="false"
+            @update:model-value="onContractUploadUpdate"
+            @change="contractAdvancedCounts.uploadChange += 1"
+            @success="contractAdvancedCounts.uploadSuccess += 1"
+          />
+          <lk-button id="form-contract-probe-upload-start" size="sm" @click="startContractUpload">
+            Start pending upload
+          </lk-button>
+          <lk-button
+            id="form-contract-probe-upload-stale-success"
+            size="sm"
+            @click="settleStaleContractUpload"
+          >
+            Resolve stale upload
+          </lk-button>
+        </view>
+
+        <view
+          id="form-contract-probe-picker-state"
+          class="form-contract-probe__case"
+          :data-value="contractPickerValue"
+          :data-visible="contractPickerVisible ? 'true' : 'false'"
+          :data-pick-count="contractAdvancedCounts.pickerPick"
+          :data-confirm-count="contractAdvancedCounts.pickerConfirm"
+          :data-cancel-count="contractAdvancedCounts.pickerCancel"
+        >
+          <text>PICKER PROBE</text>
+          <lk-button
+            id="form-contract-probe-picker-open"
+            size="sm"
+            @click="contractPickerVisible = true"
+          >
+            Open picker
+          </lk-button>
+          <lk-picker
+            id="form-contract-probe-picker"
+            v-model="contractPickerValue"
+            v-model:visible="contractPickerVisible"
+            :columns="[
+              { label: 'Picker A', value: 'a' },
+              { label: 'Picker B', value: 'b' },
+            ]"
+            @pick="contractAdvancedCounts.pickerPick += 1"
+            @confirm="contractAdvancedCounts.pickerConfirm += 1"
+            @cancel="contractAdvancedCounts.pickerCancel += 1"
+          />
+        </view>
+
+        <view
+          id="form-contract-probe-calendar-state"
+          class="form-contract-probe__case"
+          :data-value="contractCalendarValue"
+          :data-change-count="contractAdvancedCounts.calendarChange"
+        >
+          <text>CALENDAR PROBE</text>
+          <lk-calendar
+            id="form-contract-probe-calendar"
+            v-model="contractCalendarValue"
+            v-model:view-date="contractCalendarViewDate"
+            min-date="2026-08-01"
+            max-date="2026-08-31"
+            :show-today="false"
+            @change="contractAdvancedCounts.calendarChange += 1"
+          />
+        </view>
+
+        <view
+          id="form-contract-probe-calendar-picker-state"
+          class="form-contract-probe__case"
+          :data-value="contractCalendarPickerValue"
+          :data-show="contractCalendarPickerShow ? 'true' : 'false'"
+          :data-change-count="contractAdvancedCounts.calendarPickerChange"
+          :data-confirm-count="contractAdvancedCounts.calendarPickerConfirm"
+          :data-close-count="contractAdvancedCounts.calendarPickerClose"
+        >
+          <text>CALENDAR PICKER PROBE</text>
+          <lk-button
+            id="form-contract-probe-calendar-picker-open"
+            size="sm"
+            @click="contractCalendarPickerShow = true"
+          >
+            Open calendar picker
+          </lk-button>
+          <lk-calendar-picker
+            id="form-contract-probe-calendar-picker"
+            v-model="contractCalendarPickerValue"
+            v-model:show="contractCalendarPickerShow"
+            view-date="2026-08-01"
+            min-date="2026-08-01"
+            max-date="2026-08-31"
+            :show-today="false"
+            @change="contractAdvancedCounts.calendarPickerChange += 1"
+            @confirm="contractAdvancedCounts.calendarPickerConfirm += 1"
+            @close="contractAdvancedCounts.calendarPickerClose += 1"
+          />
+        </view>
+
+        <view
+          id="form-contract-probe-keyboard-state"
+          class="form-contract-probe__case"
+          :data-value="contractKeyboardValue"
+          :data-visible="contractKeyboardVisible ? 'true' : 'false'"
+          :data-input-count="contractAdvancedCounts.keyboardInput"
+          :data-confirm-count="contractAdvancedCounts.keyboardConfirm"
+          :data-close-count="contractAdvancedCounts.keyboardClose"
+        >
+          <text>KEYBOARD PROBE</text>
+          <lk-button
+            id="form-contract-probe-keyboard-open"
+            size="sm"
+            @click="contractKeyboardVisible = true"
+          >
+            Open keyboard
+          </lk-button>
+          <lk-keyboard
+            id="form-contract-probe-keyboard"
+            v-model="contractKeyboardValue"
+            v-model:visible="contractKeyboardVisible"
+            :vibrate="false"
+            @input="contractAdvancedCounts.keyboardInput += 1"
+            @confirm="contractAdvancedCounts.keyboardConfirm += 1"
+            @close="contractAdvancedCounts.keyboardClose += 1"
+          />
+        </view>
+
+        <view
+          id="form-contract-probe-verify-state"
+          class="form-contract-probe__case"
+          :data-value="contractVerifyValue"
+          :data-send-count="contractAdvancedCounts.verifySend"
+          :data-countdown-end-count="contractAdvancedCounts.verifyCountdownEnd"
+        >
+          <text>VERIFY CODE PROBE</text>
+          <lk-verify-code
+            id="form-contract-probe-verify"
+            v-model="contractVerifyValue"
+            countdown
+            :countdown-duration="1"
+            @send="contractAdvancedCounts.verifySend += 1"
+            @countdown-end="contractAdvancedCounts.verifyCountdownEnd += 1"
+          />
+        </view>
+      </lk-form>
+      <view class="form-contract-probe__actions">
+        <lk-button id="form-contract-probe-reset" size="sm" @click="resetContractProbe">
+          Reset initial values
+        </lk-button>
+        <lk-button id="form-contract-probe-disable" size="sm" @click="toggleContractDisabled">
+          {{ contractDisabled ? 'Enable form' : 'Disable form' }}
+        </lk-button>
+        <lk-button id="form-contract-probe-silent" size="sm" @click="runContractSilentValidation">
+          Silent title validation
+        </lk-button>
+        <lk-button
+          id="form-contract-probe-advanced-reset"
+          size="sm"
+          @click="resetContractAdvancedProbe"
+        >
+          Reset advanced probes
+        </lk-button>
+      </view>
+      <text id="form-contract-probe-state" class="form-contract-probe__state">{{
+        contractState
+      }}</text>
+      <view
+        v-if="contractOverlayOpen && !contractDisabled"
+        id="form-contract-probe-overlay-disable"
+        class="form-contract-probe__overlay-disable"
+        role="button"
+        aria-label="Disable form while overlay is open"
+        @tap="toggleContractDisabled"
+      >
+        Disable open overlay probe
+      </view>
     </view>
 
     <!-- 表单区：全宽占满，带细线分隔，呈现列表化平铺 -->
@@ -628,6 +1128,60 @@ const onLaunchTimeConfirm = async (value: unknown) => {
       height: 4rpx;
       background-color: #111111;
       margin-top: 24rpx;
+    }
+  }
+
+  .form-contract-probe {
+    margin: 0 var(--lk-spacing-md) var(--lk-spacing-xl);
+    padding: var(--lk-spacing-lg);
+    border: var(--lk-rpx-2) solid var(--lk-color-border-light);
+    border-radius: var(--lk-radius-lg);
+    background: var(--lk-bg-container);
+
+    &__title {
+      display: block;
+      margin-bottom: var(--lk-spacing-md);
+      color: var(--lk-text-secondary);
+      font-size: var(--lk-font-size-sm);
+      letter-spacing: var(--lk-rpx-2);
+    }
+
+    &__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--lk-spacing-sm);
+      margin-top: var(--lk-spacing-md);
+    }
+
+    &__controls,
+    &__case {
+      display: flex;
+      flex-direction: column;
+      gap: var(--lk-spacing-sm);
+      margin-top: var(--lk-spacing-md);
+      padding-top: var(--lk-spacing-md);
+      border-top: var(--lk-rpx-2) solid var(--lk-color-border-light);
+    }
+
+    &__state {
+      display: block;
+      margin-top: var(--lk-spacing-md);
+      color: var(--lk-text-secondary);
+      font-size: var(--lk-font-size-xs);
+      line-height: 1.5;
+      overflow-wrap: anywhere;
+    }
+
+    &__overlay-disable {
+      position: fixed;
+      top: var(--lk-spacing-md);
+      right: var(--lk-spacing-md);
+      z-index: 20000;
+      padding: var(--lk-spacing-sm) var(--lk-spacing-md);
+      border-radius: var(--lk-radius-md);
+      background: var(--lk-color-danger);
+      color: var(--lk-text-inverse);
+      font-size: var(--lk-font-size-sm);
     }
   }
 

--- a/src/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.scss
+++ b/src/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.scss
@@ -5,8 +5,10 @@
   box-sizing: border-box;
 
   @include when(disabled) {
-    opacity: 0.6;
-    pointer-events: none;
+    .lk-calendar-picker__trigger,
+    .lk-calendar-picker__reset {
+      opacity: 0.6;
+    }
   }
 
   @include e(trigger) {

--- a/src/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.vue
+++ b/src/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, ref, watch } from 'vue';
+import { computed, getCurrentInstance, ref, watch } from 'vue';
 import { useLocale } from '../../composables/useLocale';
+import { useFormDisabled } from '../lk-form/useFormField';
 import LkButton from '../lk-button/lk-button.vue';
 import LkCalendar from '../lk-calendar/lk-calendar.vue';
 import { CalendarMode, type CalendarDay, type CalendarValue } from '../lk-calendar/calendar.props';
@@ -33,16 +34,21 @@ defineOptions({ name: 'LkCalendarPicker' });
 const props = defineProps(calendarPickerProps);
 const emit = defineEmits(calendarPickerEmits);
 const { t } = useLocale('calendarPicker');
+const formInteraction = useFormDisabled(() => props.disabled || props.readonly);
+const instance = getCurrentInstance();
+const isInteractionLocked = formInteraction.disabled;
+const isDisabled = computed(() => props.disabled || !!formInteraction.form?.disabled);
 
 const innerShow = ref(props.show);
 const tempValue = ref<CalendarValue>(normalizePickerValue(props.modelValue));
 const startTime = ref(parseTime(props.defaultStartTime, 0));
 const endTime = ref(parseTime(props.defaultEndTime, 86399));
 const panelDate = ref(props.viewDate);
+let showGeneration = 0;
 
 const cls = computed(() => [
   ...resolveCalendarPickerClass({
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
     customClass: props.customClass,
   }),
@@ -117,7 +123,7 @@ function syncDraftFromValue(value: CalendarPickerValue) {
 }
 
 function open() {
-  if (!canOpenCalendarPicker({ disabled: props.disabled, readonly: props.readonly })) return;
+  if (!canOpenCalendarPicker({ disabled: isDisabled.value, readonly: props.readonly })) return;
   syncDraftFromValue(props.modelValue);
   innerShow.value = true;
 }
@@ -126,31 +132,42 @@ function close() {
   innerShow.value = false;
 }
 
-function reset() {
+async function reset() {
+  if (isInteractionLocked.value) return;
+  const interaction = formInteraction.captureInteraction();
   const value = resolveCalendarPickerResetValue(props.mode);
   tempValue.value = value;
   startTime.value = parseTime(props.defaultStartTime, 0);
   endTime.value = parseTime(props.defaultEndTime, 86399);
   emit('update:modelValue', value);
+  if (!(await formInteraction.awaitInteractionCurrent(interaction))) return;
   emit('change', value);
+  if (!(await formInteraction.awaitInteractionCurrent(interaction))) return;
   emit('reset');
 }
 
-function confirm() {
+async function confirm() {
+  if (isInteractionLocked.value || confirmDisabled.value) return;
+  const interaction = formInteraction.captureInteraction();
   const value = mergeTime(tempValue.value);
   emit('update:modelValue', value);
+  if (!(await formInteraction.awaitInteractionCurrent(interaction))) return;
   emit('change', value);
+  if (!(await formInteraction.awaitInteractionCurrent(interaction))) return;
   emit('confirm', value);
+  if (!(await formInteraction.awaitActive())) return;
   if (props.closeOnConfirm) close();
 }
 
 function onSelect(day: CalendarDay) {
+  if (isInteractionLocked.value) return;
   emit('select', day);
 }
 
 watch(
   () => props.show,
   value => {
+    if (innerShow.value !== value) showGeneration += 1;
     innerShow.value = value;
     if (value) syncDraftFromValue(props.modelValue);
   }
@@ -164,18 +181,32 @@ watch(
   { deep: true }
 );
 
-watch(innerShow, value => {
+watch(innerShow, async value => {
+  const generation = ++showGeneration;
+  const interaction = formInteraction.captureInteraction();
   emit('update:show', value);
   if (value) {
+    if (!(await formInteraction.awaitInteractionCurrent(interaction))) return;
+    if (instance?.vnode.props?.['onUpdate:show'] && props.show !== value) {
+      innerShow.value = props.show;
+      return;
+    }
+    if (generation !== showGeneration || innerShow.value !== value) return;
     emit('open');
   } else {
+    if (!(await formInteraction.awaitActive())) return;
+    if (instance?.vnode.props?.['onUpdate:show'] && props.show !== value) {
+      innerShow.value = props.show;
+      return;
+    }
+    if (generation !== showGeneration || innerShow.value !== value) return;
     emit('close');
   }
 });
 </script>
 
 <template>
-  <view :id="id" :class="cls" :style="style">
+  <view :id="id" :class="cls" :style="style" :aria-disabled="isDisabled" :aria-readonly="readonly">
     <slot name="trigger" :open="open" :value="modelValue" :display-value="displayValue">
       <view class="lk-calendar-picker__trigger" :class="{ 'is-empty': !hasValue }" @tap="open">
         <text class="lk-calendar-picker__trigger-text">{{ displayValue }}</text>
@@ -218,6 +249,8 @@ watch(innerShow, value => {
           :show-today="showToday"
           :show-year="showYear"
           :swipeable="swipeable"
+          :disabled="isDisabled"
+          :readonly="readonly"
           @select="onSelect"
         />
 
@@ -232,6 +265,7 @@ watch(innerShow, value => {
                 :min="0"
                 :max="timeMax"
                 :step="timeStep"
+                :disabled="isInteractionLocked"
                 show-value
                 :show-value-text="false"
                 :format-value="formatTime"
@@ -247,7 +281,7 @@ watch(innerShow, value => {
                 :min="0"
                 :max="timeMax"
                 :step="timeStep"
-                :disabled="endTimeDisabled"
+                :disabled="endTimeDisabled || isInteractionLocked"
                 show-value
                 :show-value-text="false"
                 :format-value="formatTime"
@@ -262,7 +296,7 @@ watch(innerShow, value => {
             block
             shape="round"
             size="lg"
-            :disabled="confirmDisabled"
+            :disabled="confirmDisabled || isInteractionLocked"
             hover-class="none"
             @tap="confirm"
           >

--- a/src/uni_modules/lucky-ui/components/lk-calendar/lk-calendar.vue
+++ b/src/uni_modules/lucky-ui/components/lk-calendar/lk-calendar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import { useLocale } from '../../composables/useLocale';
+import { useFormDisabled } from '../lk-form/useFormField';
 import {
   CalendarViewMode,
   calendarEmits,
@@ -39,6 +40,8 @@ defineOptions({ name: 'LkCalendar' });
 const props = defineProps(calendarProps);
 const emit = defineEmits(calendarEmits);
 const { t } = useLocale('calendar');
+const formDisabled = useFormDisabled(() => props.disabled);
+const isDisabled = formDisabled.disabled;
 
 const fallbackMonthNames = [
   '一月',
@@ -112,6 +115,7 @@ const switchDirection = ref<'prev' | 'next'>('next');
 const ignoreNextTap = ref(false);
 let switchStartTimer: ReturnType<typeof setTimeout> | null = null;
 let switchTimer: ReturnType<typeof setTimeout> | null = null;
+let panelGeneration = 0;
 let ignoreTapTimer: ReturnType<typeof setTimeout> | null = null;
 const touchState = {
   startX: 0,
@@ -120,6 +124,7 @@ const touchState = {
   deltaY: 0,
   tracking: false,
   locked: false,
+  interaction: null as number | null,
 };
 
 const markerMap = computed(() => {
@@ -165,7 +170,7 @@ const cls = computed(() => [
     size: props.size,
     mode: props.mode,
     viewMode: props.viewMode,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
     customClass: props.customClass,
   }),
@@ -196,7 +201,7 @@ function createDay(date: Date): CalendarDay {
     mode: props.mode,
     viewMode: props.viewMode,
     firstDayOfWeek: props.firstDayOfWeek,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     minDate: props.minDate,
     maxDate: props.maxDate,
     disabledDates: props.disabledDates,
@@ -214,29 +219,47 @@ const days = computed(() => {
   });
 });
 
-function emitPanelChange() {
+async function emitPanelChange(interaction: number, generation: number) {
+  if (!formDisabled.isInteractionCurrent(interaction) || generation !== panelGeneration) return;
   const value = viewDateValue.value;
-  emit('update:viewDate', value);
-  emit('month-change', value);
-  if (props.viewMode === CalendarViewMode.Week && days.value.length) {
-    emit('week-change', {
-      start: days.value[0].date,
-      end: days.value[days.value.length - 1].date,
-      viewDate: value,
-    });
-  }
-  emit('panel-change', {
+  const week =
+    props.viewMode === CalendarViewMode.Week && days.value.length
+      ? {
+          start: days.value[0].date,
+          end: days.value[days.value.length - 1].date,
+          viewDate: value,
+        }
+      : null;
+  const panel = {
     year: cursor.value.getFullYear(),
     month: cursor.value.getMonth() + 1,
-  });
+  };
+  emit('update:viewDate', value);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  if (generation !== panelGeneration) return;
+  emit('month-change', value);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  if (generation !== panelGeneration) return;
+  if (week) {
+    emit('week-change', week);
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+    if (generation !== panelGeneration) return;
+  }
+  emit('panel-change', panel);
+}
+
+function stopSwitchAnimation() {
+  if (switchStartTimer) clearTimeout(switchStartTimer);
+  if (switchTimer) clearTimeout(switchTimer);
+  switchStartTimer = null;
+  switchTimer = null;
+  isSwitching.value = false;
 }
 
 function playSwitchAnimation(amount: number) {
   if (!amount) return;
   switchDirection.value = amount > 0 ? 'next' : 'prev';
-  isSwitching.value = false;
-  if (switchStartTimer) clearTimeout(switchStartTimer);
-  if (switchTimer) clearTimeout(switchTimer);
+  stopSwitchAnimation();
   switchStartTimer = setTimeout(() => {
     isSwitching.value = true;
     switchStartTimer = null;
@@ -247,27 +270,34 @@ function playSwitchAnimation(amount: number) {
   }, 0);
 }
 
-function movePanel(amount: number, animate = true) {
-  if (props.disabled) return;
+async function movePanel(
+  amount: number,
+  animate = true,
+  interaction = formDisabled.captureInteraction()
+) {
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
+  const generation = ++panelGeneration;
   cursor.value =
     props.viewMode === CalendarViewMode.Week
       ? addDays(cursor.value, amount * 7)
       : addMonths(cursor.value, amount);
   if (animate) playSwitchAnimation(amount);
-  emitPanelChange();
+  await emitPanelChange(interaction, generation);
 }
 
 function moveMonth(amount: number) {
-  movePanel(amount);
+  void movePanel(amount);
 }
 
-function goToday() {
-  if (props.disabled) return;
+async function goToday() {
+  const interaction = formDisabled.captureInteraction();
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
+  const generation = ++panelGeneration;
   const now = new Date();
   const direction = now.getTime() >= cursor.value.getTime() ? 1 : -1;
   cursor.value = props.viewMode === CalendarViewMode.Week ? now : monthStart(now);
   playSwitchAnimation(direction);
-  emitPanelChange();
+  await emitPanelChange(interaction, generation);
 }
 
 function getTouchPoint(event: CalendarTouchEvent) {
@@ -284,6 +314,7 @@ function resetSwipe() {
   touchState.locked = false;
   touchState.deltaX = 0;
   touchState.deltaY = 0;
+  touchState.interaction = null;
   isDragging.value = false;
   dragOffset.value = 0;
 }
@@ -298,7 +329,7 @@ function suppressNextTap() {
 }
 
 function onTouchStart(event: CalendarTouchEvent) {
-  if (!props.swipeable || props.disabled) return;
+  if (!props.swipeable || isDisabled.value) return;
   const point = getTouchPoint(event);
   if (!point) return;
   touchState.startX = point.x;
@@ -307,10 +338,19 @@ function onTouchStart(event: CalendarTouchEvent) {
   touchState.deltaY = 0;
   touchState.tracking = true;
   touchState.locked = false;
+  touchState.interaction = formDisabled.captureInteraction();
 }
 
 function onTouchMove(event: CalendarTouchEvent) {
-  if (!touchState.tracking || !props.swipeable || props.disabled) return;
+  if (
+    !touchState.tracking ||
+    !props.swipeable ||
+    touchState.interaction === null ||
+    !formDisabled.isInteractionCurrent(touchState.interaction)
+  ) {
+    resetSwipe();
+    return;
+  }
   const point = getTouchPoint(event);
   if (!point) return;
 
@@ -336,7 +376,12 @@ function onTouchMove(event: CalendarTouchEvent) {
 }
 
 function onTouchEnd() {
-  if (!touchState.tracking || !props.swipeable || props.disabled) {
+  if (
+    !touchState.tracking ||
+    !props.swipeable ||
+    touchState.interaction === null ||
+    !formDisabled.isInteractionCurrent(touchState.interaction)
+  ) {
     resetSwipe();
     return;
   }
@@ -346,11 +391,12 @@ function onTouchEnd() {
     Math.abs(touchState.deltaX) >= SWIPE_THRESHOLD &&
     Math.abs(touchState.deltaX) > Math.abs(touchState.deltaY) * 1.15;
   const direction = touchState.deltaX < 0 ? 1 : -1;
+  const interaction = touchState.interaction;
 
   resetSwipe();
   if (shouldMove) {
     suppressNextTap();
-    movePanel(direction);
+    void movePanel(direction, true, interaction);
   }
 }
 
@@ -365,7 +411,7 @@ function nextValue(day: CalendarDay): CalendarValue {
   });
 }
 
-function selectDay(day: CalendarDay) {
+async function selectDay(day: CalendarDay) {
   if (ignoreNextTap.value) {
     ignoreNextTap.value = false;
     return;
@@ -376,9 +422,13 @@ function selectDay(day: CalendarDay) {
   }
   if (props.readonly) return;
 
+  const interaction = formDisabled.captureInteraction();
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
   const value = nextValue(day);
   emit('update:modelValue', value);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
   emit('select', day);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
   emit('change', value, day);
 }
 
@@ -416,13 +466,38 @@ watch(
   () => props.viewDate,
   value => {
     const next = parseDate(value);
-    if (next) cursor.value = props.viewMode === CalendarViewMode.Week ? next : monthStart(next);
+    if (!next) return;
+    const nextCursor = props.viewMode === CalendarViewMode.Week ? next : monthStart(next);
+    if (getCalendarViewDateValue(nextCursor) !== viewDateValue.value) panelGeneration += 1;
+    cursor.value = nextCursor;
   }
 );
+
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    panelGeneration += 1;
+    stopSwitchAnimation();
+    resetSwipe();
+    ignoreNextTap.value = false;
+    if (ignoreTapTimer) {
+      clearTimeout(ignoreTapTimer);
+      ignoreTapTimer = null;
+    }
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  panelGeneration += 1;
+  stopSwitchAnimation();
+  if (ignoreTapTimer) clearTimeout(ignoreTapTimer);
+});
 </script>
 
 <template>
-  <view :id="id" :class="cls" :style="style">
+  <view :id="id" :class="cls" :style="style" :aria-disabled="isDisabled">
     <slot
       v-if="showHeader"
       name="header"
@@ -462,7 +537,13 @@ watch(
       @touchcancel="onTouchEnd"
     >
       <view :class="gridClass" :style="gridStyle">
-        <view v-for="day in days" :key="day.date" :class="dayClass(day)" @tap="selectDay(day)">
+        <view
+          v-for="day in days"
+          :key="day.date"
+          :class="dayClass(day)"
+          :data-date="day.date"
+          @tap="selectDay(day)"
+        >
           <slot name="day" :day="day">
             <view class="lk-calendar__day-core">
               <text v-if="viewMode === CalendarViewMode.Week" class="lk-calendar__week-label">

--- a/src/uni_modules/lucky-ui/components/lk-checkbox/checkbox.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-checkbox/checkbox.props.ts
@@ -92,6 +92,10 @@ export const checkboxProps = {
   labelDisabled: LkProp.boolean(false),
   /** 是否为不确定状态（半选） */
   indeterminate: LkProp.boolean(false),
+  /** 单独使用时的表单字段名 */
+  prop: LkProp.string(''),
+  /** 单独使用时是否触发表单验证 */
+  validateEvent: LkProp.boolean(true),
 } as const;
 
 export type CheckboxGroupProps = ExtractPropTypes<typeof checkboxGroupProps>;

--- a/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox-group.vue
+++ b/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox-group.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { provide, computed, inject } from 'vue';
+import { provide, computed } from 'vue';
 import type { CheckboxValue } from './checkbox.props';
 import { checkboxGroupProps, checkboxGroupEmits } from './checkbox.props';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import { resolveCheckboxGroupClass, resolveCheckboxGroupToggle } from './checkbox.utils';
 
 defineOptions({ name: 'LkCheckboxGroup' });
@@ -11,22 +11,19 @@ defineOptions({ name: 'LkCheckboxGroup' });
 const props = defineProps(checkboxGroupProps);
 const emit = defineEmits(checkboxGroupEmits);
 
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const LK_CHECKBOX_GROUP_KEY = Symbol.for('LkCheckboxGroup');
 
 const style = computed(() => props.customStyle as StyleValue);
 
-function updateValue(value: CheckboxValue[], changedValue: CheckboxValue, checked: boolean) {
-  emit('update:modelValue', value);
-  emit('change', value);
-  emit('item-change', changedValue, checked, value);
-  if (props.validateEvent && props.prop) {
-    form?.emitFieldChange(props.prop, value);
-  }
-}
-
-function toggleValue(name: CheckboxValue) {
+async function toggleValue(name: CheckboxValue, interaction = formField.captureInteraction()) {
+  if (!formField.isInteractionCurrent(interaction)) return;
   const result = resolveCheckboxGroupToggle({
     currentValue: props.modelValue,
     name,
@@ -38,11 +35,19 @@ function toggleValue(name: CheckboxValue) {
     return;
   }
 
-  updateValue(result.value, name, result.checked);
+  emit('update:modelValue', result.value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  emit('change', result.value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  emit('item-change', name, result.checked, result.value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitChange(result.value, interaction);
 }
 
 provide(LK_CHECKBOX_GROUP_KEY, {
   props,
+  disabled: isDisabled,
+  captureInteraction: formField.captureInteraction,
   toggleValue,
 });
 
@@ -55,7 +60,7 @@ const groupClass = computed(() => {
 </script>
 
 <template>
-  <view :id="id" :class="groupClass" :style="style">
+  <view :id="id" :class="groupClass" :style="style" :aria-disabled="isDisabled">
     <slot />
   </view>
 </template>

--- a/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue
+++ b/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { StyleValue } from 'vue';
+import type { Ref, StyleValue } from 'vue';
 import { inject, computed } from 'vue';
 import type { CheckboxValue } from './checkbox.props';
 import { checkboxProps, checkboxEmits } from './checkbox.props';
 import LkIcon from '../lk-icon/lk-icon.vue';
+import { useFormField } from '../lk-form/useFormField';
 import {
   isCheckboxChecked,
   isCheckboxDisabled,
@@ -33,10 +34,17 @@ type CheckboxGroupContext = {
     size: string;
     activeColor: string;
   };
-  toggleValue: (name: CheckboxValue) => void;
+  disabled: Readonly<Ref<boolean>>;
+  captureInteraction: () => number;
+  toggleValue: (name: CheckboxValue, interaction?: number) => void | Promise<void>;
 };
 
 const group = inject<CheckboxGroupContext | null>(LK_CHECKBOX_GROUP_KEY, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled || !!group?.disabled.value,
+  validateEvent: () => props.validateEvent,
+});
 
 const checkboxValue = computed(() => resolveCheckboxValue(props.name, props.label));
 const style = computed(() => props.customStyle as StyleValue);
@@ -51,8 +59,8 @@ const isChecked = computed(() => {
 
 const isDisabled = computed(() => {
   return isCheckboxDisabled({
-    disabled: props.disabled,
-    group: group?.props,
+    disabled: formField.disabled.value,
+    group: group ? { ...group.props, disabled: group.disabled.value } : undefined,
   });
 });
 
@@ -96,15 +104,21 @@ const iconStyle = computed(() => {
   });
 });
 
-function handleToggle(event?: unknown) {
+async function handleToggle(event?: unknown) {
   if (isDisabled.value) return;
+  const interaction = formField.captureInteraction();
+  const groupInteraction = group?.captureInteraction();
   emit('click', event, isChecked.value, checkboxValue.value);
+  if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
   if (group) {
-    group.toggleValue(checkboxValue.value);
+    await group.toggleValue(checkboxValue.value, groupInteraction);
   } else {
     const nextValue = !props.modelValue;
     emit('update:modelValue', nextValue);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
     emit('change', nextValue);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
+    await formField.emitChange(nextValue, interaction);
   }
 }
 

--- a/src/uni_modules/lucky-ui/components/lk-form/context.ts
+++ b/src/uni_modules/lucky-ui/components/lk-form/context.ts
@@ -31,6 +31,38 @@ export interface FormValidateOptions {
   fields?: string[];
 }
 
+export interface FormItemValidateOptions {
+  silent?: boolean;
+  fields?: string[];
+  /** Internal owner predicate for automatic validation started by a control interaction. */
+  isCurrent?: () => boolean;
+}
+
+export type FormItemValidationResult = 'validated' | 'skipped' | 'stale';
+
+export const FORM_VALIDATION_SUPERSEDED = 'FORM_VALIDATION_SUPERSEDED';
+
+export class FormValidationSupersededError extends Error {
+  readonly code = FORM_VALIDATION_SUPERSEDED;
+
+  constructor() {
+    super('Form validation was superseded by a newer form state');
+    this.name = 'FormValidationSupersededError';
+  }
+}
+
+export function isFormValidationSupersededError(
+  error: unknown
+): error is FormValidationSupersededError {
+  return (
+    error instanceof FormValidationSupersededError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === FORM_VALIDATION_SUPERSEDED)
+  );
+}
+
 export interface FormContext {
   model: Record<string, unknown>;
   rules: FormRules | undefined;
@@ -38,6 +70,7 @@ export interface FormContext {
   /** 继承自表单的标签对齐方式 */
   labelAlign?: string;
   showMessage: boolean;
+  disabled: boolean;
   border?: boolean;
   card?: boolean;
   customValidator?: (
@@ -46,16 +79,28 @@ export interface FormContext {
   asteriskPosition?: 'left' | 'right';
   addField: (field: FormItemContext) => void;
   removeField: (field: FormItemContext) => void;
+  /** Supersede pending validation for a field subset, or all fields when omitted. */
+  invalidateValidation: (fields?: string[]) => void;
   validateField: (prop: string) => Promise<void>;
-  emitFieldBlur: (prop: string) => void;
+  emitFieldBlur: (prop: string, owner?: FormFieldInteractionOwner) => Promise<void>;
   /** value 为可选，供需要做业务拦截的场景使用 */
-  emitFieldChange: (prop: string, value?: unknown) => void;
+  emitFieldChange: (
+    prop: string,
+    value?: unknown,
+    owner?: FormFieldInteractionOwner
+  ) => Promise<void>;
   validate: (opts?: FormValidateOptions) => Promise<void>;
   resetFields: (fields?: string[]) => void;
   /** 仅清除验证状态，不重置字段值 */
   clearValidate: (fields?: string[]) => void;
   /** 滚动到指定字段 */
   scrollToField: (prop: string) => void;
+}
+
+/** Keeps automatic validation owned by the control interaction that proposed it. */
+export interface FormFieldInteractionOwner {
+  isCurrent: () => boolean;
+  awaitCurrent: () => Promise<boolean>;
 }
 
 export interface FormItemContext {
@@ -66,9 +111,34 @@ export interface FormItemContext {
     status: 'idle' | 'validating' | 'success' | 'error',
     message?: string
   ) => void;
-  validate: (trigger?: 'blur' | 'change') => Promise<void>;
-  reset: () => void;
+  /** Reserve a validation generation; silent reservations preserve stable visible state. */
+  beginValidation: (silent?: boolean) => number;
+  /** Test whether a stateful validation generation may still commit. */
+  isValidationCurrent: (generation: number) => boolean;
+  /** Capture the current generation without changing visible state. */
+  captureValidationGeneration: () => number;
+  /** Commit a generation after checking for synchronous supersession. */
+  commitValidation: (generation: number, errors: ValidateError[]) => number | undefined;
+  /** Clear state owned by a still-current superseded generation. */
+  rollbackValidation: (generation: number, commitToken?: number) => void;
+  /** Release rollback metadata after all external observers accepted a commit. */
+  releaseValidation: (commitToken: number) => void;
+  /** Resolve the concrete props that have rules for this validation request. */
+  getValidationProps: (trigger?: 'blur' | 'change', fields?: string[]) => string[];
+  /** Supersede pending validation, optionally clearing a visible validating state. */
+  invalidateValidation: (clearPending?: boolean) => void;
+  validate: (
+    trigger?: 'blur' | 'change',
+    options?: FormItemValidateOptions
+  ) => Promise<FormItemValidationResult>;
+  /** Execute a generation already reserved by a form-wide atomic validation. */
+  validateGeneration: (
+    generation: number,
+    trigger?: 'blur' | 'change',
+    options?: FormItemValidateOptions
+  ) => Promise<FormItemValidationResult>;
+  reset: (fields?: string[]) => void;
 }
 
 export const formContextKey: InjectionKey<FormContext> = Symbol('LkFormContext');
-export const formItemContextKey: InjectionKey<FormItemContext> = Symbol('LkFormItemContext');
+export const formItemContextKey: InjectionKey<FormItemContext | null> = Symbol('LkFormItemContext');

--- a/src/uni_modules/lucky-ui/components/lk-form/form.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-form/form.utils.ts
@@ -1,5 +1,12 @@
 import type { CSSProperties } from 'vue';
-import type { FormItemContext, FormRule, FormRules, ValidateError } from './context';
+import type {
+  FormItemContext,
+  FormRule,
+  FormRules,
+  FormValidateOptions,
+  ValidateError,
+} from './context';
+import { FormValidationSupersededError } from './context';
 
 export type FormValidateTrigger = 'blur' | 'change';
 export type FormValidateStatus = 'idle' | 'validating' | 'success' | 'error';
@@ -52,10 +59,12 @@ export async function validateFormValue(options: {
   rules: FormRule[];
   model?: Record<string, unknown>;
   fallbackMessage: string;
-}): Promise<ValidateError[]> {
+  isCurrent?: () => boolean;
+}): Promise<ValidateError[] | null> {
   const errors: ValidateError[] = [];
 
   for (const rule of options.rules) {
+    if (options.isCurrent?.() === false) return null;
     const message = rule.message || options.fallbackMessage;
 
     if (rule.required && isEmptyFormValue(options.value)) {
@@ -94,12 +103,14 @@ export async function validateFormValue(options: {
     if (rule.validator) {
       try {
         const result = await rule.validator(options.value, rule, options.model);
+        if (options.isCurrent?.() === false) return null;
         if (result === false) {
           errors.push({ field: options.field, message, rule });
         } else if (typeof result === 'string') {
           errors.push({ field: options.field, message: result, rule });
         }
       } catch (error: unknown) {
+        if (options.isCurrent?.() === false) return null;
         const errorMessage = error instanceof Error ? error.message : message;
         errors.push({ field: options.field, message: errorMessage || message, rule });
       }
@@ -128,9 +139,288 @@ export function resolveTargetFormFields(
   });
 }
 
+export function resolveFormItemProps(prop?: string | string[], names?: string[]): string[] {
+  const props = (Array.isArray(prop) ? prop : [prop]).filter(
+    (item): item is string => typeof item === 'string' && item.length > 0
+  );
+  const uniqueProps = Array.from(new Set(props));
+  if (!names?.length) return uniqueProps;
+  return uniqueProps.filter(item => names.includes(item));
+}
+
+export function resolveFormControlProp(
+  controlProp?: string,
+  itemProp?: string | string[]
+): string | undefined {
+  if (controlProp) return controlProp;
+  const itemProps = resolveFormItemProps(itemProp);
+  return itemProps.length === 1 ? itemProps[0] : undefined;
+}
+
+export interface FormItemInitialValue {
+  exists: boolean;
+  value: unknown;
+}
+
+export type FormItemInitialValues = Map<string, FormItemInitialValue>;
+
+export function cloneFormValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (value === null || typeof value !== 'object') return value;
+
+  const cached = seen.get(value);
+  if (cached !== undefined) return cached as T;
+
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (value instanceof RegExp) return new RegExp(value.source, value.flags) as T;
+
+  if (Array.isArray(value)) {
+    const result = new Array(value.length) as unknown[];
+    seen.set(value, result);
+    for (let index = 0; index < value.length; index += 1) {
+      if (index in value) result[index] = cloneFormValue(value[index], seen);
+    }
+    return result as T;
+  }
+
+  if (value instanceof Map) {
+    const result = new Map<unknown, unknown>();
+    seen.set(value, result);
+    value.forEach((entryValue, entryKey) => {
+      result.set(cloneFormValue(entryKey, seen), cloneFormValue(entryValue, seen));
+    });
+    return result as T;
+  }
+
+  if (value instanceof Set) {
+    const result = new Set<unknown>();
+    seen.set(value, result);
+    value.forEach(entryValue => result.add(cloneFormValue(entryValue, seen)));
+    return result as T;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+
+  const result = Object.create(prototype) as Record<string, unknown>;
+  seen.set(value, result);
+  Object.keys(value).forEach(key => {
+    result[key] = cloneFormValue((value as Record<string, unknown>)[key], seen);
+  });
+  return result as T;
+}
+
+export function captureFormItemInitialValues(
+  model: Record<string, unknown>,
+  prop?: string | string[]
+): FormItemInitialValues {
+  const result: FormItemInitialValues = new Map();
+  resolveFormItemProps(prop).forEach(field => {
+    result.set(field, {
+      exists: Object.prototype.hasOwnProperty.call(model, field),
+      value: cloneFormValue(model[field]),
+    });
+  });
+  return result;
+}
+
+export function restoreFormItemInitialValues(
+  model: Record<string, unknown>,
+  initialValues: FormItemInitialValues,
+  names?: string[]
+) {
+  initialValues.forEach((initial, field) => {
+    if (names?.length && !names.includes(field)) return;
+    if (initial.exists) {
+      model[field] = cloneFormValue(initial.value);
+    } else {
+      delete model[field];
+    }
+  });
+}
+
+export interface RegisteredFormValidationResult {
+  errors: ValidateError[];
+  stale: boolean;
+  reports: Array<{
+    prop: string;
+    ok: boolean;
+    errors: ValidateError[] | null;
+  }>;
+  /** Restore only commits that are still owned by this validation run. */
+  rollback: () => void;
+  /** Discard rollback snapshots after all public observers accepted the run. */
+  release: () => void;
+  /** Verify that every target reservation and external form state still belongs to this run. */
+  isCurrent: () => boolean;
+}
+
+export async function validateRegisteredFormFields(options: {
+  fields: FormItemContext[];
+  model: Record<string, unknown>;
+  customValidator?: (
+    model: Record<string, unknown>
+  ) => Record<string, string> | null | Promise<Record<string, string> | null>;
+  validateOptions?: FormValidateOptions;
+  isCurrent?: () => boolean;
+}): Promise<RegisteredFormValidationResult> {
+  const names = options.validateOptions?.fields;
+  const silent = options.validateOptions?.silent === true;
+  const target = resolveTargetFormFields(options.fields, names);
+  const createResult = (
+    errors: ValidateError[],
+    reports: RegisteredFormValidationResult['reports'],
+    rollback: () => void,
+    release: () => void,
+    isCurrent: () => boolean
+  ): RegisteredFormValidationResult => {
+    const result = { errors, stale: false } as RegisteredFormValidationResult;
+    Object.defineProperties(result, {
+      reports: { value: reports },
+      rollback: { value: rollback },
+      release: { value: release },
+      isCurrent: { value: isCurrent },
+    });
+    return result;
+  };
+  const emptyResult = () =>
+    createResult(
+      [],
+      [],
+      () => undefined,
+      () => undefined,
+      () => true
+    );
+  if (!target.length) return emptyResult();
+  const reports: Array<{
+    prop: string;
+    ok: boolean;
+    errors: ValidateError[] | null;
+  }> = [];
+  const candidates = target
+    .map(field => ({
+      field,
+      props: options.customValidator
+        ? resolveFormItemProps(field.prop, names)
+        : field.getValidationProps(undefined, names),
+    }))
+    .filter(entry => entry.props.length > 0);
+  if (!candidates.length) return emptyResult();
+  const baselineGenerations = new Map(
+    candidates.map(candidate => [candidate.field, candidate.field.captureValidationGeneration()])
+  );
+  const startedGenerations = new Map<FormItemContext, number>();
+  const entries: Array<
+    (typeof candidates)[number] & {
+      generation: number;
+      errors: ValidateError[];
+    }
+  > = [];
+  const errors: ValidateError[] = [];
+  const commitTokens = new Map<FormItemContext, number>();
+  const isCurrent = () =>
+    (!options.isCurrent || options.isCurrent()) &&
+    candidates.every(candidate =>
+      candidate.field.isValidationCurrent(
+        startedGenerations.get(candidate.field) ??
+          (baselineGenerations.get(candidate.field) as number)
+      )
+    );
+  let ownershipClosed = false;
+  const rollback = () => {
+    if (ownershipClosed) return;
+    ownershipClosed = true;
+    entries.forEach(entry => {
+      const commitToken = commitTokens.get(entry.field);
+      if (commitToken !== undefined) {
+        entry.field.rollbackValidation(entry.generation, commitToken);
+      }
+    });
+  };
+  const release = () => {
+    if (ownershipClosed) return;
+    ownershipClosed = true;
+    entries.forEach(entry => {
+      const commitToken = commitTokens.get(entry.field);
+      if (commitToken !== undefined) entry.field.releaseValidation(commitToken);
+    });
+  };
+  const superseded = (): never => {
+    rollback();
+    throw new FormValidationSupersededError();
+  };
+
+  // Reserve every target before any validator starts. Reservations are silent, so a
+  // form-wide run cannot expose partially validating state while another field is pending.
+  for (const candidate of candidates) {
+    if (!isCurrent()) superseded();
+    const generation = candidate.field.beginValidation(true);
+    startedGenerations.set(candidate.field, generation);
+    entries.push({ ...candidate, generation, errors: [] });
+    if (!isCurrent()) superseded();
+  }
+
+  if (options.customValidator) {
+    let errorMap: Record<string, string>;
+    let validatorError: string | undefined;
+    try {
+      errorMap = (await options.customValidator(options.model)) || {};
+    } catch (error) {
+      errorMap = {};
+      validatorError = error instanceof Error ? error.message : String(error);
+    }
+    if (!isCurrent()) superseded();
+    entries.forEach(entry => {
+      entry.errors = validatorError
+        ? [{ field: entry.props[0], message: validatorError }]
+        : entry.props
+            .filter(prop => !!errorMap[prop])
+            .map(prop => ({ field: prop, message: errorMap[prop] }));
+      errors.push(...entry.errors);
+    });
+  } else {
+    for (const entry of entries) {
+      if (!isCurrent()) superseded();
+      try {
+        const result = await entry.field.validateGeneration(entry.generation, undefined, {
+          silent: true,
+          fields: names,
+        });
+        if (result === 'stale') superseded();
+      } catch (error: unknown) {
+        if (error instanceof FormValidationSupersededError) throw error;
+        entry.errors = normalizeValidateErrors(error);
+        errors.push(...entry.errors);
+      }
+      if (!isCurrent()) superseded();
+    }
+  }
+
+  if (!silent) {
+    for (const entry of entries) {
+      const commitToken = isCurrent()
+        ? entry.field.commitValidation(entry.generation, entry.errors)
+        : undefined;
+      if (commitToken === undefined) return superseded();
+      commitTokens.set(entry.field, commitToken);
+      if (!isCurrent()) superseded();
+      entry.props.forEach(prop => {
+        const matchedErrors = entry.errors.filter(error => error.field === prop);
+        reports.push({
+          prop,
+          ok: matchedErrors.length === 0,
+          errors: matchedErrors.length ? matchedErrors : null,
+        });
+      });
+    }
+    if (!isCurrent()) superseded();
+  }
+  return createResult(errors, reports, rollback, release, isCurrent);
+}
+
 export function resolveFormClass(options: {
   border: boolean;
   card: boolean;
+  disabled: boolean;
   customClass: unknown;
 }) {
   return [
@@ -138,17 +428,10 @@ export function resolveFormClass(options: {
     {
       'lk-form--border': options.border,
       'lk-form--card': options.card,
+      'is-disabled': options.disabled,
     },
     options.customClass,
   ];
-}
-
-export function resolveFormItemResetValue(value: unknown): unknown {
-  if (Array.isArray(value)) return [];
-  if (typeof value === 'boolean') return false;
-  if (typeof value === 'number') return 0;
-  if (value === null || value === undefined) return null;
-  return '';
 }
 
 export function resolveFormItemLabelStyle(width?: string | number): CSSProperties {

--- a/src/uni_modules/lucky-ui/components/lk-form/form.validation.ts
+++ b/src/uni_modules/lucky-ui/components/lk-form/form.validation.ts
@@ -1,0 +1,266 @@
+import { watch, type WatchSource, type WatchStopHandle } from 'vue';
+import type {
+  FormContext,
+  FormItemValidateOptions,
+  FormItemValidationResult,
+  ValidateError,
+} from './context';
+import {
+  filterFormRulesByTrigger,
+  getFormFieldRules,
+  resolveFormItemProps,
+  validateFormValue,
+  type FormValidateStatus,
+  type FormValidateTrigger,
+} from './form.utils';
+
+export function watchFormItemInitialValueSources(options: {
+  model: WatchSource<Record<string, unknown> | undefined>;
+  prop: WatchSource<string | string[] | undefined>;
+  rebuild: () => void;
+}): WatchStopHandle[] {
+  return [
+    watch(options.model, options.rebuild, { flush: 'sync' }),
+    watch(options.prop, options.rebuild, { deep: true, flush: 'sync' }),
+  ];
+}
+
+export interface FormItemValidationController {
+  begin: (silent?: boolean) => number;
+  isCurrent: (generation: number) => boolean;
+  captureGeneration: () => number;
+  commitGeneration: (generation: number, errors: ValidateError[]) => number | undefined;
+  rollbackGeneration: (generation: number, commitToken?: number) => void;
+  releaseGeneration: (commitToken: number) => void;
+  setStatus: (status: FormValidateStatus, message?: string) => void;
+  getValidationProps: (trigger?: FormValidateTrigger, fields?: string[]) => string[];
+  invalidate: (clearPending?: boolean) => void;
+  validate: (
+    trigger?: FormValidateTrigger,
+    options?: FormItemValidateOptions
+  ) => Promise<FormItemValidationResult>;
+  validateGeneration: (
+    generation: number,
+    trigger?: FormValidateTrigger,
+    options?: FormItemValidateOptions
+  ) => Promise<FormItemValidationResult>;
+}
+
+export function createFormItemValidationController(options: {
+  getForm: () => FormContext | null;
+  getProp: () => string | string[] | undefined;
+  getStatus: () => FormValidateStatus;
+  getMessage: () => string;
+  setState: (status: FormValidateStatus, message: string) => void;
+  fallbackMessage: () => string;
+}): FormItemValidationController {
+  let validationGeneration = 0;
+  let stateRevision = 0;
+  const pendingSnapshots = new Map<number, { status: FormValidateStatus; message: string }>();
+  const commitSnapshots = new Map<number, { status: FormValidateStatus; message: string }>();
+
+  function setStatus(status: FormValidateStatus, message = '') {
+    stateRevision += 1;
+    const revision = stateRevision;
+    options.setState(status, message);
+    return revision;
+  }
+
+  function getStableState() {
+    const pending = pendingSnapshots.get(validationGeneration);
+    if (options.getStatus() === 'validating' && pending) return pending;
+    if (options.getStatus() === 'validating') return { status: 'idle' as const, message: '' };
+    // A public validation observer may re-enter before the current commit is released.
+    // Such a commit is still tentative, so descendants must inherit its accepted lineage
+    // instead of treating the temporarily visible success/error as their rollback target.
+    const tentative = commitSnapshots.get(stateRevision);
+    if (tentative) return tentative;
+    return { status: options.getStatus(), message: options.getMessage() };
+  }
+
+  function restoreState(snapshot: { status: FormValidateStatus; message: string }) {
+    setStatus(snapshot.status, snapshot.message);
+  }
+
+  function begin(silent = false) {
+    const previous = getStableState();
+    const generation = ++validationGeneration;
+    pendingSnapshots.clear();
+    if (silent) {
+      if (options.getStatus() === 'validating') restoreState(previous);
+    } else {
+      pendingSnapshots.set(generation, previous);
+      setStatus('validating');
+    }
+    return generation;
+  }
+
+  function isCurrent(generation: number) {
+    return generation === validationGeneration;
+  }
+
+  function captureGeneration() {
+    return validationGeneration;
+  }
+
+  function getValidationProps(trigger?: FormValidateTrigger, fields?: string[]) {
+    const form = options.getForm();
+    if (!form) return [];
+    const propsList = resolveFormItemProps(options.getProp(), fields);
+    if (form.customValidator) return propsList;
+    return propsList.filter(prop => {
+      return filterFormRulesByTrigger(getFormFieldRules(form.rules, prop), trigger).length > 0;
+    });
+  }
+
+  function invalidate(clearPending = false) {
+    const previous = getStableState();
+    validationGeneration += 1;
+    pendingSnapshots.clear();
+    if (clearPending && options.getStatus() === 'validating') {
+      restoreState(previous);
+    }
+  }
+
+  function commitGeneration(generation: number, errors: ValidateError[]) {
+    if (!isCurrent(generation)) return undefined;
+    const nextStatus = errors.length ? 'error' : 'success';
+    const previous = pendingSnapshots.get(generation) || {
+      status: options.getStatus(),
+      message: options.getMessage(),
+    };
+    // Reserve the lineage before setState: a flush:'sync' observer may re-enter begin()
+    // while the tentative success/error is being delivered.
+    const expectedCommitToken = stateRevision + 1;
+    commitSnapshots.set(expectedCommitToken, previous);
+    const commitToken = setStatus(nextStatus, errors[0]?.message);
+    if (isCurrent(generation) && stateRevision === commitToken) {
+      pendingSnapshots.delete(generation);
+      return commitToken;
+    }
+
+    // A synchronous state observer may mutate the model or start a newer validation.
+    // Clear only the value this commit just wrote; never overwrite the newer validating state.
+    commitSnapshots.delete(commitToken);
+    if (stateRevision === commitToken && options.getStatus() === nextStatus) restoreState(previous);
+    return undefined;
+  }
+
+  function rollbackGeneration(generation: number, commitToken?: number) {
+    let previous: { status: FormValidateStatus; message: string } | undefined;
+    if (commitToken !== undefined) {
+      previous = commitSnapshots.get(commitToken);
+      if (!previous) return;
+      commitSnapshots.delete(commitToken);
+      if (stateRevision !== commitToken) return;
+    } else if (!isCurrent(generation)) {
+      return;
+    } else {
+      previous = pendingSnapshots.get(generation);
+    }
+    if (commitToken === undefined) {
+      validationGeneration += 1;
+      pendingSnapshots.clear();
+    }
+    restoreState(previous || { status: 'idle', message: '' });
+  }
+
+  function releaseGeneration(commitToken: number) {
+    commitSnapshots.delete(commitToken);
+  }
+
+  async function validateGeneration(
+    generation: number,
+    trigger?: FormValidateTrigger,
+    validateOptions?: FormItemValidateOptions
+  ): Promise<FormItemValidationResult> {
+    const form = options.getForm();
+    if (!form) return 'skipped';
+    const propsList = resolveFormItemProps(options.getProp(), validateOptions?.fields);
+    if (!propsList.length) return 'skipped';
+    const silent = validateOptions?.silent === true;
+    const ownsValidation = () => isCurrent(generation) && validateOptions?.isCurrent?.() !== false;
+    if (!ownsValidation()) return 'stale';
+
+    if (form.customValidator) {
+      let errors: ValidateError[];
+      try {
+        const errorMap = (await form.customValidator(form.model)) || {};
+        errors = propsList
+          .filter(prop => !!errorMap[prop])
+          .map(prop => ({ field: prop, message: errorMap[prop] }));
+      } catch (error) {
+        errors = [
+          {
+            field: propsList[0],
+            message: error instanceof Error ? error.message : String(error),
+          },
+        ];
+      }
+
+      if (!ownsValidation()) return 'stale';
+      if (!silent) {
+        const commitToken = commitGeneration(generation, errors);
+        if (commitToken === undefined) return 'stale';
+        releaseGeneration(commitToken);
+      }
+      if (errors.length) return Promise.reject(errors);
+      return 'validated';
+    }
+
+    const validationEntries = propsList.map(prop => ({
+      prop,
+      rules: filterFormRulesByTrigger(getFormFieldRules(form.rules, prop), trigger),
+    }));
+    const performed = validationEntries.some(entry => entry.rules.length > 0);
+    if (!performed) return 'skipped';
+
+    const validationErrors: ValidateError[] = [];
+    for (const entry of validationEntries) {
+      if (!entry.rules.length) continue;
+      const errors = await validateFormValue({
+        field: entry.prop,
+        value: form.model[entry.prop],
+        rules: entry.rules,
+        model: form.model,
+        fallbackMessage: options.fallbackMessage(),
+        isCurrent: ownsValidation,
+      });
+      if (!errors || !ownsValidation()) return 'stale';
+      validationErrors.push(...errors);
+    }
+
+    if (!silent) {
+      const commitToken = commitGeneration(generation, validationErrors);
+      if (commitToken === undefined) return 'stale';
+      releaseGeneration(commitToken);
+    }
+    if (validationErrors.length) return Promise.reject(validationErrors);
+    return 'validated';
+  }
+
+  async function validate(
+    trigger?: FormValidateTrigger,
+    validateOptions?: FormItemValidateOptions
+  ): Promise<FormItemValidationResult> {
+    const silent = validateOptions?.silent === true;
+    const generation = begin(silent);
+    const result = await validateGeneration(generation, trigger, validateOptions);
+    if (result === 'skipped' && !silent && isCurrent(generation)) rollbackGeneration(generation);
+    return result;
+  }
+
+  return {
+    begin,
+    isCurrent,
+    captureGeneration,
+    commitGeneration,
+    rollbackGeneration,
+    releaseGeneration,
+    setStatus,
+    getValidationProps,
+    invalidate,
+    validate,
+    validateGeneration,
+  };
+}

--- a/src/uni_modules/lucky-ui/components/lk-form/lk-form-item.vue
+++ b/src/uni_modules/lucky-ui/components/lk-form/lk-form-item.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
 import {
-  inject,
-  provide,
-  ref,
-  readonly,
-  onMounted,
-  onBeforeUnmount,
   computed,
-  watch,
   getCurrentInstance,
+  inject,
+  onBeforeUnmount,
+  onMounted,
+  nextTick,
+  provide,
+  readonly,
+  ref,
   useSlots,
+  watch,
 } from 'vue';
 import { formItemEmits, formItemProps } from './form.props';
 import LkIcon from '../lk-icon/lk-icon.vue';
@@ -18,18 +19,23 @@ import {
   formContextKey,
   formItemContextKey,
   type FormContext,
-  type FormRule,
   type FormItemContext,
+  type FormRule,
 } from './context';
+import {
+  createFormItemValidationController,
+  watchFormItemInitialValueSources,
+} from './form.validation';
 import { useLocale } from '../../composables/useLocale';
 import {
-  filterFormRulesByTrigger,
+  captureFormItemInitialValues,
   getFormFieldRules,
   resolveFormItemClass,
   resolveFormItemLabelStyle,
+  resolveFormItemProps,
   resolveFormItemRequired,
-  resolveFormItemResetValue,
-  validateFormValue,
+  restoreFormItemInitialValues,
+  type FormItemInitialValues,
   type FormValidateStatus,
 } from './form.utils';
 import { addUnit } from '../../core/src/utils/unit';
@@ -44,75 +50,39 @@ const slots = useSlots();
 
 const status = ref<FormValidateStatus>('idle');
 const msg = ref('');
-const requiredMark = ref(false);
+let initialValues: FormItemInitialValues = new Map();
 
 function rules(): FormRule[] {
   return getFormFieldRules(form?.rules, props.prop);
 }
-function computeReq() {
-  return resolveFormItemRequired({
+
+const requiredMark = computed(() =>
+  resolveFormItemRequired({
     explicitRequired: props.required,
     rules: rules(),
-  });
-}
+  })
+);
 
 const resolvedAsteriskPosition = computed(() => {
   return props.asteriskPosition || form?.asteriskPosition || 'left';
 });
 
-async function doValidate(trigger?: 'blur' | 'change') {
-  const prop = props.prop;
-  if (!prop || !form) return;
+const validation = createFormItemValidationController({
+  getForm: () => form,
+  getProp: () => props.prop || undefined,
+  getStatus: () => status.value,
+  getMessage: () => msg.value,
+  setState(nextStatus, message) {
+    status.value = nextStatus;
+    msg.value = message;
+  },
+  fallbackMessage: () => t<string>('validationFailed'),
+});
 
-  // 1. 如果使用了自定义验证器 (例如 Zod)
-  if (form.customValidator) {
-    try {
-      const errorMap = await form.customValidator(form.model);
-      const propsList = Array.isArray(prop) ? prop : [prop];
-      const matchedProp = errorMap ? propsList.find(p => errorMap[p]) : undefined;
-      if (matchedProp) {
-        status.value = 'error';
-        msg.value = errorMap?.[matchedProp] || '';
-        return Promise.reject([{ field: matchedProp, message: msg.value }]);
-      } else {
-        status.value = 'success';
-        msg.value = '';
-      }
-    } catch (e) {
-      status.value = 'error';
-      msg.value = e instanceof Error ? e.message : String(e);
-      return Promise.reject([{ field: Array.isArray(prop) ? prop[0] : prop, message: msg.value }]);
-    }
-    return;
-  }
-
-  // 2. 默认的表单规则校验
-  const propsList = Array.isArray(prop) ? prop : [prop];
-  for (const p of propsList) {
-    const list = filterFormRulesByTrigger(getFormFieldRules(form.rules, p), trigger);
-    if (!list.length) continue;
-    const val = form.model[p];
-    status.value = 'validating';
-    msg.value = '';
-    const errs = await validateFormValue({
-      field: p,
-      value: val,
-      rules: list,
-      model: form.model,
-      fallbackMessage: t<string>('validationFailed'),
-    });
-    if (errs.length) {
-      status.value = 'error';
-      msg.value = errs[0].message;
-      return Promise.reject(errs);
-    }
-  }
-  status.value = 'success';
-  msg.value = '';
-}
-
-const itemCtx: FormItemContext = {
-  prop: props.prop || undefined,
+const itemContext: FormItemContext = {
+  get prop() {
+    return props.prop || undefined;
+  },
   validateStatus: readonly(status),
   getBoundingClientRect() {
     return new Promise(resolve => {
@@ -128,80 +98,113 @@ const itemCtx: FormItemContext = {
         .exec();
     });
   },
-  setValidateStatus(s, m) {
-    status.value = s;
-    if (m !== undefined) msg.value = m;
+  setValidateStatus(nextStatus, message) {
+    validation.setStatus(
+      nextStatus,
+      message !== undefined
+        ? message
+        : nextStatus === 'idle' || nextStatus === 'success'
+          ? ''
+          : msg.value
+    );
   },
-  validate: doValidate,
-  reset() {
-    if (props.prop && form) {
-      const propsList = Array.isArray(props.prop) ? props.prop : [props.prop];
-      propsList.forEach(p => {
-        const v = form.model[p];
-        form.model[p] = resolveFormItemResetValue(v);
-      });
-    }
-    status.value = 'idle';
-    msg.value = '';
+  beginValidation: validation.begin,
+  isValidationCurrent: validation.isCurrent,
+  captureValidationGeneration: validation.captureGeneration,
+  commitValidation: validation.commitGeneration,
+  rollbackValidation: validation.rollbackGeneration,
+  releaseValidation: validation.releaseGeneration,
+  getValidationProps: validation.getValidationProps,
+  invalidateValidation: validation.invalidate,
+  validate: validation.validate,
+  validateGeneration: validation.validateGeneration,
+  reset(fieldNames) {
+    validation.invalidate();
+    if (form) restoreFormItemInitialValues(form.model, initialValues, fieldNames);
+    validation.setStatus('idle');
   },
 };
+let active = true;
 
-provide(formItemContextKey, itemCtx);
+provide(formItemContextKey, itemContext);
 
-onMounted(() => {
-  requiredMark.value = computeReq();
-  form?.addField(itemCtx);
+function rebuildInitialValues() {
+  validation.invalidate();
+  initialValues = form ? captureFormItemInitialValues(form.model, props.prop) : new Map();
+  validation.setStatus('idle');
+}
+
+rebuildInitialValues();
+watchFormItemInitialValueSources({
+  model: () => form?.model,
+  prop: () => props.prop || undefined,
+  rebuild: rebuildInitialValues,
 });
-onBeforeUnmount(() => form?.removeField(itemCtx));
-watch([() => props.required, () => form?.rules], () => (requiredMark.value = computeReq()), {
-  deep: true,
+watch(
+  () => form?.disabled,
+  () => {
+    validation.invalidate(true);
+  },
+  { flush: 'sync' }
+);
+watch(
+  () => resolveFormItemProps(props.prop).map(prop => form?.rules?.[prop]),
+  () => validation.invalidate(true),
+  { deep: true, flush: 'sync' }
+);
+
+onMounted(() => form?.addField(itemContext));
+onBeforeUnmount(() => {
+  active = false;
+  validation.invalidate();
+  form?.removeField(itemContext);
 });
 
 const labelStyle = computed(() => {
-  const w = props.labelWidth || form?.labelWidth;
-  return resolveFormItemLabelStyle(w);
+  const width = props.labelWidth || form?.labelWidth;
+  return resolveFormItemLabelStyle(width);
 });
-
-// 继承表单的 labelAlign
 const resolvedLabelAlign = computed(() => props.labelAlign || form?.labelAlign || 'left');
-
-// 是否 top 布局
 const isTopLayout = computed(() => resolvedLabelAlign.value === 'top' || props.vertical);
-
-// 表单是否开启 border/card
 const hasBorder = computed(() => {
   return props.border !== undefined ? props.border : !!form?.border;
 });
-
+const isFormDisabled = computed(() => !!form?.disabled);
 const style = computed(() => props.customStyle as StyleValue);
 const errorStyle = computed<StyleValue>(() => {
   if (isTopLayout.value || (!props.label && !slots.label)) return {};
-
   const width = addUnit(props.labelWidth || form?.labelWidth) || 'var(--lk-rpx-160)';
   return {
     paddingLeft: `calc(var(--_padding-x) + ${width} + var(--_gap-x))`,
   };
 });
-const classes = computed(() =>
-  resolveFormItemClass({
+const classes = computed(() => [
+  ...resolveFormItemClass({
     customClass: props.customClass,
     status: status.value,
     labelAlign: resolvedLabelAlign.value,
     topLayout: isTopLayout.value,
     border: hasBorder.value,
     link: props.isLink,
-  })
-);
+  }),
+  { 'is-disabled': isFormDisabled.value },
+]);
 
-function onItemTap(event: unknown) {
+async function onItemTap(event: unknown) {
+  if (isFormDisabled.value) return;
   emit('tap', event);
+  await nextTick();
+  if (!active || isFormDisabled.value) return;
   emit('click', event);
 }
 
 defineExpose({
-  validate: doValidate,
-  resetField: itemCtx.reset,
-  clearValidate: () => itemCtx.setValidateStatus('idle'),
+  validate: validation.validate,
+  resetField: itemContext.reset,
+  clearValidate: () => {
+    itemContext.invalidateValidation();
+    itemContext.setValidateStatus('idle');
+  },
 });
 </script>
 
@@ -212,6 +215,10 @@ defineExpose({
     :class="classes"
     :style="style"
     :data-prop="Array.isArray(prop) ? prop.join(',') : prop"
+    :data-validation-status="status"
+    :data-validation-message="msg"
+    :data-disabled="isFormDisabled ? 'true' : 'false'"
+    :aria-disabled="isFormDisabled"
     @tap="onItemTap"
   >
     <view class="lk-form-item__body">

--- a/src/uni_modules/lucky-ui/components/lk-form/lk-form.vue
+++ b/src/uni_modules/lucky-ui/components/lk-form/lk-form.vue
@@ -1,212 +1,275 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { reactive, provide, computed, watchEffect } from 'vue';
-import { formProps, formEmits } from './form.props';
-import type { FormContext, FormItemContext, ValidateError } from './context';
-import { formContextKey } from './context';
-import { normalizeValidateErrors, resolveFormClass, resolveTargetFormFields } from './form.utils';
+import { computed, nextTick, onBeforeUnmount, provide, reactive, watch, watchEffect } from 'vue';
+import { formEmits, formProps } from './form.props';
+import type {
+  FormContext,
+  FormFieldInteractionOwner,
+  FormItemContext,
+  FormValidateOptions,
+  ValidateError,
+} from './context';
+import {
+  FormValidationSupersededError,
+  formContextKey,
+  formItemContextKey,
+  isFormValidationSupersededError,
+} from './context';
+import {
+  normalizeValidateErrors,
+  resolveFormClass,
+  resolveFormItemProps,
+  resolveTargetFormFields,
+  validateRegisteredFormFields,
+} from './form.utils';
 
 defineOptions({ name: 'LkForm' });
 const props = defineProps(formProps);
 const emit = defineEmits(formEmits);
 
 const fields: FormItemContext[] = reactive([]);
+const fieldModelStops = new Map<FormItemContext, () => void>();
+let formStateGeneration = 0;
+let formActive = true;
 
-function addField(f: FormItemContext) {
-  if (f && !fields.includes(f)) fields.push(f);
+function invalidateValidation(fieldNames?: string[]) {
+  resolveTargetFormFields(fields, fieldNames).forEach(field => field.invalidateValidation(true));
 }
-function removeField(f: FormItemContext) {
-  const i = fields.indexOf(f);
-  if (i > -1) fields.splice(i, 1);
+
+function invalidateFormState() {
+  formStateGeneration += 1;
+  invalidateValidation();
+}
+
+function addField(field: FormItemContext) {
+  if (field && !fields.includes(field)) {
+    fields.push(field);
+    formStateGeneration += 1;
+    fieldModelStops.set(
+      field,
+      watch(
+        () => resolveFormItemProps(field.prop).map(prop => props.model[prop]),
+        () => {
+          if (props.customValidator) invalidateValidation();
+          else field.invalidateValidation(true);
+        },
+        { deep: true, flush: 'sync' }
+      )
+    );
+  }
+}
+
+function removeField(field: FormItemContext) {
+  const index = fields.indexOf(field);
+  if (index > -1) {
+    fieldModelStops.get(field)?.();
+    fieldModelStops.delete(field);
+    fields.splice(index, 1);
+    formStateGeneration += 1;
+  }
 }
 
 function findFieldByProp(prop: string) {
-  return fields.find(f => {
-    if (!f.prop) return false;
-    if (Array.isArray(f.prop)) return f.prop.includes(prop);
-    return f.prop === prop;
+  return fields.find(field => {
+    if (!field.prop) return false;
+    if (Array.isArray(field.prop)) return field.prop.includes(prop);
+    return field.prop === prop;
   });
 }
 
-/** 验证全部或指定字段，返回 Promise。失败时 reject 携带 ValidateError[] */
-async function validate(opts?: { fields?: string[]; silent?: boolean }) {
-  // 1. 如果使用了自定义验证器 (例如 Zod)
-  if (props.customValidator) {
-    try {
-      const res = await props.customValidator(props.model);
-      const errors: ValidateError[] = [];
-      const errorMap = res || {};
-
-      for (const f of fields) {
-        if (!f.prop) continue;
-        const propsList = Array.isArray(f.prop) ? f.prop : [f.prop];
-        const errProp = propsList.find(p => errorMap[p]);
-
-        if (errProp) {
-          const errMsg = errorMap[errProp];
-          f.setValidateStatus('error', errMsg);
-          errors.push({ field: errProp, message: errMsg });
-          emit('validate-field', errProp, false, [{ field: errProp, message: errMsg }]);
-        } else {
-          f.setValidateStatus('success', '');
-          propsList.forEach(p => {
-            emit('validate-field', p, true, null);
-          });
-        }
-      }
-
-      // 如果指定了特定字段校验，进行过滤
-      const targetErrors = opts?.fields
-        ? errors.filter(e => opts.fields!.includes(e.field))
-        : errors;
-
-      emit('validate', targetErrors.length === 0, targetErrors.length ? targetErrors : null);
-
-      if (targetErrors.length) {
-        if (props.scrollToError) {
-          scrollToField(targetErrors[0].field);
-        }
-        return Promise.reject(targetErrors);
-      }
-      return; // 验证成功
-    } catch (e) {
-      const errMsg = e instanceof Error ? e.message : String(e);
-      const errors = [{ field: 'global', message: errMsg }];
-      emit('validate', false, errors);
-      return Promise.reject(errors);
-    }
+/** Validate all registered fields or an explicit subset. */
+async function validate(options?: FormValidateOptions) {
+  const silent = options?.silent === true;
+  const stateGeneration = formStateGeneration;
+  const result = await validateRegisteredFormFields({
+    fields,
+    model: props.model,
+    customValidator: props.customValidator,
+    validateOptions: options,
+    isCurrent: () => stateGeneration === formStateGeneration,
+  });
+  function isCurrent() {
+    return stateGeneration === formStateGeneration && result.isCurrent();
   }
 
-  // 2. 默认的表单规则校验
-  const target = resolveTargetFormFields(fields, opts?.fields);
-  const errors: ValidateError[] = [];
-  for (const f of target) {
-    try {
-      await f.validate();
-      if (f.prop) {
-        const propsList = Array.isArray(f.prop) ? f.prop : [f.prop];
-        propsList.forEach(p => emit('validate-field', p, true, null));
-      }
-    } catch (e: unknown) {
-      const fieldErrors = normalizeValidateErrors(e);
-      errors.push(...fieldErrors);
-      if (f.prop) {
-        const propsList = Array.isArray(f.prop) ? f.prop : [f.prop];
-        propsList.forEach(p => {
-          const matchedErrs = fieldErrors.filter(err => err.field === p);
-          emit('validate-field', p, false, matchedErrs.length ? matchedErrs : null);
-        });
-      }
-    }
+  if (!isCurrent() || result.stale) {
+    result.rollback();
+    throw new FormValidationSupersededError();
   }
-  emit('validate', errors.length === 0, errors.length ? errors : null);
-  if (errors.length) {
-    if (props.scrollToError) {
-      scrollToField(errors[0].field);
-    }
-    return Promise.reject(errors);
-  }
-}
 
-/** 重置指定或全部字段到初始状态，并清除验证结果 */
-function resetFields(list?: string[]) {
-  resolveTargetFormFields(fields, list).forEach(f => f.reset());
-  emit('reset', list);
-}
-
-/** 清除指定或全部字段的验证状态（不重置值） */
-function clearValidate(list?: string[]) {
-  resolveTargetFormFields(fields, list).forEach(f => f.setValidateStatus('idle'));
-  emit('clear-validate', list);
-}
-
-/** 触发 blur 验证 */
-function emitFieldBlur(prop: string) {
-  emit('field-blur', prop);
-  const field = findFieldByProp(prop);
-  field
-    ?.validate('blur')
-    .then(() => emit('validate-field', prop, true, null))
-    .catch((error: ValidateError[]) => emit('validate-field', prop, false, error));
-}
-
-/** 触发 change 验证 */
-function emitFieldChange(prop: string, _value?: unknown) {
-  emit('field-change', prop, _value);
-  const field = findFieldByProp(prop);
-  field
-    ?.validate('change')
-    .then(() => emit('validate-field', prop, true, null))
-    .catch((error: ValidateError[]) => emit('validate-field', prop, false, error));
-}
-
-/** 验证单个字段 */
-async function validateField(prop: string) {
-  const f = findFieldByProp(prop);
-  if (!f) return;
   try {
-    await f.validate();
-    emit('validate-field', prop, true, null);
+    if (!silent) {
+      for (const report of result.reports) {
+        if (!isCurrent()) throw new FormValidationSupersededError();
+        emit('validate-field', report.prop, report.ok, report.errors);
+        await nextTick();
+        if (!isCurrent()) throw new FormValidationSupersededError();
+      }
+      emit('validate', result.errors.length === 0, result.errors.length ? result.errors : null);
+      await nextTick();
+      if (!isCurrent()) throw new FormValidationSupersededError();
+    }
   } catch (error) {
-    const errors = normalizeValidateErrors(error);
-    emit('validate-field', prop, false, errors);
-    return Promise.reject(errors);
+    result.rollback();
+    if (isFormValidationSupersededError(error) || !isCurrent()) {
+      throw new FormValidationSupersededError();
+    }
+    throw error;
+  }
+  result.release();
+
+  if (result.errors.length) {
+    if (!silent && props.scrollToError) {
+      scrollToField(result.errors[0].field, isCurrent);
+    }
+    return Promise.reject(result.errors);
   }
 }
 
-/** 滚动到指定字段 */
-function scrollToField(prop: string) {
-  const selector = `.lk-form-item[data-prop*="${prop}"]`;
+/** Restore registered fields to their mount-time values and clear validation state. */
+function resetFields(fieldNames?: string[]) {
+  invalidateValidation(fieldNames);
+  resolveTargetFormFields(fields, fieldNames).forEach(field => field.reset(fieldNames));
+  emit('reset', fieldNames);
+}
 
-  // #ifdef H5
-  const el = typeof document !== 'undefined' ? document.querySelector(selector) : null;
-  if (el instanceof HTMLElement) {
-    el.scrollIntoView({
-      behavior: 'smooth',
-      block: 'center',
-      inline: 'nearest',
+/** Clear validation state without changing field values. */
+function clearValidate(fieldNames?: string[]) {
+  invalidateValidation(fieldNames);
+  resolveTargetFormFields(fields, fieldNames).forEach(field => {
+    field.invalidateValidation();
+    field.setValidateStatus('idle');
+  });
+  emit('clear-validate', fieldNames);
+}
+
+async function runOwnedFieldValidation(
+  field: FormItemContext,
+  prop: string,
+  generation: number,
+  trigger?: 'blur' | 'change',
+  owner?: FormFieldInteractionOwner
+): Promise<{ skipped: boolean; errors: ValidateError[] }> {
+  let errors: ValidateError[] = [];
+  let result: 'validated' | 'skipped' | 'stale';
+
+  try {
+    result = await field.validateGeneration(generation, trigger, {
+      fields: [prop],
+      silent: true,
+      isCurrent: owner?.isCurrent,
     });
-    return;
+  } catch (error) {
+    if (!field.isValidationCurrent(generation) || isFormValidationSupersededError(error)) {
+      throw new FormValidationSupersededError();
+    }
+    errors = normalizeValidateErrors(error);
+    result = 'validated';
   }
-  // #endif
 
+  if (
+    !field.isValidationCurrent(generation) ||
+    owner?.isCurrent() === false ||
+    result === 'stale'
+  ) {
+    field.rollbackValidation(generation);
+    throw new FormValidationSupersededError();
+  }
+  if (result === 'skipped') {
+    field.rollbackValidation(generation);
+    return { skipped: true, errors };
+  }
+
+  const commitToken = field.commitValidation(generation, errors);
+  if (
+    commitToken === undefined ||
+    !field.isValidationCurrent(generation) ||
+    owner?.isCurrent() === false
+  ) {
+    if (commitToken !== undefined) field.rollbackValidation(generation, commitToken);
+    throw new FormValidationSupersededError();
+  }
+
+  try {
+    emit('validate-field', prop, errors.length === 0, errors.length ? errors : null);
+    const sourceCurrent = owner ? await owner.awaitCurrent() : (await nextTick(), true);
+    if (!sourceCurrent || !field.isValidationCurrent(generation)) {
+      throw new FormValidationSupersededError();
+    }
+  } catch (error) {
+    field.rollbackValidation(generation, commitToken);
+    if (isFormValidationSupersededError(error) || !field.isValidationCurrent(generation)) {
+      throw new FormValidationSupersededError();
+    }
+    throw error;
+  }
+
+  field.releaseValidation(commitToken);
+  return { skipped: false, errors };
+}
+
+async function validateFromField(
+  prop: string,
+  trigger: 'blur' | 'change',
+  owner?: FormFieldInteractionOwner
+) {
+  if (owner?.isCurrent() === false) return;
+  const field = findFieldByProp(prop);
+  if (!field) return;
+  const generation = field.beginValidation();
+  await runOwnedFieldValidation(field, prop, generation, trigger, owner).catch(() => undefined);
+}
+
+async function emitFieldBlur(prop: string, owner?: FormFieldInteractionOwner) {
+  if (props.disabled || owner?.isCurrent() === false) return;
+  emit('field-blur', prop);
+  const sourceCurrent = owner ? await owner.awaitCurrent() : (await nextTick(), true);
+  if (props.disabled || !sourceCurrent) return;
+  await validateFromField(prop, 'blur', owner);
+}
+
+async function emitFieldChange(prop: string, value?: unknown, owner?: FormFieldInteractionOwner) {
+  if (props.disabled || owner?.isCurrent() === false) return;
+  emit('field-change', prop, value);
+  const sourceCurrent = owner ? await owner.awaitCurrent() : (await nextTick(), true);
+  if (props.disabled || !sourceCurrent) return;
+  await validateFromField(prop, 'change', owner);
+}
+
+async function validateField(prop: string) {
+  const field = findFieldByProp(prop);
+  if (!field) return;
+  const generation = field.beginValidation();
+  const result = await runOwnedFieldValidation(field, prop, generation);
+  if (!result.skipped && result.errors.length) return Promise.reject(result.errors);
+}
+
+function scrollToField(prop: string, isCurrent: () => boolean = () => true) {
+  function ownsScroll() {
+    return formActive && isCurrent();
+  }
+  if (!ownsScroll()) return;
   const field = findFieldByProp(prop);
   if (field?.getBoundingClientRect) {
     field.getBoundingClientRect().then(node => {
-      if (node?.top != null) {
-        scrollPageToRectTop(node.top, node.height);
+      if (node?.top != null && ownsScroll()) {
+        scrollPageToRectTop(node.top, node.height, ownsScroll);
       }
     });
-    return;
   }
-
-  const query = uni.createSelectorQuery();
-  query.select(selector).boundingClientRect();
-  applyViewportScrollOffset(query);
-  query.exec(results => {
-    const rect = results?.[0];
-    const scroll = results?.[1] as { scrollTop?: number } | undefined;
-    const node = Array.isArray(rect) ? rect[0] : rect;
-    const currentScrollTop = typeof scroll?.scrollTop === 'number' ? scroll.scrollTop : 0;
-
-    if (node?.top != null) {
-      const blockOffset = getScrollBlockOffset(node.height);
-      uni.pageScrollTo({
-        scrollTop: Math.max(0, currentScrollTop + node.top - blockOffset),
-        duration: 300,
-      });
-    }
-  });
 }
 
-function scrollPageToRectTop(top: number, height?: number) {
+function scrollPageToRectTop(top: number, height?: number, isCurrent: () => boolean = () => true) {
+  if (!isCurrent()) return;
   const query = uni.createSelectorQuery();
   applyViewportScrollOffset(query);
   query.exec(results => {
+    if (!isCurrent()) return;
     const scroll = results?.[0] as { scrollTop?: number } | undefined;
     const currentScrollTop = typeof scroll?.scrollTop === 'number' ? scroll.scrollTop : 0;
     const blockOffset = getScrollBlockOffset(height);
 
+    if (!isCurrent()) return;
     uni.pageScrollTo({
       scrollTop: Math.max(0, currentScrollTop + top - blockOffset),
       duration: 300,
@@ -226,7 +289,7 @@ function getScrollBlockOffset(height?: number) {
       return Math.max(20, (viewportHeight - (height || 0)) / 2);
     }
   } catch {
-    // ignore
+    // Fall back to a small top offset when system information is unavailable.
   }
   return 20;
 }
@@ -235,10 +298,10 @@ const classes = computed(() => [
   ...resolveFormClass({
     border: props.border,
     card: props.card,
+    disabled: props.disabled,
     customClass: props.customClass,
   }),
 ]);
-
 const style = computed(() => props.customStyle as StyleValue);
 
 const formContext = reactive<FormContext>({
@@ -247,12 +310,14 @@ const formContext = reactive<FormContext>({
   labelWidth: props.labelWidth,
   labelAlign: props.labelAlign,
   showMessage: props.showMessage,
+  disabled: props.disabled,
   border: props.border,
   card: props.card,
   customValidator: props.customValidator,
   asteriskPosition: props.asteriskPosition,
   addField,
   removeField,
+  invalidateValidation,
   validateField,
   emitFieldBlur,
   emitFieldChange,
@@ -262,19 +327,34 @@ const formContext = reactive<FormContext>({
   scrollToField,
 });
 
-watchEffect(() => {
-  formContext.model = props.model;
-  formContext.rules = props.rules;
-  formContext.labelWidth = props.labelWidth;
-  formContext.labelAlign = props.labelAlign;
-  formContext.showMessage = props.showMessage;
-  formContext.border = props.border;
-  formContext.card = props.card;
-  formContext.customValidator = props.customValidator;
-  formContext.asteriskPosition = props.asteriskPosition;
+watchEffect(
+  () => {
+    formContext.model = props.model;
+    formContext.rules = props.rules;
+    formContext.labelWidth = props.labelWidth;
+    formContext.labelAlign = props.labelAlign;
+    formContext.showMessage = props.showMessage;
+    formContext.disabled = props.disabled;
+    formContext.border = props.border;
+    formContext.card = props.card;
+    formContext.customValidator = props.customValidator;
+    formContext.asteriskPosition = props.asteriskPosition;
+  },
+  { flush: 'sync' }
+);
+
+watch([() => props.customValidator, () => props.disabled], invalidateFormState, { flush: 'sync' });
+
+onBeforeUnmount(() => {
+  formActive = false;
+  invalidateFormState();
+  fieldModelStops.forEach(stop => stop());
+  fieldModelStops.clear();
 });
 
 provide(formContextKey, formContext);
+// A nested Form is an ownership boundary; do not inherit an outer FormItem.
+provide(formItemContextKey, null);
 
 defineExpose({
   validate,
@@ -286,7 +366,16 @@ defineExpose({
 </script>
 
 <template>
-  <view :id="id" :class="classes" :style="style" :data-lk-form="true"><slot /></view>
+  <view
+    :id="id"
+    :class="classes"
+    :style="style"
+    :data-lk-form="true"
+    :data-disabled="disabled ? 'true' : 'false'"
+    :aria-disabled="disabled"
+  >
+    <slot />
+  </view>
 </template>
 
 <style lang="scss">

--- a/src/uni_modules/lucky-ui/components/lk-form/useFormField.ts
+++ b/src/uni_modules/lucky-ui/components/lk-form/useFormField.ts
@@ -1,0 +1,136 @@
+import { computed, inject, nextTick, onBeforeUnmount, watch } from 'vue';
+import { formContextKey, formItemContextKey } from './context';
+import { resolveFormControlProp } from './form.utils';
+
+export interface UseFormFieldOptions {
+  prop?: () => string;
+  disabled: () => boolean;
+  validateEvent?: () => boolean;
+  inheritFormItemProp?: boolean;
+  /** Editing locks (for example readonly) invalidate an in-flight user chain without styling disabled. */
+  interactionLocked?: () => boolean;
+}
+
+/**
+ * Connect a form control to its nearest Form/FormItem pair.
+ * FormItem prop inheritance is opt-in so existing controls keep their explicit-prop contract.
+ */
+export function useFormField(options: UseFormFieldOptions) {
+  const disabledState = useFormDisabled(
+    options.disabled,
+    () => options.disabled() || options.interactionLocked?.() === true
+  );
+  const form = disabledState.form;
+  const formItem = inject(formItemContextKey, null);
+
+  const prop = computed(() =>
+    resolveFormControlProp(
+      options.prop?.() || '',
+      options.inheritFormItemProp ? formItem?.prop : undefined
+    )
+  );
+  // A pending interaction belongs to the field identity captured at its entrypoint.
+  // Rebinding either an explicit prop or an inherited FormItem prop supersedes it.
+  watch(prop, () => disabledState.invalidateInteraction(), { flush: 'sync' });
+  const disabled = disabledState.disabled;
+  const validateEvent = computed(() => options.validateEvent?.() !== false);
+  const hasError = computed(() => formItem?.validateStatus?.value === 'error');
+
+  async function emitChange(value?: unknown, interaction = disabledState.captureInteraction()) {
+    if (disabled.value || !validateEvent.value || !prop.value) return;
+    const fieldProp = prop.value;
+    if (!disabledState.isInteractionCurrent(interaction)) return;
+    await form?.emitFieldChange(fieldProp, value, {
+      isCurrent: () => disabledState.isInteractionCurrent(interaction),
+      awaitCurrent: () => disabledState.awaitInteractionCurrent(interaction),
+    });
+  }
+
+  async function emitBlur(interaction = disabledState.captureInteraction()) {
+    if (disabled.value || !validateEvent.value || !prop.value) return;
+    const fieldProp = prop.value;
+    if (!disabledState.isInteractionCurrent(interaction)) return;
+    await form?.emitFieldBlur(fieldProp, {
+      isCurrent: () => disabledState.isInteractionCurrent(interaction),
+      awaitCurrent: () => disabledState.awaitInteractionCurrent(interaction),
+    });
+  }
+
+  return {
+    awaitInteractionCurrent: disabledState.awaitInteractionCurrent,
+    captureInteraction: disabledState.captureInteraction,
+    disabled,
+    emitBlur,
+    emitChange,
+    form,
+    formItem,
+    hasError,
+    isInteractionCurrent: disabledState.isInteractionCurrent,
+    prop,
+  };
+}
+
+export function useFormDisabled(
+  disabledSource: () => boolean,
+  interactionLockedSource: () => boolean = disabledSource
+) {
+  const form = inject(formContextKey, null);
+  const disabled = computed(() => disabledSource() || !!form?.disabled);
+  let interactionGeneration = 0;
+  let active = true;
+
+  watch([interactionLockedSource, () => !!form?.disabled], () => (interactionGeneration += 1), {
+    flush: 'sync',
+  });
+
+  onBeforeUnmount(() => {
+    active = false;
+    interactionGeneration += 1;
+  });
+
+  function captureInteraction() {
+    return interactionGeneration;
+  }
+
+  function invalidateInteraction() {
+    interactionGeneration += 1;
+  }
+
+  function isInteractionCurrent(generation: number) {
+    return (
+      active &&
+      generation === interactionGeneration &&
+      !interactionLockedSource() &&
+      !form?.disabled
+    );
+  }
+
+  /**
+   * Let a public event listener's parent-state proposal reach the real Form props before
+   * continuing a multi-stage interaction. A same-stack true -> false pulse is intentionally
+   * not observable; only the state delivered by Vue's next render edge is authoritative.
+   */
+  async function awaitInteractionCurrent(generation: number) {
+    await nextTick();
+    return isInteractionCurrent(generation);
+  }
+
+  /**
+   * Observe one Vue delivery edge without treating Form.disabled as a cancellation signal.
+   * This is reserved for close/cancel flows that must remain available while disabled.
+   */
+  async function awaitActive() {
+    await nextTick();
+    return active;
+  }
+
+  return {
+    awaitActive,
+    awaitInteractionCurrent,
+    captureInteraction,
+    disabled,
+    form,
+    invalidateInteraction,
+    isInteractionCurrent,
+  };
+}

--- a/src/uni_modules/lucky-ui/components/lk-input/input.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-input/input.props.ts
@@ -129,6 +129,9 @@ export const inputProps = {
   /** 表单字段名，用于表单验证联动 */
   prop: LkProp.string(''),
 
+  /** Whether value and blur events should trigger Form validation. */
+  validateEvent: LkProp.boolean(true),
+
   /** 是否自动聚焦 */
   autofocus: LkProp.boolean(false),
 

--- a/src/uni_modules/lucky-ui/components/lk-input/input.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-input/input.utils.ts
@@ -24,6 +24,10 @@ export function hasInputValue(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
 }
 
+export function shouldCommitInputBlur(options: { disabled: boolean; readonly: boolean }): boolean {
+  return !options.disabled && !options.readonly;
+}
+
 export function resolveInputNativeState(options: { type: InputType; passwordVisible: boolean }) {
   return {
     nativeType: options.type === 'password' ? 'text' : options.type,

--- a/src/uni_modules/lucky-ui/components/lk-input/lk-input.vue
+++ b/src/uni_modules/lucky-ui/components/lk-input/lk-input.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { ref, watch, computed, inject, useSlots } from 'vue';
-import { formContextKey, formItemContextKey } from '../lk-form/context';
+import { ref, watch, computed, onBeforeUnmount, useSlots } from 'vue';
+import { useFormField } from '../lk-form/useFormField';
 import type { InputEventPayload, InputValue } from './input.props';
 import { inputProps, inputEmits } from './input.props';
 import LkIcon from '../lk-icon/lk-icon.vue';
@@ -13,6 +13,7 @@ import {
   resolveInputClass,
   resolveInputCount,
   resolveInputNativeState,
+  shouldCommitInputBlur,
   shouldShowPasswordToggle,
   shouldShowSuffix,
   shouldShowTrailingBalance,
@@ -24,12 +25,28 @@ const props = defineProps(inputProps);
 const emit = defineEmits(inputEmits);
 const slots = useSlots();
 
-const form = inject(formContextKey, null);
-const formItem = inject(formItemContextKey, null);
-
 const inner = ref<InputValue>(props.modelValue);
 const composing = ref(false);
+let compositionInteraction: number | null = null;
+let compositionInputValue: InputValue | null = null;
 const passwordVisible = ref(false);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+  inheritFormItemProp: true,
+  interactionLocked: () => props.readonly || props.fake,
+});
+const isDisabled = formField.disabled;
+const resolvedFormProp = formField.prop;
+const isNativeDisabled = computed(() => {
+  // H5 keeps readonly text focusable/selectable; mini-programs need disabled to suppress keyboards.
+  let disabled = isDisabled.value || props.readonly;
+  // #ifdef H5
+  disabled = isDisabled.value;
+  // #endif
+  return disabled;
+});
 
 const nativeState = computed(() =>
   resolveInputNativeState({
@@ -42,51 +59,101 @@ const nativePassword = computed(() => nativeState.value.nativePassword);
 
 const style = computed(() => props.customStyle as StyleValue);
 const isFocused = computed(() => props.focus || props.autofocus);
-const hasValidationError = computed(() => formItem?.validateStatus?.value === 'error');
+const hasValidationError = formField.hasError;
 
-function commit(val: InputValue, change = false) {
+async function commit(
+  val: InputValue,
+  change = false,
+  interaction = formField.captureInteraction()
+) {
+  if (!formField.isInteractionCurrent(interaction) || props.readonly || props.fake) return;
   inner.value = val;
   emit('update:modelValue', val);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('input', val);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   if (change) {
     emit('change', val);
-    if (props.prop) form?.emitFieldChange(props.prop, val);
+    if (!(await formField.awaitInteractionCurrent(interaction))) return;
   }
+  await formField.emitChange(val, interaction);
 }
 
-function onInput(e: InputEventPayload) {
+async function onInput(e: InputEventPayload, interaction = formField.captureInteraction()) {
+  if (!formField.isInteractionCurrent(interaction) || props.readonly || props.fake) return;
   const v = applyInputMaxlength(readInputValue(e), props.maxlength);
-  if (!composing.value) commit(v, false);
+  if (composing.value) {
+    if (interaction === compositionInteraction) compositionInputValue = v;
+    return;
+  }
+  await commit(v, false, interaction);
 }
-function onBlur(e: InputEventPayload) {
+async function onBlur(e: InputEventPayload) {
+  const interaction = formField.captureInteraction();
   emit('blur', e);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  if (!shouldCommitInputBlur({ disabled: isDisabled.value, readonly: props.readonly })) return;
   emit('change', inner.value);
-  if (props.prop) form?.emitFieldBlur(props.prop);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitBlur(interaction);
 }
 function onFocus(e: InputEventPayload) {
+  if (isDisabled.value) return;
   emit('focus', e);
 }
 function onConfirm(e: InputEventPayload) {
+  if (isDisabled.value) return;
   emit('confirm', e);
 }
 function onKeyboardHeightChange(e: InputEventPayload) {
+  if (isDisabled.value) return;
   emit('keyboardheightchange', e);
 }
-function onCompositionStart(e: InputEventPayload) {
+async function onCompositionStart(e: InputEventPayload) {
+  if (isDisabled.value || props.readonly || props.fake) return;
+  const interaction = formField.captureInteraction();
+  compositionInteraction = interaction;
+  compositionInputValue = null;
   composing.value = true;
   emit('compositionstart', e);
+  if (!(await formField.awaitInteractionCurrent(interaction))) {
+    if (compositionInteraction === interaction) compositionInteraction = null;
+    compositionInputValue = null;
+    composing.value = false;
+  }
 }
 function onCompositionUpdate(e: InputEventPayload) {
+  if (
+    compositionInteraction === null ||
+    !formField.isInteractionCurrent(compositionInteraction) ||
+    !composing.value
+  )
+    return;
   emit('compositionupdate', e);
 }
-function onCompositionEnd(e: InputEventPayload) {
+async function onCompositionEnd(e: InputEventPayload) {
+  const interaction = compositionInteraction;
+  if (
+    interaction === null ||
+    !composing.value ||
+    props.readonly ||
+    props.fake ||
+    !formField.isInteractionCurrent(interaction)
+  )
+    return;
+  const value = compositionInputValue ?? applyInputMaxlength(readInputValue(e), props.maxlength);
+  compositionInteraction = null;
+  compositionInputValue = null;
   composing.value = false;
   emit('compositionend', e);
-  onInput(e);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await commit(value, false, interaction);
 }
-function clear() {
-  if (props.disabled || props.readonly || !hasInputValue(inner.value)) return;
-  commit('', true);
+async function clear() {
+  if (isDisabled.value || props.readonly || !hasInputValue(inner.value)) return;
+  const interaction = formField.captureInteraction();
+  await commit('', true, interaction);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('clear');
 }
 
@@ -96,7 +163,7 @@ function togglePassword() {
 }
 
 function onFakeClick(e: unknown) {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
   emit('click', e);
 }
 
@@ -112,7 +179,7 @@ const count = computed(() => {
 const classes = computed(() => [
   ...resolveInputClass({
     size: props.size,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
     fake: props.fake,
     value: props.fake ? props.fakeText : inner.value,
@@ -134,7 +201,7 @@ const showPasswordToggle = computed(() => {
   return shouldShowPasswordToggle({
     showPassword: props.showPassword,
     type: props.type,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
     fake: props.fake,
   });
@@ -162,7 +229,7 @@ const showTrailingBalance = computed(() =>
 const showClear = computed(
   () =>
     props.clearable &&
-    !props.disabled &&
+    !isDisabled.value &&
     !props.readonly &&
     hasInputValue(inner.value) &&
     !props.fake
@@ -172,10 +239,44 @@ watch(
   () => props.modelValue,
   v => (inner.value = v)
 );
+watch(
+  isDisabled,
+  disabled => {
+    if (disabled) {
+      composing.value = false;
+      compositionInteraction = null;
+      compositionInputValue = null;
+    }
+  },
+  { flush: 'sync' }
+);
+watch(
+  () => props.readonly,
+  readonly => {
+    if (!readonly) return;
+    composing.value = false;
+    compositionInteraction = null;
+    compositionInputValue = null;
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  composing.value = false;
+  compositionInteraction = null;
+  compositionInputValue = null;
+});
 </script>
 
 <template>
-  <view :id="id" :class="classes" :style="style" @tap="fake ? onFakeClick($event) : undefined">
+  <view
+    :id="id"
+    :class="classes"
+    :style="style"
+    :data-form-prop="resolvedFormProp || ''"
+    :data-disabled="isDisabled ? 'true' : 'false'"
+    @tap="fake ? onFakeClick($event) : undefined"
+  >
     <view v-if="$slots.prefix || prefixIcon" class="lk-input__prefix">
       <slot name="prefix">
         <lk-icon v-if="prefixIcon" :name="prefixIcon" size="36" />
@@ -203,7 +304,7 @@ watch(
         :placeholder-style="placeholderStyle"
         :placeholder-class="placeholderClass"
         :maxlength="maxlength > -1 ? maxlength : 140000"
-        :disabled="disabled"
+        :disabled="isNativeDisabled"
         :readonly="readonly"
         :focus="isFocused"
         :confirm-type="confirmType"
@@ -216,7 +317,7 @@ watch(
         :hold-keyboard="holdKeyboard"
         :inputmode="inputmode"
         :ignore-composition-event="ignoreCompositionEvent"
-        :aria-disabled="disabled"
+        :aria-disabled="isDisabled"
         :aria-readonly="readonly"
         :aria-label="placeholder"
         @input="onInput"

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
@@ -9,6 +9,13 @@
   background: var(--lk-keyboard-bg);
   color: var(--lk-keyboard-text);
 
+  @include when(disabled) {
+    .lk-keyboard__body,
+    .lk-keyboard__done {
+      opacity: 0.5;
+    }
+  }
+
   @include e(header) {
     display: flex;
     align-items: center;

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
@@ -8,6 +8,7 @@ import {
 } from './keyboard.utils';
 import LkIcon from '../lk-icon/lk-icon.vue';
 import LkPopup from '../lk-popup/lk-popup.vue';
+import { useFormDisabled } from '../lk-form/useFormField';
 import { useLocale } from '../../composables/useLocale';
 
 defineOptions({ name: 'LkKeyboard' });
@@ -15,6 +16,8 @@ defineOptions({ name: 'LkKeyboard' });
 const props = defineProps(keyboardProps);
 const emit = defineEmits(keyboardEmits);
 const { t } = useLocale('keyboard');
+const formDisabled = useFormDisabled(() => false);
+const isDisabled = formDisabled.disabled;
 
 const plateMode = ref<KeyboardPlateMode>('province');
 
@@ -54,27 +57,32 @@ function triggerHaptic() {
   // #endif
 }
 
-function closeKeyboard() {
+async function closeKeyboard() {
   emit('update:visible', false);
+  if (!(await formDisabled.awaitActive())) return;
   emit('close');
 }
 
-function onPopupModelChange(visible: boolean) {
+async function onPopupModelChange(visible: boolean) {
   if (visible) {
     emit('update:visible', true);
     return;
   }
 
-  closeKeyboard();
+  await closeKeyboard();
 }
 
-function onConfirm() {
+async function onConfirm() {
+  if (isDisabled.value) return;
   triggerHaptic();
   emit('confirm', props.modelValue);
-  closeKeyboard();
+  if (!(await formDisabled.awaitActive())) return;
+  await closeKeyboard();
 }
 
-function onKeyPress(key: KeyboardKey) {
+async function onKeyPress(key: KeyboardKey) {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
   const action = resolveKeyboardPressAction({
     key,
     modelValue: props.modelValue,
@@ -86,9 +94,11 @@ function onKeyPress(key: KeyboardKey) {
 
   triggerHaptic();
   emit('key-press', key);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
 
   if (action.kind === 'delete') {
     emit('delete');
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
     if (props.modelValue.length > 0) {
       emit('update:modelValue', action.nextValue);
     }
@@ -97,7 +107,8 @@ function onKeyPress(key: KeyboardKey) {
 
   if (action.kind === 'confirm') {
     emit('confirm', props.modelValue);
-    closeKeyboard();
+    if (!(await formDisabled.awaitActive())) return;
+    await closeKeyboard();
     return;
   }
 
@@ -107,6 +118,7 @@ function onKeyPress(key: KeyboardKey) {
   }
 
   emit('input', action.input);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
   emit('update:modelValue', action.nextValue);
 }
 
@@ -139,10 +151,20 @@ function getKeyStyle(key: KeyboardKey): Record<string, number> {
     :custom-style="popupStyle"
     @update:model-value="onPopupModelChange"
   >
-    <view :id="id" class="lk-keyboard" :class="[`lk-keyboard--${type}`, customClass]">
+    <view
+      :id="id"
+      class="lk-keyboard"
+      :class="[`lk-keyboard--${type}`, customClass, { 'is-disabled': isDisabled }]"
+      :data-disabled="isDisabled ? 'true' : 'false'"
+      :aria-disabled="isDisabled"
+    >
       <view v-if="title || showClose || showConfirm" class="lk-keyboard__header">
         <view class="lk-keyboard__header-side">
-          <view v-if="showClose" class="lk-keyboard__header-action" @tap="closeKeyboard">
+          <view
+            v-if="showClose"
+            class="lk-keyboard__header-action lk-keyboard__close"
+            @tap="closeKeyboard"
+          >
             <text>{{ t('hide') }}</text>
           </view>
         </view>
@@ -150,7 +172,11 @@ function getKeyStyle(key: KeyboardKey): Record<string, number> {
         <text class="lk-keyboard__title">{{ title }}</text>
 
         <view class="lk-keyboard__header-side lk-keyboard__header-side--end">
-          <view v-if="showConfirm" class="lk-keyboard__header-action" @tap="onConfirm">
+          <view
+            v-if="showConfirm"
+            class="lk-keyboard__header-action lk-keyboard__done"
+            @tap="onConfirm"
+          >
             <text>{{ resolvedConfirmText }}</text>
           </view>
         </view>
@@ -163,6 +189,7 @@ function getKeyStyle(key: KeyboardKey): Record<string, number> {
             :key="keyIndex"
             :class="getKeyClass(key)"
             :style="getKeyStyle(key)"
+            :data-key="key.text"
             @tap="onKeyPress(key)"
           >
             <lk-icon v-if="key.type === 'delete'" name="eraser" :size="40" />

--- a/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.scss
+++ b/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.scss
@@ -11,6 +11,13 @@
   width: 100%;
   background: var(--lk-picker-bg);
 
+  @include when(disabled) {
+    .lk-picker__view-wrap,
+    .lk-picker__btn--confirm {
+      opacity: 0.5;
+    }
+  }
+
   @include m(inline) {
     border-radius: var(--lk-radius-lg);
     overflow: hidden;

--- a/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue
+++ b/src/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue
@@ -3,12 +3,10 @@ import type { StyleValue } from 'vue';
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
 import { pickerProps, pickerEmits, type PickerOption } from './picker.props';
 import LkPopup from '../lk-popup/lk-popup.vue';
+import { useFormDisabled } from '../lk-form/useFormField';
 import { useLocale } from '../../composables/useLocale';
 import {
   clampPickerIndex,
-  dispatchPickerCancelEvents,
-  dispatchPickerConfirmEvents,
-  dispatchPickerSelectionEvents,
   resolvePickerColumnOffset,
   resolvePickerColumnOffsetByDelta,
   resolvePickerColumnWrapperStyle,
@@ -33,6 +31,8 @@ defineOptions({ name: 'LkPicker' });
 const props = defineProps(pickerProps);
 const emit = defineEmits(pickerEmits);
 const { t } = useLocale('picker');
+const formDisabled = useFormDisabled(() => false);
+const isDisabled = formDisabled.disabled;
 
 const resolvedConfirmText = computed(() => props.confirmText || t('confirm'));
 const resolvedCancelText = computed(() => props.cancelText || t('cancel'));
@@ -57,6 +57,7 @@ const touchState = {
   startOffset: 0,
   startTime: 0,
   pxToRpx: 1,
+  interaction: null as number | null,
 };
 
 // 计算列数据
@@ -222,7 +223,8 @@ watch(
   }
 );
 
-function commitColumnIndex(columnIndex: number, optionIndex: number) {
+async function commitColumnIndex(columnIndex: number, optionIndex: number, interaction: number) {
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
   const columns = computedColumns.value;
   const selection = resolvePickerColumnSelection({
     mode: props.mode,
@@ -241,15 +243,20 @@ function commitColumnIndex(columnIndex: number, optionIndex: number) {
       : [];
   }
 
-  dispatchPickerSelectionEvents({
-    inline: props.inline,
-    selection,
-    onPick: (value, indexes, options) => emit('pick', value, indexes, options),
-    onUpdateModelValue: value => emit('update:modelValue', value),
-    onChange: value => emit('change', value),
-  });
+  if (selection.changed) {
+    emit('pick', selection.value, selection.indexes, selection.options);
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+
+    if (props.inline) {
+      emit('update:modelValue', selection.value);
+      if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+      emit('change', selection.value);
+      if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+    }
+  }
 
   nextTick(() => {
+    if (!formDisabled.isInteractionCurrent(interaction)) return;
     const normalized = computedColumns.value.map((column, index) =>
       clampPickerIndex(selectedIndexes.value[index] ?? 0, column.length)
     );
@@ -259,7 +266,9 @@ function commitColumnIndex(columnIndex: number, optionIndex: number) {
 }
 
 function onColumnTouchStart(event: unknown, columnIndex: number) {
+  if (isDisabled.value) return;
   touchState.columnIndex = columnIndex;
+  touchState.interaction = formDisabled.captureInteraction();
   touchState.startY = getTouchY(event);
   touchState.startOffset = columnOffsets.value[columnIndex] ?? 0;
   touchState.startTime = Date.now();
@@ -269,7 +278,14 @@ function onColumnTouchStart(event: unknown, columnIndex: number) {
 }
 
 function onColumnTouchMove(event: unknown, columnIndex: number) {
-  if (touchState.columnIndex !== columnIndex) return;
+  if (
+    touchState.columnIndex !== columnIndex ||
+    touchState.interaction === null ||
+    !formDisabled.isInteractionCurrent(touchState.interaction)
+  ) {
+    cancelPickerInteraction();
+    return;
+  }
 
   const column = computedColumns.value[columnIndex] || [];
   const delta = (getTouchY(event) - touchState.startY) * touchState.pxToRpx;
@@ -283,15 +299,24 @@ function onColumnTouchMove(event: unknown, columnIndex: number) {
   setColumnScrollState(columnIndex, offset, 0);
 }
 
-function onColumnTouchEnd(event: unknown, columnIndex: number) {
-  if (touchState.columnIndex !== columnIndex) return;
+async function onColumnTouchEnd(event: unknown, columnIndex: number) {
+  if (
+    touchState.columnIndex !== columnIndex ||
+    touchState.interaction === null ||
+    !formDisabled.isInteractionCurrent(touchState.interaction)
+  ) {
+    cancelPickerInteraction();
+    return;
+  }
 
   const column = computedColumns.value[columnIndex] || [];
   const offset = columnOffsets.value[columnIndex] ?? 0;
   const moveDistance = (getTouchY(event, true) - touchState.startY) * touchState.pxToRpx;
   const moveDuration = Date.now() - touchState.startTime;
 
+  const interaction = touchState.interaction;
   touchState.columnIndex = -1;
+  touchState.interaction = null;
 
   if (offset === touchState.startOffset) return;
 
@@ -306,19 +331,34 @@ function onColumnTouchEnd(event: unknown, columnIndex: number) {
 
   updateRenderedColumn(columnIndex, offset, result.offset, result.fast);
   setColumnScrollState(columnIndex, result.offset, result.duration);
-  commitColumnIndex(columnIndex, result.index);
+  await commitColumnIndex(columnIndex, result.index, interaction);
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
   scheduleRenderedColumnSettle(columnIndex, result.offset, result.duration);
 }
 
-function onClickItem(columnIndex: number, optionIndex: number) {
+async function onClickItem(columnIndex: number, optionIndex: number) {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
   const column = computedColumns.value[columnIndex] || [];
   const index = clampPickerIndex(optionIndex, column.length);
   const offset = resolvePickerColumnOffset(index, props.itemHeight);
 
   updateRenderedColumn(columnIndex, columnOffsets.value[columnIndex] ?? 0, offset);
   setColumnScrollState(columnIndex, offset, 200);
-  commitColumnIndex(columnIndex, index);
+  await commitColumnIndex(columnIndex, index, interaction);
+  if (!formDisabled.isInteractionCurrent(interaction)) return;
   scheduleRenderedColumnSettle(columnIndex, offset, 200);
+}
+
+function cancelPickerInteraction() {
+  touchState.columnIndex = -1;
+  touchState.interaction = null;
+  renderedColumnTimers.forEach((timer, index) => {
+    if (!timer) return;
+    clearTimeout(timer);
+    renderedColumnTimers[index] = undefined;
+  });
+  resetDraftSelection();
 }
 
 onBeforeUnmount(() => {
@@ -327,23 +367,26 @@ onBeforeUnmount(() => {
   });
 });
 
-function onCancel() {
+async function onCancel() {
   resetDraftSelection();
-  dispatchPickerCancelEvents({
-    snapshot: getSelectionSnapshot(),
-    onCancel: (value, indexes, options) => emit('cancel', value, indexes, options),
-    onVisibleChange: visible => emit('update:visible', visible),
-  });
+  const snapshot = getSelectionSnapshot();
+  emit('cancel', snapshot.value, snapshot.indexes, snapshot.options);
+  if (!(await formDisabled.awaitActive())) return;
+  emit('update:visible', false);
 }
 
-function onConfirm() {
-  dispatchPickerConfirmEvents({
-    snapshot: getSelectionSnapshot(),
-    onUpdateModelValue: value => emit('update:modelValue', value),
-    onChange: value => emit('change', value),
-    onConfirm: (value, indexes, options) => emit('confirm', value, [...indexes], options),
-    onVisibleChange: visible => emit('update:visible', visible),
-  });
+async function onConfirm() {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
+  const snapshot = getSelectionSnapshot();
+
+  emit('update:modelValue', snapshot.value);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  emit('change', snapshot.value);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  emit('confirm', snapshot.value, [...snapshot.indexes], snapshot.options);
+  if (!(await formDisabled.awaitActive())) return;
+  emit('update:visible', false);
 }
 
 /** 分层样式挂在 text 上，减少整项节点在滚动选中时的样式抖动。 */
@@ -369,6 +412,7 @@ const cls = computed(() => [
     inline: props.inline,
     customClass: props.customClass,
   }),
+  { 'is-disabled': isDisabled.value },
 ]);
 const style = computed(() => props.customStyle as StyleValue);
 const itemStyle = computed(() => resolvePickerItemStyle(props.itemHeight));
@@ -381,11 +425,19 @@ function columnWrapperStyle(columnIndex: number): string {
     visibleCount: props.visibleCount,
   });
 }
+
+watch(
+  isDisabled,
+  disabled => {
+    if (disabled) cancelPickerInteraction();
+  },
+  { flush: 'sync' }
+);
 </script>
 
 <template>
   <!-- 内联模式 -->
-  <view v-if="inline" :id="id" :class="cls" :style="style">
+  <view v-if="inline" :id="id" :class="cls" :style="style" :aria-disabled="isDisabled">
     <view v-if="title" class="lk-picker__header">
       <text class="lk-picker__title">{{ title }}</text>
     </view>
@@ -454,7 +506,7 @@ function columnWrapperStyle(columnIndex: number): string {
     :round="round"
     @update:model-value="(v: boolean) => emit('update:visible', v)"
   >
-    <view :id="id" :class="cls" :style="style">
+    <view :id="id" :class="cls" :style="style" :aria-disabled="isDisabled">
       <view class="lk-picker__toolbar">
         <view class="lk-picker__btn lk-picker__btn--cancel" @tap="onCancel">
           {{ resolvedCancelText }}

--- a/src/uni_modules/lucky-ui/components/lk-radio/lk-radio-group.vue
+++ b/src/uni_modules/lucky-ui/components/lk-radio/lk-radio-group.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { provide, computed, inject } from 'vue';
+import { provide, computed } from 'vue';
 import type { RadioValue } from './radio.props';
 import { radioGroupProps, radioGroupEmits } from './radio.props';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import { resolveRadioGroupClass } from './radio.utils';
 
 defineOptions({ name: 'LkRadioGroup' });
@@ -11,24 +11,33 @@ defineOptions({ name: 'LkRadioGroup' });
 const props = defineProps(radioGroupProps);
 const emit = defineEmits(radioGroupEmits);
 
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const LK_RADIO_GROUP_KEY = Symbol.for('LkRadioGroup');
 
 const style = computed(() => props.customStyle as StyleValue);
 
-function updateValue(value: RadioValue) {
+async function updateValue(value: RadioValue, interaction = formField.captureInteraction()) {
+  if (!formField.isInteractionCurrent(interaction)) return;
   if (value === props.modelValue) return;
   emit('update:modelValue', value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('change', value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('item-change', value);
-  if (props.validateEvent && props.prop) {
-    form?.emitFieldChange(props.prop, value);
-  }
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitChange(value, interaction);
 }
 
 provide(LK_RADIO_GROUP_KEY, {
   props,
+  disabled: isDisabled,
+  captureInteraction: formField.captureInteraction,
   updateValue,
 });
 
@@ -41,7 +50,7 @@ const groupClass = computed(() => {
 </script>
 
 <template>
-  <view :id="id" :class="groupClass" :style="style">
+  <view :id="id" :class="groupClass" :style="style" :aria-disabled="isDisabled">
     <slot />
   </view>
 </template>

--- a/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue
+++ b/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { StyleValue } from 'vue';
+import type { Ref, StyleValue } from 'vue';
 import { inject, computed } from 'vue';
 import type { RadioValue } from './radio.props';
 import { radioProps, radioEmits } from './radio.props';
 import LkIcon from '../lk-icon/lk-icon.vue';
+import { useFormField } from '../lk-form/useFormField';
 import {
   isRadioChecked,
   isRadioDisabled,
@@ -33,10 +34,17 @@ type RadioGroupContext = {
     size: string;
     activeColor: string;
   };
-  updateValue: (value: RadioValue) => void;
+  disabled: Readonly<Ref<boolean>>;
+  captureInteraction: () => number;
+  updateValue: (value: RadioValue, interaction?: number) => void | Promise<void>;
 };
 
 const group = inject<RadioGroupContext | null>(LK_RADIO_GROUP_KEY, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled || !!group?.disabled.value,
+  validateEvent: () => props.validateEvent,
+});
 
 const radioValue = computed(() => resolveRadioValue(props.name, props.label));
 const style = computed(() => props.customStyle as StyleValue);
@@ -51,8 +59,8 @@ const isChecked = computed(() => {
 
 const isDisabled = computed(() => {
   return isRadioDisabled({
-    disabled: props.disabled,
-    group: group?.props,
+    disabled: formField.disabled.value,
+    group: group ? { ...group.props, disabled: group.disabled.value } : undefined,
   });
 });
 
@@ -94,15 +102,21 @@ const iconStyle = computed(() => {
   });
 });
 
-function handleToggle(event?: unknown) {
+async function handleToggle(event?: unknown) {
   if (isDisabled.value) return;
+  const interaction = formField.captureInteraction();
+  const groupInteraction = group?.captureInteraction();
   emit('click', event, isChecked.value, radioValue.value);
+  if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
   if (isChecked.value) return;
   if (group) {
-    group.updateValue(radioValue.value);
+    await group.updateValue(radioValue.value, groupInteraction);
   } else {
     emit('update:modelValue', radioValue.value);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
     emit('change', radioValue.value);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || isDisabled.value) return;
+    await formField.emitChange(radioValue.value, interaction);
   }
 }
 

--- a/src/uni_modules/lucky-ui/components/lk-radio/radio.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-radio/radio.props.ts
@@ -83,6 +83,10 @@ export const radioProps = {
   label: LkProp.string(''),
   /** 是否禁用标签点击 */
   labelDisabled: LkProp.boolean(false),
+  /** 单独使用时的表单字段名 */
+  prop: LkProp.string(''),
+  /** 单独使用时是否触发表单验证 */
+  validateEvent: LkProp.boolean(true),
 } as const;
 
 export type RadioGroupProps = ExtractPropTypes<typeof radioGroupProps>;

--- a/src/uni_modules/lucky-ui/components/lk-rate/lk-rate.vue
+++ b/src/uni_modules/lucky-ui/components/lk-rate/lk-rate.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { ref, watch, computed, inject } from 'vue';
-import { formContextKey } from '../lk-form/context';
+import { ref, watch, computed } from 'vue';
+import { useFormField } from '../lk-form/useFormField';
 import { rateProps, rateEmits } from './rate.props';
 import {
   createRateStars,
@@ -16,7 +16,12 @@ defineOptions({ name: 'LkRate' });
 const props = defineProps(rateProps);
 const emit = defineEmits(rateEmits);
 
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const innerValue = ref<number>(props.modelValue);
 
@@ -54,12 +59,13 @@ function getStarColor(index: number) {
   return status === 'void' ? voidColor.value : activeColor.value;
 }
 
-function select(index: number, event?: unknown) {
+async function select(index: number, event?: unknown) {
+  const interaction = formField.captureInteraction();
   const result = resolveRateSelection({
     currentValue: innerValue.value,
     index,
     allowClear: props.allowClear,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
   });
 
@@ -67,7 +73,7 @@ function select(index: number, event?: unknown) {
     emit('click-disabled', {
       value: innerValue.value,
       index,
-      disabled: props.disabled,
+      disabled: isDisabled.value,
       readonly: props.readonly,
       event,
     });
@@ -77,25 +83,27 @@ function select(index: number, event?: unknown) {
   const newValue = result.value;
   const oldValue = result.oldValue;
   emit('click', { value: newValue, oldValue, index, event });
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
 
   // 点击当前已选中的星才清零
   if (result.cleared) {
     emit('clear', { oldValue, index, event });
+    if (!(await formField.awaitInteractionCurrent(interaction))) return;
   }
 
   if (!result.changed) return;
 
   innerValue.value = newValue;
   emit('update:modelValue', newValue);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('change', newValue, oldValue);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
 
-  if (props.prop) {
-    form?.emitFieldChange(props.prop, newValue);
-  }
+  await formField.emitChange(newValue, interaction);
 }
 
-function onTap(_e: unknown, index: number) {
-  select(index, _e);
+async function onTap(_e: unknown, index: number) {
+  await select(index, _e);
 }
 </script>
 
@@ -106,11 +114,12 @@ function onTap(_e: unknown, index: number) {
     :class="[
       customClass,
       {
-        'is-disabled': props.disabled,
+        'is-disabled': isDisabled,
         'is-readonly': props.readonly,
       },
     ]"
     :style="rootStyle"
+    :aria-disabled="isDisabled"
   >
     <view v-for="item in stars" :key="item" class="lk-rate__item" @tap="onTap($event, item)">
       <lk-icon :name="getStarIcon(item)" :size="iconSize" :color="getStarColor(item)" />

--- a/src/uni_modules/lucky-ui/components/lk-rate/rate.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-rate/rate.props.ts
@@ -42,6 +42,9 @@ export const rateProps = {
 
   /** 表单字段名 */
   prop: LkProp.string(''),
+
+  /** 值变化时是否触发表单校验 */
+  validateEvent: LkProp.boolean(true),
 } as const;
 
 export type RateProps = ExtractPropTypes<typeof rateProps>;

--- a/src/uni_modules/lucky-ui/components/lk-select-list/lk-select-list.vue
+++ b/src/uni_modules/lucky-ui/components/lk-select-list/lk-select-list.vue
@@ -2,6 +2,7 @@
 import type { StyleValue } from 'vue';
 import { computed } from 'vue';
 import LkIcon from '../lk-icon/lk-icon.vue';
+import { useFormDisabled } from '../lk-form/useFormField';
 import {
   selectListEmits,
   selectListProps,
@@ -25,12 +26,14 @@ defineOptions({ name: 'LkSelectList' });
 
 const props = defineProps(selectListProps);
 const emit = defineEmits(selectListEmits);
+const formDisabled = useFormDisabled(() => props.disabled);
+const isDisabled = formDisabled.disabled;
 
 const rootClass = computed(() => [
   ...resolveSelectListClass({
     size: props.size,
     inset: props.inset,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     bordered: props.bordered,
     selectedBg: props.selectedBg,
     selectedBorder: props.selectedBorder,
@@ -69,7 +72,7 @@ function getDescription(option: SelectListOption): string {
 function isOptionDisabled(option: SelectListOption): boolean {
   return isSelectListOptionDisabled({
     option,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     disabledKey: props.disabledKey,
   });
 }
@@ -90,7 +93,8 @@ function optionClass(option: SelectListOption) {
   });
 }
 
-function onSelect(option: SelectListOption) {
+async function onSelect(option: SelectListOption) {
+  const interaction = formDisabled.captureInteraction();
   const result = resolveSelectListSelection({
     option,
     valueKey: props.valueKey,
@@ -111,14 +115,16 @@ function onSelect(option: SelectListOption) {
 
   if (result.type === 'select') {
     emit('update:modelValue', result.value);
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
     emit('change', result.value, option);
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
     emit('select', option, result.selected);
   }
 }
 </script>
 
 <template>
-  <view :id="id" :class="rootClass" :style="rootStyle">
+  <view :id="id" :class="rootClass" :style="rootStyle" :aria-disabled="isDisabled">
     <view
       v-for="option in options"
       :key="String(getValue(option))"

--- a/src/uni_modules/lucky-ui/components/lk-slider/lk-slider.vue
+++ b/src/uni_modules/lucky-ui/components/lk-slider/lk-slider.vue
@@ -3,13 +3,13 @@ import {
   ref,
   watch,
   computed,
-  inject,
   getCurrentInstance,
+  onBeforeUnmount,
   onMounted,
   nextTick,
   type StyleValue,
 } from 'vue';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import type { SliderValue } from './slider.props';
 import { sliderProps, sliderEmits } from './slider.props';
 import {
@@ -25,7 +25,6 @@ import {
   resolveSliderThumbStyle,
   resolveSliderTrackStyle,
   resolveSliderUpdate,
-  shouldValidateSliderField,
   type SliderPointerEvent,
 } from './slider.utils';
 
@@ -33,11 +32,28 @@ defineOptions({ name: 'LkSlider' });
 
 const props = defineProps(sliderProps);
 const emit = defineEmits(sliderEmits);
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const currentVal = ref<number[]>([]);
 const dragging = ref(false);
 const draggingIndex = ref(-1);
+let dragInteraction: number | null = null;
+let updateGeneration = 0;
+let activeDragGeneration: number | null = null;
+
+function beginUpdate() {
+  updateGeneration += 1;
+  return updateGeneration;
+}
+
+function ownsUpdate(generation: number) {
+  return generation === updateGeneration;
+}
 
 const instance = getCurrentInstance();
 const trackId = `lk-slider-track-${instance?.uid ?? Math.random().toString(36).slice(2)}`;
@@ -84,7 +100,7 @@ const barStyle = computed(() => {
 const rootClass = computed(() => [
   ...resolveSliderRootClass({
     size: props.size,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     dragging: dragging.value,
     customClass: props.customClass,
   }),
@@ -122,12 +138,22 @@ const blockCustomStyle = computed(() => {
   });
 });
 
-function measureTrack(): Promise<{ left: number; width: number }> {
+function measureTrack(
+  interaction = formField.captureInteraction()
+): Promise<{ left: number; width: number }> {
   return new Promise(resolve => {
+    if (!formField.isInteractionCurrent(interaction)) {
+      resolve(trackRect.value);
+      return;
+    }
     const q = uni.createSelectorQuery();
     if (instance?.proxy) q.in(instance.proxy);
     q.select(`#${trackId}`)
       .boundingClientRect(data => {
+        if (!formField.isInteractionCurrent(interaction)) {
+          resolve(trackRect.value);
+          return;
+        }
         const node = Array.isArray(data) ? data[0] : data;
         trackRect.value = { left: node?.left ?? 0, width: node?.width ?? 0 };
         resolve(trackRect.value);
@@ -151,16 +177,26 @@ function emitValue(): SliderValue {
   });
 }
 
-function commitChange() {
+async function commitChange(
+  interaction: number,
+  ownsCommit: () => boolean = () => true
+): Promise<SliderValue | null> {
+  if (!ownsCommit() || !formField.isInteractionCurrent(interaction)) return null;
   const finalVal = emitValue();
   emit('change', finalVal);
-  if (shouldValidateSliderField({ validateEvent: props.validateEvent, prop: props.prop })) {
-    form?.emitFieldChange(props.prop, finalVal);
-  }
+  if (!(await formField.awaitInteractionCurrent(interaction)) || !ownsCommit()) return null;
+  await formField.emitChange(finalVal, interaction);
+  if (!(await formField.awaitInteractionCurrent(interaction)) || !ownsCommit()) return null;
   return finalVal;
 }
 
-function updateValue(clientX: number, isClick = false): SliderValue | null {
+async function updateValue(
+  clientX: number,
+  isClick: boolean,
+  interaction: number,
+  ownsUpdate: () => boolean = () => true
+): Promise<SliderValue | null> {
+  if (!ownsUpdate() || !formField.isInteractionCurrent(interaction)) return null;
   const result = resolveSliderUpdate({
     clientX,
     rect: trackRect.value,
@@ -181,54 +217,126 @@ function updateValue(clientX: number, isClick = false): SliderValue | null {
   if (result.changed) {
     currentVal.value = result.values;
     emit('update:modelValue', result.emitValue);
+    const interactionCurrent = await formField.awaitInteractionCurrent(interaction);
+    if (!ownsUpdate()) return null;
+    if (!interactionCurrent) {
+      initValue(props.modelValue);
+      return null;
+    }
     emit('input', result.emitValue);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || !ownsUpdate()) return null;
   }
 
   return result.emitValue;
 }
 
 async function onTouchStart(e: Event | SliderPointerEvent) {
-  if (props.disabled) return;
-  await measureTrack();
+  if (isDisabled.value) return;
+  const generation = beginUpdate();
+  activeDragGeneration = generation;
+  const interaction = formField.captureInteraction();
+  await measureTrack(interaction);
+  function ownsDrag() {
+    return activeDragGeneration === generation && ownsUpdate(generation);
+  }
+  if (!ownsDrag() || !formField.isInteractionCurrent(interaction)) return;
+  dragInteraction = interaction;
   dragging.value = true;
   const clientX = getPointX(e);
-  updateValue(clientX, true);
+  if ((await updateValue(clientX, true, interaction, ownsDrag)) === null) return;
+  if (!ownsDrag() || !formField.isInteractionCurrent(interaction)) return;
   emit('dragstart', emitValue(), draggingIndex.value, e);
 }
 
 function onTouchMove(e: Event | SliderPointerEvent) {
-  if (props.disabled || !dragging.value) return;
+  if (isDisabled.value || !dragging.value || dragInteraction === null) return;
   const clientX = getPointX(e);
-  updateValue(clientX);
+  const generation = activeDragGeneration;
+  if (generation === null) return;
+  void updateValue(
+    clientX,
+    false,
+    dragInteraction,
+    () => activeDragGeneration === generation && ownsUpdate(generation)
+  );
 }
 
-function onTouchEnd(e?: Event | SliderPointerEvent) {
-  if (props.disabled || !dragging.value) return;
+async function onTouchEnd(e?: Event | SliderPointerEvent) {
+  if (isDisabled.value || !dragging.value) {
+    if (activeDragGeneration !== null && ownsUpdate(activeDragGeneration)) beginUpdate();
+    activeDragGeneration = null;
+    dragging.value = false;
+    draggingIndex.value = -1;
+    dragInteraction = null;
+    return;
+  }
+  const generation = activeDragGeneration;
+  const interaction = dragInteraction;
   const index = draggingIndex.value;
+  activeDragGeneration = null;
   dragging.value = false;
   draggingIndex.value = -1;
-  const finalVal = commitChange();
+  dragInteraction = null;
+  if (interaction === null || generation === null) return;
+  const commitGeneration = generation;
+  function ownsCommit() {
+    return ownsUpdate(commitGeneration);
+  }
+  const finalVal = await commitChange(interaction, ownsCommit);
+  if (finalVal === null || !ownsCommit() || !formField.isInteractionCurrent(interaction)) return;
   emit('dragend', finalVal, index, e);
+  if (!(await formField.awaitInteractionCurrent(interaction)) || !ownsCommit()) return;
   emit('drag-release', finalVal);
 }
 
 async function onTrackClick(e: Event | SliderPointerEvent) {
-  if (props.disabled || dragging.value) return;
-  if (trackRect.value.width <= 0) await measureTrack();
-  const clientX = getPointX(e);
-  const nextValue = updateValue(clientX, true);
-  if (nextValue !== null) {
-    emit('click', nextValue, e);
-    commitChange();
+  if (isDisabled.value || dragging.value) return;
+  const generation = beginUpdate();
+  activeDragGeneration = null;
+  const interaction = formField.captureInteraction();
+  if (trackRect.value.width <= 0) await measureTrack(interaction);
+  function ownsClick() {
+    return ownsUpdate(generation);
   }
-  draggingIndex.value = -1;
+  if (!ownsClick() || !formField.isInteractionCurrent(interaction)) return;
+  const clientX = getPointX(e);
+  const nextValue = await updateValue(clientX, true, interaction, ownsClick);
+  if (nextValue !== null && ownsClick()) {
+    emit('click', nextValue, e);
+    if (!(await formField.awaitInteractionCurrent(interaction)) || !ownsClick()) return;
+    await commitChange(interaction, ownsClick);
+  }
+  if (ownsClick()) draggingIndex.value = -1;
 }
 
-onMounted(() => nextTick(() => measureTrack()));
+onMounted(() => {
+  const interaction = formField.captureInteraction();
+  void nextTick(() => {
+    if (formField.isInteractionCurrent(interaction)) void measureTrack(interaction);
+  });
+});
+
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    beginUpdate();
+    activeDragGeneration = null;
+    dragging.value = false;
+    draggingIndex.value = -1;
+    dragInteraction = null;
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  beginUpdate();
+  activeDragGeneration = null;
+});
 </script>
 
 <template>
-  <view :id="id" :class="rootClass" :style="rootStyle">
+  <view :id="id" :class="rootClass" :style="rootStyle" :aria-disabled="isDisabled">
     <view
       :id="trackId"
       class="lk-slider__track-container"

--- a/src/uni_modules/lucky-ui/components/lk-stepper/lk-stepper.vue
+++ b/src/uni_modules/lucky-ui/components/lk-stepper/lk-stepper.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, ref, watch, inject } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import type { StepperAction } from './stepper.props';
 import { stepperProps, stepperEmits } from './stepper.props';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import {
   formatStepperValue,
   isStepperMinusDisabled,
@@ -13,16 +13,38 @@ import {
   resolveStepperChange,
   resolveStepperClass,
   resolveStepperStyle,
-  shouldValidateStepperField,
 } from './stepper.utils';
 
 defineOptions({ name: 'LkStepper' });
 
 const props = defineProps(stepperProps);
 const emit = defineEmits(stepperEmits);
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const current = ref(format(props.modelValue));
+let changeGeneration = 0;
+
+function beginChange() {
+  changeGeneration += 1;
+  return changeGeneration;
+}
+
+function isChangeCurrent(generation: number, interaction: number) {
+  return generation === changeGeneration && formField.isInteractionCurrent(interaction);
+}
+
+async function awaitChangeCurrent(generation: number, interaction: number) {
+  return (
+    generation === changeGeneration &&
+    (await formField.awaitInteractionCurrent(interaction)) &&
+    generation === changeGeneration
+  );
+}
 
 function format(value: string | number): string {
   return formatStepperValue({
@@ -35,7 +57,7 @@ function format(value: string | number): string {
 
 const isMinusDisabled = computed(() =>
   isStepperMinusDisabled({
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     current: current.value,
     min: props.min,
   })
@@ -43,7 +65,7 @@ const isMinusDisabled = computed(() =>
 
 const isPlusDisabled = computed(() =>
   isStepperPlusDisabled({
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     current: current.value,
     max: props.max,
   })
@@ -61,16 +83,22 @@ const classes = computed(() =>
   resolveStepperClass({
     customClass: props.customClass,
     size: props.size,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
   })
 );
 
-async function handleChange(type: StepperAction, val?: string) {
+async function handleChange(
+  type: StepperAction,
+  val?: string,
+  interaction = formField.captureInteraction(),
+  generation = beginChange()
+) {
+  if (!isChangeCurrent(generation, interaction)) return;
   const result = resolveStepperChange({
     action: type,
     inputValue: val,
     current: current.value,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     min: props.min,
     max: props.max,
     step: props.step,
@@ -85,68 +113,103 @@ async function handleChange(type: StepperAction, val?: string) {
 
   const clampedVal = result.value;
   emit('before-change', clampedVal, type);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
 
   if (props.beforeChange) {
     try {
       const allow = await props.beforeChange(clampedVal);
+      if (!(await awaitChangeCurrent(generation, interaction))) return;
       if (!allow) {
         current.value = String(props.modelValue);
         emit('change-cancel', clampedVal, type, 'before-change');
         return;
       }
     } catch {
+      if (!(await awaitChangeCurrent(generation, interaction))) return;
       current.value = String(props.modelValue);
       emit('change-cancel', clampedVal, type, 'error');
       return;
     }
   }
 
+  if (!isChangeCurrent(generation, interaction)) return;
+
   current.value = String(clampedVal);
   emit('update:modelValue', clampedVal);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
   emit('change', clampedVal, type);
-  if (type === 'plus') emit('plus', clampedVal);
-  if (type === 'minus') emit('minus', clampedVal);
-  if (shouldValidateStepperField({ validateEvent: props.validateEvent, prop: props.prop })) {
-    form?.emitFieldChange(props.prop, clampedVal);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
+  if (type === 'plus') {
+    emit('plus', clampedVal);
+    if (!(await awaitChangeCurrent(generation, interaction))) return;
   }
+  if (type === 'minus') {
+    emit('minus', clampedVal);
+    if (!(await awaitChangeCurrent(generation, interaction))) return;
+  }
+  await formField.emitChange(clampedVal, interaction);
 }
 
 function onInput(e: Event | { detail?: { value?: string }; target?: { value?: string } }) {
+  if (isDisabled.value || props.disableInput) return;
+  beginChange();
   const value = readStepperInputValue(e);
   current.value = value;
   emit('input', value);
 }
 
-function onBlur(e: unknown) {
-  handleChange(
+async function onBlur(e: unknown) {
+  const interaction = formField.captureInteraction();
+  const generation = beginChange();
+  emit('blur', e);
+  if (!(await awaitChangeCurrent(generation, interaction)) || props.disableInput) return;
+  await handleChange(
     'input',
     normalizeStepperBlurValue({
       current: current.value,
       min: props.min,
       max: props.max,
       integer: props.integer,
-    })
+    }),
+    interaction,
+    generation
   );
-  emit('blur', e);
 }
 
 function onFocus(e: unknown) {
+  if (isDisabled.value || props.disableInput) return;
   emit('focus', e);
 }
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+let touchHandledTimer: ReturnType<typeof setTimeout> | null = null;
 // 移动端 touch 后可能继续触发 click，需屏蔽重复变更。
 let touchHandled = false;
 
 function onTouchStart(type: 'minus' | 'plus') {
+  if (isDisabled.value) return;
+  const interaction = formField.captureInteraction();
+  if (touchHandledTimer) {
+    clearTimeout(touchHandledTimer);
+    touchHandledTimer = null;
+  }
   touchHandled = true;
-  handleChange(type);
+  void handleChange(type, undefined, interaction);
 
-  if (!props.longPress) return;
+  if (!props.longPress || !formField.isInteractionCurrent(interaction)) return;
 
   longPressTimer = setTimeout(() => {
+    if (!formField.isInteractionCurrent(interaction)) {
+      longPressTimer = null;
+      return;
+    }
     longPressTimer = setInterval(() => {
-      handleChange(type);
+      if (!formField.isInteractionCurrent(interaction)) {
+        if (longPressTimer) clearInterval(longPressTimer);
+        longPressTimer = null;
+        return;
+      }
+      void handleChange(type, undefined, interaction);
     }, 200);
   }, 600);
 }
@@ -157,14 +220,40 @@ function onTouchEnd() {
     clearInterval(longPressTimer);
     longPressTimer = null;
   }
-  setTimeout(() => {
+  if (touchHandledTimer) clearTimeout(touchHandledTimer);
+  touchHandledTimer = setTimeout(() => {
     touchHandled = false;
+    touchHandledTimer = null;
   }, 300);
 }
 
-function onClick(type: 'minus' | 'plus') {
-  if (touchHandled) return;
-  handleChange(type);
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    beginChange();
+    current.value = format(props.modelValue);
+    onTouchEnd();
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  beginChange();
+  if (longPressTimer) {
+    clearTimeout(longPressTimer);
+    clearInterval(longPressTimer);
+    longPressTimer = null;
+  }
+  if (touchHandledTimer) {
+    clearTimeout(touchHandledTimer);
+    touchHandledTimer = null;
+  }
+});
+
+async function onClick(type: 'minus' | 'plus') {
+  if (touchHandled || isDisabled.value) return;
+  await handleChange(type);
 }
 
 watch(
@@ -178,7 +267,13 @@ watch(
 </script>
 
 <template>
-  <view :id="id" class="lk-stepper" :class="classes" :style="wrapperStyle">
+  <view
+    :id="id"
+    class="lk-stepper"
+    :class="classes"
+    :style="wrapperStyle"
+    :aria-disabled="isDisabled"
+  >
     <view
       class="lk-stepper__btn lk-stepper__minus"
       :class="{ 'is-disabled': isMinusDisabled }"
@@ -189,11 +284,11 @@ watch(
     />
 
     <input
-      v-model="current"
+      :value="current"
       class="lk-stepper__input"
       :class="{ 'is-disabled': disableInput }"
       :type="integer ? 'number' : 'digit'"
-      :disabled="disabled || disableInput"
+      :disabled="isDisabled || disableInput"
       @input="onInput"
       @blur="onBlur"
       @focus="onFocus"

--- a/src/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue
+++ b/src/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, ref, inject } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import { switchProps, switchEmits } from './switch.props';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import {
   canToggleSwitch,
   isSwitchChecked,
@@ -10,7 +10,6 @@ import {
   resolveSwitchNextValue,
   resolveSwitchPromptText,
   resolveSwitchStyle,
-  shouldValidateSwitchField,
 } from './switch.utils';
 
 defineOptions({ name: 'LkSwitch' });
@@ -18,7 +17,12 @@ defineOptions({ name: 'LkSwitch' });
 const props = defineProps(switchProps);
 const emit = defineEmits(switchEmits);
 
-const form = inject(formContextKey, null);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+});
+const isDisabled = formField.disabled;
 
 const isChecked = computed(() =>
   isSwitchChecked({
@@ -28,6 +32,20 @@ const isChecked = computed(() =>
 );
 
 const changing = ref(false);
+let changeGeneration = 0;
+let changingGeneration: number | null = null;
+
+function isChangeCurrent(generation: number, interaction: number) {
+  return generation === changeGeneration && formField.isInteractionCurrent(interaction);
+}
+
+async function awaitChangeCurrent(generation: number, interaction: number) {
+  return (
+    generation === changeGeneration &&
+    (await formField.awaitInteractionCurrent(interaction)) &&
+    generation === changeGeneration
+  );
+}
 
 const rootStyle = computed(() => {
   return resolveSwitchStyle({
@@ -51,17 +69,18 @@ const classes = computed(() =>
     customClass: props.customClass,
     size: props.size,
     checked: isChecked.value,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     loading: props.loading,
     changing: changing.value,
     inlinePrompt: props.inlinePrompt,
   })
 );
 
-async function toggle() {
+async function toggle(interaction: number, generation: number) {
+  if (!isChangeCurrent(generation, interaction)) return;
   if (
     !canToggleSwitch({
-      disabled: props.disabled,
+      disabled: isDisabled.value,
       loading: props.loading,
       changing: changing.value,
     })
@@ -74,6 +93,7 @@ async function toggle() {
     inactiveValue: props.inactiveValue,
   });
   emit('before-change', nextValue);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
 
   // 轻震动反馈（只在支持的平台上触发）
   if (props.hapticFeedback) {
@@ -86,41 +106,68 @@ async function toggle() {
 
   // beforeChange 拦截
   if (props.beforeChange) {
+    changingGeneration = generation;
     changing.value = true;
     try {
       const allowed = await props.beforeChange(nextValue);
+      if (!(await awaitChangeCurrent(generation, interaction))) return;
       if (!allowed) {
         emit('change-cancel', nextValue, 'before-change');
         return;
       }
     } catch {
+      if (!(await awaitChangeCurrent(generation, interaction))) return;
       emit('change-cancel', nextValue, 'error');
       return;
     } finally {
-      changing.value = false;
+      if (changingGeneration === generation) {
+        changingGeneration = null;
+        changing.value = false;
+      }
     }
   }
 
-  emit('update:modelValue', nextValue);
-  emit('change', nextValue);
+  if (!isChangeCurrent(generation, interaction)) return;
 
-  if (shouldValidateSwitchField({ validateEvent: props.validateEvent, prop: props.prop })) {
-    form?.emitFieldChange(props.prop, nextValue);
-  }
+  emit('update:modelValue', nextValue);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
+  emit('change', nextValue);
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
+
+  await formField.emitChange(nextValue, interaction);
 }
 
-function onClick(e: unknown) {
+async function onClick(e: unknown) {
   if (
     !canToggleSwitch({
-      disabled: props.disabled,
+      disabled: isDisabled.value,
       loading: props.loading,
       changing: changing.value,
     })
   )
     return;
+  const generation = ++changeGeneration;
+  const interaction = formField.captureInteraction();
   emit('click', e, isChecked.value);
-  toggle();
+  if (!(await awaitChangeCurrent(generation, interaction))) return;
+  await toggle(interaction, generation);
 }
+
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    changeGeneration += 1;
+    changingGeneration = null;
+    changing.value = false;
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  changeGeneration += 1;
+  changingGeneration = null;
+});
 </script>
 
 <template>
@@ -130,6 +177,7 @@ function onClick(e: unknown) {
     :class="classes"
     :style="rootStyle"
     :aria-checked="isChecked"
+    :aria-disabled="isDisabled"
     role="switch"
     @tap="onClick"
   >

--- a/src/uni_modules/lucky-ui/components/lk-textarea/lk-textarea.vue
+++ b/src/uni_modules/lucky-ui/components/lk-textarea/lk-textarea.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import type { StyleValue } from 'vue';
-import { computed, ref, inject } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import type { TextareaEventPayload } from './textarea.props';
 import { textareaProps, textareaEmits } from './textarea.props';
-import { formContextKey } from '../lk-form/context';
+import { useFormField } from '../lk-form/useFormField';
 import { useLocale } from '../../composables/useLocale';
 import {
   applyTextareaMaxlength,
+  createTextareaBlurController,
   isTextareaNativeFocused,
   readTextareaValue,
   resolveTextareaClass,
   resolveTextareaCount,
   resolveTextareaPlaceholder,
+  shouldCommitTextareaBlur,
   shouldShowTextareaClear,
   shouldShowTextareaFooter,
 } from './textarea.utils';
@@ -22,13 +24,33 @@ const props = defineProps(textareaProps);
 const emit = defineEmits(textareaEmits);
 const { t } = useLocale('textarea');
 
-const form = inject(formContextKey, null);
 const isFocused = ref(false);
+let compositionInteraction: number | null = null;
+let compositionInputValue: string | null = null;
+const composing = ref(false);
+const formField = useFormField({
+  prop: () => props.prop,
+  disabled: () => props.disabled,
+  validateEvent: () => props.validateEvent,
+  inheritFormItemProp: true,
+  interactionLocked: () => props.readonly,
+});
+const isDisabled = formField.disabled;
+const resolvedFormProp = formField.prop;
+const blurController = createTextareaBlurController();
+const isNativeDisabled = computed(() => {
+  // H5 keeps readonly text focusable/selectable; mini-programs retain the native disabled fallback.
+  let disabled = isDisabled.value || props.readonly;
+  // #ifdef H5
+  disabled = isDisabled.value;
+  // #endif
+  return disabled;
+});
 
 const cls = computed(() => [
   ...resolveTextareaClass({
     variant: props.variant,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     focused: isFocused.value,
     autoHeight: props.autoHeight,
     label: props.label,
@@ -51,73 +73,174 @@ const showClear = computed(() =>
   shouldShowTextareaClear({
     clearable: props.clearable,
     value: props.modelValue,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     readonly: props.readonly,
   })
 );
 
-function onInput(e: TextareaEventPayload) {
+async function onInput(e: TextareaEventPayload, interaction = formField.captureInteraction()) {
+  if (isDisabled.value || props.readonly) return;
+  if (!formField.isInteractionCurrent(interaction)) return;
   const val = applyTextareaMaxlength(readTextareaValue(e), props.maxlength);
+  if (composing.value) {
+    if (interaction === compositionInteraction) compositionInputValue = val;
+    return;
+  }
   emit('update:modelValue', val);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('input', val);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitChange(val, interaction);
 }
 
 function onFocus(e: TextareaEventPayload) {
-  if (props.disabled) return;
+  blurController.cancel();
+  if (isDisabled.value) return;
   isFocused.value = true;
   emit('focus', e);
 }
 
 function onBlur(e: TextareaEventPayload) {
-  setTimeout(() => {
+  const interaction = formField.captureInteraction();
+  const canCommitAtSchedule = shouldCommitTextareaBlur({
+    disabled: isDisabled.value,
+    readonly: props.readonly,
+  });
+  blurController.schedule(async () => {
+    if (!formField.isInteractionCurrent(interaction)) return;
     isFocused.value = false;
     emit('blur', e);
-    emit('change', props.modelValue);
-    if (props.validateEvent && props.prop) {
-      form?.emitFieldBlur(props.prop);
+    if (!(await formField.awaitInteractionCurrent(interaction))) return;
+    if (
+      !canCommitAtSchedule ||
+      !shouldCommitTextareaBlur({ disabled: isDisabled.value, readonly: props.readonly })
+    ) {
+      return;
     }
-  }, 100);
+    emit('change', props.modelValue);
+    if (!(await formField.awaitInteractionCurrent(interaction))) return;
+    await formField.emitBlur(interaction);
+  });
 }
 
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    blurController.cancel();
+    isFocused.value = false;
+    compositionInteraction = null;
+    compositionInputValue = null;
+    composing.value = false;
+  },
+  { flush: 'sync' }
+);
+watch(
+  () => props.readonly,
+  readonly => {
+    if (readonly) {
+      blurController.cancel();
+      compositionInteraction = null;
+      compositionInputValue = null;
+      composing.value = false;
+    }
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  compositionInteraction = null;
+  compositionInputValue = null;
+  composing.value = false;
+  blurController.dispose();
+});
+
 function onConfirm(e: TextareaEventPayload) {
+  if (isDisabled.value) return;
   emit('confirm', e);
 }
 
 function onLineChange(e: TextareaEventPayload) {
+  if (isDisabled.value) return;
   emit('linechange', e);
 }
 
 function onKeyboardHeightChange(e: TextareaEventPayload) {
+  if (isDisabled.value) return;
   emit('keyboardheightchange', e);
 }
 
-function onCompositionStart(e: TextareaEventPayload) {
+async function onCompositionStart(e: TextareaEventPayload) {
+  if (isDisabled.value || props.readonly) return;
+  const interaction = formField.captureInteraction();
+  compositionInteraction = interaction;
+  compositionInputValue = null;
+  composing.value = true;
   emit('compositionstart', e);
+  if (!(await formField.awaitInteractionCurrent(interaction))) {
+    if (compositionInteraction === interaction) compositionInteraction = null;
+    compositionInputValue = null;
+    composing.value = false;
+  }
 }
 
 function onCompositionUpdate(e: TextareaEventPayload) {
+  if (
+    compositionInteraction === null ||
+    !formField.isInteractionCurrent(compositionInteraction) ||
+    !composing.value
+  )
+    return;
   emit('compositionupdate', e);
 }
 
-function onCompositionEnd(e: TextareaEventPayload) {
+async function onCompositionEnd(e: TextareaEventPayload) {
+  const interaction = compositionInteraction;
+  if (
+    interaction === null ||
+    !composing.value ||
+    props.readonly ||
+    !formField.isInteractionCurrent(interaction)
+  )
+    return;
+  const value =
+    compositionInputValue ?? applyTextareaMaxlength(readTextareaValue(e), props.maxlength);
+  compositionInteraction = null;
+  compositionInputValue = null;
+  composing.value = false;
   emit('compositionend', e);
-  onInput(e);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  emit('update:modelValue', value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  emit('input', value);
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitChange(value, interaction);
 }
 
-function onClear() {
-  if (props.disabled || props.readonly) return;
+async function onClear() {
+  if (isDisabled.value || props.readonly) return;
+  const interaction = formField.captureInteraction();
+  blurController.cancel();
   emit('update:modelValue', '');
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('input', '');
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('change', '');
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
   emit('clear');
-  if (props.validateEvent && props.prop) {
-    form?.emitFieldChange(props.prop, '');
-  }
+  if (!(await formField.awaitInteractionCurrent(interaction))) return;
+  await formField.emitChange('', interaction);
 }
 </script>
 
 <template>
-  <view :id="id" :class="cls" :style="style">
+  <view
+    :id="id"
+    :class="cls"
+    :style="style"
+    :data-form-prop="resolvedFormProp || ''"
+    :data-disabled="isDisabled ? 'true' : 'false'"
+  >
     <!-- Label -->
     <view v-if="label" class="lk-textarea__label">{{ label }}</view>
 
@@ -129,7 +252,8 @@ function onClear() {
         :placeholder="resolvedPlaceholder"
         :placeholder-style="placeholderStyle"
         :placeholder-class="placeholderClass"
-        :disabled="disabled || readonly"
+        :disabled="isNativeDisabled"
+        :readonly="readonly"
         :maxlength="maxlength"
         :auto-height="autoHeight"
         :focus="isTextareaFocused"
@@ -147,6 +271,8 @@ function onClear() {
         :auto-blur="autoBlur"
         :inputmode="inputmode"
         :ignore-composition-event="ignoreCompositionEvent"
+        :aria-disabled="isDisabled"
+        :aria-readonly="readonly"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"

--- a/src/uni_modules/lucky-ui/components/lk-textarea/textarea.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-textarea/textarea.utils.ts
@@ -31,6 +31,51 @@ export function isTextareaNativeFocused(options: { focus: boolean; autofocus: bo
   return options.focus || options.autofocus;
 }
 
+export function shouldCommitTextareaBlur(options: {
+  disabled: boolean;
+  readonly: boolean;
+}): boolean {
+  return !options.disabled && !options.readonly;
+}
+
+export interface TextareaBlurController {
+  schedule: (callback: () => void) => void;
+  cancel: () => void;
+  dispose: () => void;
+}
+
+export function createTextareaBlurController(delay = 100): TextareaBlurController {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let generation = 0;
+  let disposed = false;
+
+  function cancel() {
+    generation += 1;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  function schedule(callback: () => void) {
+    cancel();
+    if (disposed) return;
+    const currentGeneration = generation;
+    timer = setTimeout(() => {
+      timer = undefined;
+      if (disposed || currentGeneration !== generation) return;
+      callback();
+    }, delay);
+  }
+
+  function dispose() {
+    disposed = true;
+    cancel();
+  }
+
+  return { schedule, cancel, dispose };
+}
+
 export function shouldShowTextareaClear(options: {
   clearable: boolean;
   value: string;

--- a/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.scss
+++ b/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.scss
@@ -28,7 +28,6 @@
 
   @include when(disabled) {
     opacity: 0.55;
-    pointer-events: none;
   }
 
   @include e(item) {

--- a/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue
+++ b/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, watch, type StyleValue } from 'vue';
+import { computed, onBeforeUnmount, ref, watch, type StyleValue } from 'vue';
 import { addUnit } from '@/uni_modules/lucky-ui/core/src/utils/unit';
 import { useLocale } from '../../composables/useLocale';
+import { useFormDisabled } from '../lk-form/useFormField';
 import { uploadProps, uploadEmits, UploadStatus, type UploadFile } from './upload.props';
 import {
   createH5UploadFiles,
@@ -15,18 +16,52 @@ defineOptions({ name: 'LkUpload' });
 const props = defineProps(uploadProps);
 const emit = defineEmits(uploadEmits);
 const { t } = useLocale('upload');
+const formDisabled = useFormDisabled(() => props.disabled);
+const isDisabled = formDisabled.disabled;
 
-const fileList = ref<UploadFile[]>([...props.modelValue]);
+function cloneUploadFiles(files: readonly UploadFile[]): UploadFile[] {
+  return files.map(file => ({ ...file }));
+}
+
+const fileList = ref<UploadFile[]>(cloneUploadFiles(props.modelValue));
 
 watch(
   () => props.modelValue,
   v => {
-    fileList.value = [...v];
+    fileList.value = cloneUploadFiles(v);
+    activeUploads.forEach((record, uid) => {
+      if (v.some(file => file.uid === uid)) return;
+      record.cancelled = true;
+      record.abort?.();
+      activeUploads.delete(uid);
+    });
+    failedAttemptTokens.forEach((_token, uid) => {
+      const file = v.find(item => item.uid === uid);
+      if (!file || file.status !== UploadStatus.Fail) failedAttemptTokens.delete(uid);
+    });
   }
 );
 
 const deleteConfirmVisible = ref(false);
-const pendingDeleteIndex = ref(-1);
+const pendingDeleteUid = ref<string | null>(null);
+let pendingDeleteInteraction: number | null | undefined = null;
+
+type ActiveUpload = {
+  interaction?: number;
+  file: UploadFile;
+  status: UploadFile['status'];
+  progress: UploadFile['progress'];
+  message: UploadFile['message'];
+  response: UploadFile['response'];
+  cancelled: boolean;
+  stageGeneration: number;
+  terminalClaimed: boolean;
+  abort?: () => void;
+};
+
+const activeUploads = new Map<string, ActiveUpload>();
+const autoRemoveTimers = new Set<ReturnType<typeof setTimeout>>();
+const failedAttemptTokens = new Map<string, symbol>();
 
 let _uid = 0;
 function genUid(): string {
@@ -38,7 +73,7 @@ const remainCount = computed(() => Math.max(0, props.maxCount - fileList.value.l
 
 /** 是否显示上传按钮 */
 const showAddBtn = computed(
-  () => props.showUpload && fileList.value.length < props.maxCount && !props.disabled
+  () => props.showUpload && fileList.value.length < props.maxCount && !isDisabled.value
 );
 const resolvedUploadText = computed(() => props.uploadText || t('upload'));
 const uploadFailedText = computed(() => t('failed'));
@@ -47,7 +82,7 @@ const rootClass = computed(() => [
   'lk-upload',
   props.customClass,
   {
-    'is-disabled': props.disabled,
+    'is-disabled': isDisabled.value,
   },
 ]);
 
@@ -70,29 +105,186 @@ function getItemClass(file: UploadFile) {
   ];
 }
 
-function syncModel(list: UploadFile[]) {
-  fileList.value = list;
-  emit('update:modelValue', [...list]);
-  emit('change', [...list]);
+function isInteractionCurrent(interaction?: number): boolean {
+  return interaction === undefined || formDisabled.isInteractionCurrent(interaction);
+}
+
+function syncModelUpdateOnly(list: UploadFile[]) {
+  fileList.value = cloneUploadFiles(list);
+  emit('update:modelValue', cloneUploadFiles(fileList.value));
+}
+
+function resolveOwnedFiles(uids: readonly string[]): UploadFile[] {
+  const byUid = new Map(fileList.value.map(file => [file.uid, file]));
+  return uids.map(uid => byUid.get(uid)).filter((file): file is UploadFile => !!file);
+}
+
+function restoreOwnedSnapshots(entries: ReadonlyArray<{ uid: string; file: UploadFile }>) {
+  entries.forEach(({ uid, file }) => {
+    const current = fileList.value.find(item => item.uid === uid);
+    if (current) Object.assign(current, file, { uid });
+  });
+}
+
+function snapshotOwnedFiles(files: readonly UploadFile[]) {
+  return files.map(file => ({ uid: file.uid, file: { ...file } }));
+}
+
+function uploadFileChanged(before: UploadFile, after: UploadFile) {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)] as Array<keyof UploadFile>);
+  return [...keys].some(key => !Object.is(before[key], after[key]));
+}
+
+async function publishHookChanges(
+  uids: readonly string[],
+  interaction: number
+): Promise<UploadFile[]> {
+  const owned = resolveOwnedFiles(uids);
+  if (!owned.length || !formDisabled.isInteractionCurrent(interaction)) return [];
+  emit('update:modelValue', cloneUploadFiles(fileList.value));
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return [];
+  return resolveOwnedFiles(uids);
+}
+
+async function syncModel(
+  list: UploadFile[],
+  interaction?: number,
+  ownsRun: () => boolean = () => true
+): Promise<boolean> {
+  if (!isInteractionCurrent(interaction) || !ownsRun()) return false;
+  fileList.value = cloneUploadFiles(list);
+  if (!isInteractionCurrent(interaction) || !ownsRun()) {
+    fileList.value = cloneUploadFiles(props.modelValue);
+    return false;
+  }
+  emit('update:modelValue', cloneUploadFiles(fileList.value));
+  const canContinue =
+    interaction === undefined
+      ? await formDisabled.awaitActive()
+      : await formDisabled.awaitInteractionCurrent(interaction);
+  if (!canContinue || !ownsRun()) {
+    if (canContinue) return false;
+    fileList.value = cloneUploadFiles(props.modelValue);
+    return false;
+  }
+  emit('change', cloneUploadFiles(fileList.value));
+  const stillActive =
+    interaction === undefined
+      ? await formDisabled.awaitActive()
+      : await formDisabled.awaitInteractionCurrent(interaction);
+  return stillActive && ownsRun();
+}
+
+function awaitRunCurrent(interaction?: number) {
+  return interaction === undefined
+    ? formDisabled.awaitActive()
+    : formDisabled.awaitInteractionCurrent(interaction);
+}
+
+function isUploadCurrent(record: ActiveUpload): boolean {
+  return (
+    activeUploads.get(record.file.uid) === record &&
+    !record.cancelled &&
+    isInteractionCurrent(record.interaction)
+  );
+}
+
+function claimUploadStage(record: ActiveUpload, terminal = false): number | undefined {
+  if (!isUploadCurrent(record) || record.terminalClaimed) return undefined;
+  if (terminal) record.terminalClaimed = true;
+  record.stageGeneration += 1;
+  return record.stageGeneration;
+}
+
+function ownsUploadStage(record: ActiveUpload, stage: number): boolean {
+  return isUploadCurrent(record) && record.stageGeneration === stage;
+}
+
+function completeUpload(record: ActiveUpload) {
+  if (activeUploads.get(record.file.uid) === record) {
+    activeUploads.delete(record.file.uid);
+  }
+}
+
+function cancelActiveUpload(uid: string) {
+  const record = activeUploads.get(uid);
+  if (!record) return;
+  record.cancelled = true;
+  record.abort?.();
+  activeUploads.delete(uid);
+}
+
+function findActiveFile(record: ActiveUpload): UploadFile | undefined {
+  return fileList.value.find(file => file.uid === record.file.uid);
+}
+
+function cancelActiveUploads() {
+  let restored = false;
+  activeUploads.forEach(record => {
+    record.cancelled = true;
+    record.abort?.();
+    const currentFile = findActiveFile(record);
+    if (currentFile) {
+      currentFile.status = record.status;
+      currentFile.progress = record.progress;
+      currentFile.message = record.message;
+      currentFile.response = record.response;
+      restored = true;
+    }
+  });
+  activeUploads.clear();
+  // Disabled cleanup is a controlled-state repair, not a new user change.
+  if (restored) syncModelUpdateOnly([...fileList.value]);
+}
+
+function clearAutoRemoveTimers() {
+  autoRemoveTimers.forEach(timer => clearTimeout(timer));
+  autoRemoveTimers.clear();
+  failedAttemptTokens.clear();
+}
+
+function scheduleAutoRemove(file: UploadFile, token: symbol, interaction?: number) {
+  const uid = file.uid;
+  if (
+    failedAttemptTokens.get(uid) !== token ||
+    activeUploads.has(uid) ||
+    fileList.value.find(item => item.uid === uid)?.status !== UploadStatus.Fail
+  )
+    return;
+  const timer = setTimeout(() => {
+    autoRemoveTimers.delete(timer);
+    if (!isInteractionCurrent(interaction)) return;
+    if (failedAttemptTokens.get(uid) !== token || activeUploads.has(uid)) return;
+    const currentIndex = fileList.value.findIndex(
+      item => item.uid === uid && item.status === UploadStatus.Fail
+    );
+    if (currentIndex < 0) return;
+    failedAttemptTokens.delete(uid);
+    void removeFileWithRun(currentIndex, interaction);
+  }, 1500);
+  autoRemoveTimers.add(timer);
 }
 
 async function onSelect(e?: Event) {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
   if (remainCount.value <= 0) {
     emit('overcount', { maxCount: props.maxCount, currentCount: fileList.value.length });
     return;
   }
   emit('clickUpload', e);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  if (remainCount.value <= 0) return;
 
   // #ifdef MP || APP-PLUS
-  chooseFileMp();
+  chooseFileMp(interaction);
   // #endif
   // #ifdef H5
-  chooseFileH5();
+  chooseFileH5(interaction);
   // #endif
 }
 
-function chooseFileMp() {
+function chooseFileMp(interaction: number) {
   const count = props.multiple ? remainCount.value : 1;
 
   if (props.accept === 'video') {
@@ -100,7 +292,8 @@ function chooseFileMp() {
       sourceType: props.sourceType as string[],
       compressed: props.sizeType.includes('compressed'),
       success(res: { tempFilePath: string; size: number; name?: string; type?: string }) {
-        handleAfterChoose([createMpVideoUploadFile(res, genUid)]);
+        if (!formDisabled.isInteractionCurrent(interaction)) return;
+        handleAfterChoose([createMpVideoUploadFile(res, genUid)], interaction);
       },
     });
     return;
@@ -111,30 +304,32 @@ function chooseFileMp() {
     sizeType: props.sizeType as UniApp.ChooseImageOptions['sizeType'],
     sourceType: props.sourceType as string[],
     success(res: UniApp.ChooseImageSuccessCallbackResult) {
+      if (!formDisabled.isInteractionCurrent(interaction)) return;
       const paths = Array.isArray(res.tempFilePaths) ? res.tempFilePaths : [];
       const infos = (res.tempFiles as Array<{ size?: number; name?: string; type?: string }>) || [];
-      handleAfterChoose(createMpImageUploadFiles(paths, infos, genUid));
+      handleAfterChoose(createMpImageUploadFiles(paths, infos, genUid), interaction);
     },
   });
 }
 
 // #ifdef H5
-function chooseFileH5() {
+function chooseFileH5(interaction: number) {
   const input = document.createElement('input');
   input.type = 'file';
   if (props.inputAccept) input.accept = props.inputAccept;
   if (props.multiple && remainCount.value > 1) input.multiple = true;
 
   input.onchange = () => {
+    if (!formDisabled.isInteractionCurrent(interaction)) return;
     const rawFiles = Array.from(input.files || []);
-    handleAfterChoose(createH5UploadFiles(rawFiles, remainCount.value, genUid));
+    handleAfterChoose(createH5UploadFiles(rawFiles, remainCount.value, genUid), interaction);
   };
   input.click();
 }
 // #endif
 
-async function handleAfterChoose(items: UploadFile[]) {
-  if (!items.length) return;
+async function handleAfterChoose(items: UploadFile[], interaction: number) {
+  if (!items.length || !formDisabled.isInteractionCurrent(interaction)) return;
 
   const oversized: UploadFile[] = [];
   const valid: UploadFile[] = [];
@@ -147,6 +342,7 @@ async function handleAfterChoose(items: UploadFile[]) {
   }
   if (oversized.length) {
     emit('oversize', oversized.length === 1 ? oversized[0] : oversized);
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
   }
   if (!valid.length) return;
 
@@ -154,6 +350,7 @@ async function handleAfterChoose(items: UploadFile[]) {
     const target = valid.length === 1 ? valid[0] : valid;
     try {
       const pass = await props.beforeRead(target, { index: fileList.value.length });
+      if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
       if (pass === false) return;
     } catch {
       return;
@@ -161,56 +358,141 @@ async function handleAfterChoose(items: UploadFile[]) {
   }
 
   const merged = fileList.value.concat(valid).slice(0, props.maxCount);
-  syncModel(merged);
+  const acceptedUids = valid
+    .map(file => file.uid)
+    .filter(uid => merged.some(file => file.uid === uid));
+  if (!(await syncModel(merged, interaction))) return;
+  let owned = resolveOwnedFiles(acceptedUids);
+  if (!owned.length) return;
 
-  const readTarget = valid.length === 1 ? valid[0] : valid;
+  const beforeEvent = cloneUploadFiles(owned);
+  const readTarget = owned.length === 1 ? owned[0] : owned;
   emit('afterRead', readTarget, { index: fileList.value.length - valid.length });
+  const eventSnapshots = snapshotOwnedFiles(owned);
+  let hookChanged = owned.some((file, index) => uploadFileChanged(beforeEvent[index], file));
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+  restoreOwnedSnapshots(eventSnapshots);
+  owned = resolveOwnedFiles(acceptedUids);
+  if (!owned.length) return;
 
   if (props.afterRead) {
-    props.afterRead(readTarget, { index: fileList.value.length - valid.length });
+    const beforeProp = cloneUploadFiles(owned);
+    const propTarget = owned.length === 1 ? owned[0] : owned;
+    await props.afterRead(propTarget, { index: fileList.value.length - owned.length });
+    const propSnapshots = snapshotOwnedFiles(owned);
+    hookChanged ||= owned.some((file, index) => uploadFileChanged(beforeProp[index], file));
+    if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
+    restoreOwnedSnapshots(propSnapshots);
+    owned = resolveOwnedFiles(acceptedUids);
+    if (!owned.length) return;
   }
 
+  if (hookChanged) owned = await publishHookChanges(acceptedUids, interaction);
+  if (!owned.length) return;
+
   if (props.action) {
-    valid.forEach(f => doUpload(f));
+    for (const file of owned) {
+      if (!formDisabled.isInteractionCurrent(interaction)) return;
+      await doUpload(file, interaction);
+    }
   }
 }
 
-function doUpload(file: UploadFile) {
+async function doUpload(sourceFile: UploadFile, interaction?: number) {
+  if (!isInteractionCurrent(interaction)) return;
+  const fileIndex = fileList.value.findIndex(file => file.uid === sourceFile.uid);
+  if (fileIndex < 0) return;
+  // Public callbacks and controlled props may retain every previously observed object.
+  // Start each upload generation from a fresh component-owned list before mutating status.
+  fileList.value = cloneUploadFiles(fileList.value);
+  const file = fileList.value[fileIndex];
+  failedAttemptTokens.delete(file.uid);
+  const record: ActiveUpload = {
+    interaction,
+    file,
+    status: file.status,
+    progress: file.progress,
+    message: file.message,
+    response: file.response,
+    cancelled: false,
+    stageGeneration: 0,
+    terminalClaimed: false,
+  };
+  activeUploads.set(file.uid, record);
   file.status = UploadStatus.Uploading;
   file.progress = 0;
   file.message = t('uploading');
-  syncModel([...fileList.value]);
+  if (
+    !(await syncModel([...fileList.value], interaction, () => isUploadCurrent(record))) ||
+    !isUploadCurrent(record)
+  )
+    return;
 
   if (props.customRequest) {
-    props.customRequest({
+    const customTask = props.customRequest({
       file,
       action: props.action,
       name: props.name,
       headers: props.headers,
       data: props.data,
-      onProgress(progress: number) {
-        file.progress = progress;
-        emit('progress', file, { progress });
-        syncModel([...fileList.value]);
+      async onProgress(progress: number) {
+        const stage = claimUploadStage(record);
+        if (stage === undefined) return;
+        const currentFile = findActiveFile(record);
+        if (!currentFile) return;
+        currentFile.progress = progress;
+        emit('progress', currentFile, { progress });
+        if (!(await awaitRunCurrent(interaction)) || !ownsUploadStage(record, stage)) return;
+        await syncModel([...fileList.value], interaction, () => ownsUploadStage(record, stage));
       },
-      onSuccess(response: unknown) {
-        file.status = UploadStatus.Success;
-        file.progress = 100;
-        file.message = '';
-        file.response = response;
-        syncModel([...fileList.value]);
-        emit('success', file, { response });
+      async onSuccess(response: unknown) {
+        const stage = claimUploadStage(record, true);
+        if (stage === undefined) return;
+        const currentFile = findActiveFile(record);
+        if (!currentFile) return;
+        currentFile.status = UploadStatus.Success;
+        currentFile.progress = 100;
+        currentFile.message = '';
+        currentFile.response = response;
+        if (
+          !(await syncModel([...fileList.value], interaction, () =>
+            ownsUploadStage(record, stage)
+          )) ||
+          !ownsUploadStage(record, stage)
+        )
+          return;
+        completeUpload(record);
+        emit('success', currentFile, { response });
       },
-      onFail(error: unknown) {
-        file.status = UploadStatus.Fail;
-        file.message = t('failed');
-        syncModel([...fileList.value]);
-        emit('fail', file, { error });
+      async onFail(error: unknown) {
+        const stage = claimUploadStage(record, true);
+        if (stage === undefined) return;
+        const currentFile = findActiveFile(record);
+        if (!currentFile) return;
+        currentFile.status = UploadStatus.Fail;
+        currentFile.message = t('failed');
+        if (
+          !(await syncModel([...fileList.value], interaction, () =>
+            ownsUploadStage(record, stage)
+          )) ||
+          !ownsUploadStage(record, stage)
+        )
+          return;
+        const failToken = Symbol(file.uid);
+        if (props.autoRemoveFail) failedAttemptTokens.set(file.uid, failToken);
+        completeUpload(record);
+        emit('fail', currentFile, { error });
+        if (!(await awaitRunCurrent(interaction))) return;
+        if (isDisabled.value) return;
         if (props.autoRemoveFail) {
-          setTimeout(() => removeFile(fileList.value.indexOf(file)), 1500);
+          scheduleAutoRemove(currentFile, failToken, interaction);
         }
       },
     });
+    if (customTask && typeof customTask.abort === 'function') {
+      if (isUploadCurrent(record)) record.abort = () => customTask.abort?.();
+      else customTask.abort();
+    }
     return;
   }
 
@@ -220,87 +502,160 @@ function doUpload(file: UploadFile) {
     name: props.name,
     header: props.headers,
     formData: props.data,
-    success(res) {
-      file.status = UploadStatus.Success;
-      file.progress = 100;
-      file.message = '';
-      file.response = res.data;
-      syncModel([...fileList.value]);
-      emit('success', file, { response: res.data });
+    async success(res) {
+      const stage = claimUploadStage(record, true);
+      if (stage === undefined) return;
+      const currentFile = findActiveFile(record);
+      if (!currentFile) return;
+      currentFile.status = UploadStatus.Success;
+      currentFile.progress = 100;
+      currentFile.message = '';
+      currentFile.response = res.data;
+      if (
+        !(await syncModel([...fileList.value], interaction, () =>
+          ownsUploadStage(record, stage)
+        )) ||
+        !ownsUploadStage(record, stage)
+      )
+        return;
+      completeUpload(record);
+      emit('success', currentFile, { response: res.data });
     },
-    fail(err) {
-      file.status = UploadStatus.Fail;
-      file.message = t('failed');
-      syncModel([...fileList.value]);
-      emit('fail', file, { error: err });
+    async fail(err) {
+      const stage = claimUploadStage(record, true);
+      if (stage === undefined) return;
+      const currentFile = findActiveFile(record);
+      if (!currentFile) return;
+      currentFile.status = UploadStatus.Fail;
+      currentFile.message = t('failed');
+      if (
+        !(await syncModel([...fileList.value], interaction, () =>
+          ownsUploadStage(record, stage)
+        )) ||
+        !ownsUploadStage(record, stage)
+      )
+        return;
+      const failToken = Symbol(file.uid);
+      if (props.autoRemoveFail) failedAttemptTokens.set(file.uid, failToken);
+      completeUpload(record);
+      emit('fail', currentFile, { error: err });
+      if (!(await awaitRunCurrent(interaction))) return;
+      if (isDisabled.value) return;
 
       if (props.autoRemoveFail) {
-        setTimeout(() => removeFile(fileList.value.indexOf(file)), 1500);
+        scheduleAutoRemove(currentFile, failToken, interaction);
       }
     },
   });
 
   if (uploadTask && typeof uploadTask.onProgressUpdate === 'function') {
-    uploadTask.onProgressUpdate(res => {
-      file.progress = res.progress;
-      emit('progress', file, { progress: res.progress });
-      syncModel([...fileList.value]);
+    uploadTask.onProgressUpdate(async res => {
+      const stage = claimUploadStage(record);
+      if (stage === undefined) return;
+      const currentFile = findActiveFile(record);
+      if (!currentFile) return;
+      currentFile.progress = res.progress;
+      emit('progress', currentFile, { progress: res.progress });
+      if (!(await awaitRunCurrent(interaction)) || !ownsUploadStage(record, stage)) return;
+      await syncModel([...fileList.value], interaction, () => ownsUploadStage(record, stage));
     });
+  }
+  if (uploadTask && typeof uploadTask.abort === 'function') {
+    if (isUploadCurrent(record)) record.abort = () => uploadTask.abort();
+    else uploadTask.abort();
   }
 }
 
-async function removeFile(index: number) {
+async function removeFileWithRun(index: number, interaction?: number) {
+  if (!isInteractionCurrent(interaction)) return;
   if (index < 0 || index >= fileList.value.length) return;
   const file = fileList.value[index];
+  const uid = file.uid;
 
   if (props.beforeDelete) {
     try {
       const pass = await props.beforeDelete(file, { index });
+      if (!(await awaitRunCurrent(interaction))) return;
       if (pass === false) return;
     } catch {
       return;
     }
   }
 
-  doRemove(index);
+  await doRemove(uid, interaction);
 }
 
-function doRemove(index: number) {
+async function removeFile(index: number) {
+  await removeFileWithRun(index);
+}
+
+async function doRemove(uid: string, interaction?: number) {
+  if (!isInteractionCurrent(interaction)) return;
+  const index = fileList.value.findIndex(file => file.uid === uid);
+  if (index < 0) return;
   const file = fileList.value[index];
   if (!file) return;
   const next = [...fileList.value];
   next.splice(index, 1);
-  syncModel(next);
+  // Claim cancellation before the first public removal update. An abort implementation may
+  // synchronously call fail, and an update/change listener may reenter a pending progress chain.
+  cancelActiveUpload(uid);
+  failedAttemptTokens.delete(uid);
+  if (!(await syncModel(next, interaction))) return;
   emit('delete', file, { index });
+}
+
+function onRemove(index: number) {
+  if (isDisabled.value) return;
+  void removeFileWithRun(index, formDisabled.captureInteraction());
 }
 
 /** 内置确认删除（通过 lk-modal） */
 function confirmRemove(index: number) {
-  pendingDeleteIndex.value = index;
+  const file = fileList.value[index];
+  if (!file) return;
+  pendingDeleteInteraction = undefined;
+  pendingDeleteUid.value = file.uid;
   deleteConfirmVisible.value = true;
 }
 
-function onDeleteConfirm() {
-  const idx = pendingDeleteIndex.value;
+async function onDeleteConfirm() {
+  const uid = pendingDeleteUid.value;
   deleteConfirmVisible.value = false;
-  pendingDeleteIndex.value = -1;
-  if (idx >= 0) doRemove(idx);
+  pendingDeleteUid.value = null;
+  const interaction = pendingDeleteInteraction;
+  pendingDeleteInteraction = null;
+  if (uid && interaction !== null) await doRemove(uid, interaction);
 }
 
 function onDeleteCancel() {
   deleteConfirmVisible.value = false;
-  pendingDeleteIndex.value = -1;
+  pendingDeleteUid.value = null;
+  pendingDeleteInteraction = null;
 }
 
-function onPreview(index: number) {
+function cancelPendingDelete() {
+  if (!deleteConfirmVisible.value && pendingDeleteUid.value === null) return;
+  deleteConfirmVisible.value = false;
+  pendingDeleteUid.value = null;
+  pendingDeleteInteraction = null;
+}
+
+async function onPreview(index: number) {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
   const file = fileList.value[index];
+  if (!file) return;
+  const uid = file.uid;
   emit('clickPreview', file, { index });
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
 
   if (!props.previewImage) return;
-  if (!isImageUrl(file.url)) return;
+  const currentFile = fileList.value.find(item => item.uid === uid);
+  if (!currentFile || !isImageUrl(currentFile.url)) return;
 
   const urls = fileList.value.filter(f => isImageUrl(f.url)).map(f => f.url);
-  const current = file.url;
+  const current = currentFile.url;
 
   // #ifdef MP
   uni.previewImage({ current, urls });
@@ -310,17 +665,55 @@ function onPreview(index: number) {
   // #endif
 }
 
-function retryUpload(index: number) {
+async function retryUploadWithRun(index: number, interaction?: number) {
+  if (!isInteractionCurrent(interaction)) return;
   const file = fileList.value[index];
+  if (!file) return;
   if (file.status !== UploadStatus.Fail) return;
   emit('retry', file, { index });
-  doUpload(file);
+  if (!(await awaitRunCurrent(interaction))) return;
+  await doUpload(file, interaction);
 }
 
-function clearFiles() {
-  syncModel([]);
+async function retryUpload(index: number) {
+  await retryUploadWithRun(index);
+}
+
+function onRetry(index: number) {
+  if (isDisabled.value) return;
+  void retryUploadWithRun(index, formDisabled.captureInteraction());
+}
+
+async function clearFiles() {
+  activeUploads.forEach(record => {
+    record.cancelled = true;
+    record.abort?.();
+  });
+  activeUploads.clear();
+  clearAutoRemoveTimers();
+  if (!(await syncModel([]))) return;
   emit('clear');
 }
+
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    cancelPendingDelete();
+    clearAutoRemoveTimers();
+    cancelActiveUploads();
+  },
+  { flush: 'sync' }
+);
+
+onBeforeUnmount(() => {
+  clearAutoRemoveTimers();
+  activeUploads.forEach(record => {
+    record.cancelled = true;
+    record.abort?.();
+  });
+  activeUploads.clear();
+});
 
 defineExpose({
   /** 手动选择文件 */
@@ -337,7 +730,7 @@ defineExpose({
 </script>
 
 <template>
-  <view :id="id" class="lk-upload-wrapper">
+  <view :id="id" class="lk-upload-wrapper" :aria-disabled="isDisabled">
     <view :class="rootClass" :style="rootStyle">
       <!-- 已选文件列表 -->
       <view v-for="(f, i) in fileList" :key="f.uid" :class="getItemClass(f)" @tap="onPreview(i)">
@@ -367,7 +760,7 @@ defineExpose({
         <view
           v-if="f.status === 'fail'"
           class="lk-upload__mask lk-upload__mask--fail"
-          @tap.stop="retryUpload(i)"
+          @tap.stop="onRetry(i)"
         >
           <lk-icon name="arrow-clockwise" size="36" color="var(--lk-upload-mask-text)" />
           <text class="lk-upload__mask-text">{{ f.message || uploadFailedText }}</text>
@@ -375,9 +768,9 @@ defineExpose({
 
         <!-- 删除按钮 -->
         <view
-          v-if="deletable && !disabled && f.status !== 'uploading'"
+          v-if="deletable && !isDisabled && f.status !== 'uploading'"
           class="lk-upload__del"
-          @tap.stop="removeFile(i)"
+          @tap.stop="onRemove(i)"
         >
           <lk-icon name="x" size="20" color="var(--lk-upload-del-icon-color)" />
         </view>

--- a/src/uni_modules/lucky-ui/components/lk-upload/upload.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-upload/upload.props.ts
@@ -72,7 +72,7 @@ export type CustomRequestFn = (options: {
   onProgress: (progress: number) => void;
   onSuccess: (response: unknown) => void;
   onFail: (error: unknown) => void;
-}) => void;
+}) => void | { abort?: () => void };
 
 export const uploadProps = {
   ...baseProps,

--- a/src/uni_modules/lucky-ui/components/lk-verify-code/lk-verify-code.vue
+++ b/src/uni_modules/lucky-ui/components/lk-verify-code/lk-verify-code.vue
@@ -19,12 +19,15 @@ import {
   type VerifyCodeKeydownEventLike,
 } from './verify-code.utils';
 import { useLocale } from '../../composables/useLocale';
+import { useFormDisabled } from '../lk-form/useFormField';
 
 defineOptions({ name: 'LkVerifyCode' });
 
 const props = defineProps(verifyCodeProps);
 const emit = defineEmits(verifyCodeEmits);
 const { t } = useLocale('verifyCode');
+const formDisabled = useFormDisabled(() => props.disabled);
+const isDisabled = formDisabled.disabled;
 
 interface FocusableInput {
   focus?: () => void;
@@ -39,6 +42,7 @@ const focusIndex = ref(0);
 const isCountingDown = ref(false);
 const countdownRemaining = ref(0);
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
+let countdownInteraction: number | null = null;
 
 // 当前激活的单元格索引（基于输入值长度）
 const activeIndex = computed(() => resolveVerifyCodeActiveIndex(val.value, props.length));
@@ -74,7 +78,7 @@ const rootClass = computed(() =>
   resolveVerifyCodeRootClass({
     variant: props.variant,
     statusClass: statusClass.value,
-    disabled: props.disabled,
+    disabled: isDisabled.value,
     customClass: props.customClass,
   })
 );
@@ -95,7 +99,7 @@ watch(
 );
 
 function focus() {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
   // #ifdef H5
   try {
     inputRef.value?.focus?.();
@@ -120,7 +124,7 @@ function blur() {
 }
 
 function onFocus() {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
   isFocused.value = true;
   emit('focus');
 }
@@ -130,8 +134,9 @@ function onBlur() {
   emit('blur');
 }
 
-function onInput(e: Event | VerifyCodeInputEventLike) {
-  if (props.disabled) return;
+async function onInput(e: Event | VerifyCodeInputEventLike) {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
 
   const v = resolveVerifyCodeInputValue({
     event: e,
@@ -142,6 +147,7 @@ function onInput(e: Event | VerifyCodeInputEventLike) {
   val.value = v;
   focusIndex.value = resolveVerifyCodeFocusIndex(v, props.length);
   emit('update:modelValue', v);
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
 
   if (shouldFinishVerifyCode(v, props.length)) {
     emit('finish', v);
@@ -149,8 +155,9 @@ function onInput(e: Event | VerifyCodeInputEventLike) {
 }
 
 // 处理粘贴（H5平台）
-function onPaste(e: ClipboardEvent) {
-  if (props.disabled) return;
+async function onPaste(e: ClipboardEvent) {
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
 
   // #ifdef H5
   try {
@@ -161,15 +168,15 @@ function onPaste(e: ClipboardEvent) {
     });
 
     if (pastedText) {
+      e.preventDefault?.();
       val.value = pastedText;
       focusIndex.value = resolveVerifyCodeFocusIndex(pastedText, props.length);
       emit('update:modelValue', pastedText);
+      if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
 
       if (shouldFinishVerifyCode(pastedText, props.length)) {
         emit('finish', pastedText);
       }
-
-      e.preventDefault?.();
     }
   } catch (err) {
     console.warn('Paste handling failed', err);
@@ -178,7 +185,8 @@ function onPaste(e: ClipboardEvent) {
 }
 
 function onKeydown(e: KeyboardEvent | VerifyCodeKeydownEventLike) {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
 
   const newVal = resolveVerifyCodeKeydownValue({
     event: e,
@@ -189,17 +197,19 @@ function onKeydown(e: KeyboardEvent | VerifyCodeKeydownEventLike) {
     val.value = newVal;
     focusIndex.value = resolveVerifyCodeFocusIndex(newVal, props.length);
     emit('update:modelValue', newVal);
+    if (!formDisabled.isInteractionCurrent(interaction)) return;
   }
 }
 
 function onCellClick(index: number) {
-  if (props.disabled) return;
+  if (isDisabled.value) return;
   focusIndex.value = index;
   focus();
 }
 
-function startCountdown() {
-  if (isCountingDown.value || props.disabled) return;
+async function startCountdown() {
+  if (isCountingDown.value || isDisabled.value) return;
+  const interaction = formDisabled.captureInteraction();
 
   // 触发发送事件
   if (val.value.length === 0) {
@@ -207,14 +217,21 @@ function startCountdown() {
   } else {
     emit('resend');
   }
+  if (!(await formDisabled.awaitInteractionCurrent(interaction))) return;
 
   isCountingDown.value = true;
   countdownRemaining.value = props.countdownDuration;
+  countdownInteraction = interaction;
 
   countdownTimer = setInterval(() => {
+    if (countdownInteraction !== interaction || !formDisabled.isInteractionCurrent(interaction)) {
+      stopCountdown();
+      return;
+    }
     countdownRemaining.value--;
     if (countdownRemaining.value <= 0) {
       stopCountdown();
+      if (!formDisabled.isInteractionCurrent(interaction)) return;
       emit('countdownEnd');
     }
   }, 1000);
@@ -227,6 +244,7 @@ function stopCountdown() {
   }
   isCountingDown.value = false;
   countdownRemaining.value = 0;
+  countdownInteraction = null;
 }
 
 function clear() {
@@ -252,7 +270,9 @@ function setValue(code: string) {
 
 onMounted(async () => {
   if (props.autofocus) {
+    const interaction = formDisabled.captureInteraction();
     await nextTick();
+    if (!formDisabled.isInteractionCurrent(interaction)) return;
     focus();
   }
 });
@@ -260,6 +280,16 @@ onMounted(async () => {
 onUnmounted(() => {
   stopCountdown();
 });
+
+watch(
+  isDisabled,
+  disabled => {
+    if (!disabled) return;
+    blur();
+    stopCountdown();
+  },
+  { flush: 'sync' }
+);
 
 defineExpose({
   focus,
@@ -272,7 +302,14 @@ defineExpose({
 </script>
 
 <template>
-  <view class="lk-verify-code" :class="rootClass" :style="rootStyle">
+  <view
+    :id="id"
+    class="lk-verify-code"
+    :class="rootClass"
+    :style="rootStyle"
+    :data-disabled="isDisabled ? 'true' : 'false'"
+    :aria-disabled="isDisabled"
+  >
     <!-- 隐藏的真实输入框 -->
     <input
       ref="inputRef"
@@ -280,7 +317,7 @@ defineExpose({
       :value="val"
       :maxlength="props.length"
       :type="props.type === 'number' ? 'number' : 'text'"
-      :disabled="props.disabled"
+      :disabled="isDisabled"
       :focus="isFocused"
       @input="onInput"
       @focus="onFocus"
@@ -337,7 +374,7 @@ defineExpose({
     <view v-if="props.countdown" class="lk-verify-code__countdown">
       <text
         class="lk-verify-code__countdown-btn"
-        :class="{ 'is-disabled': isCountingDown || props.disabled }"
+        :class="{ 'is-disabled': isCountingDown || isDisabled }"
         @tap="startCountdown"
       >
         {{ countdownDisplayText }}

--- a/tests/miniprogram/input.spec.js
+++ b/tests/miniprogram/input.spec.js
@@ -1,0 +1,70 @@
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+const assert = require('node:assert');
+
+function buildFreshInputComponent() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lucky-ui-mp-input-'));
+  const outputDir = path.join(tempRoot, 'mp-weixin');
+  const cli = require.resolve('@dcloudio/vite-plugin-uni/bin/uni.js');
+
+  try {
+    execFileSync(process.execPath, [cli, 'build', '-p', 'mp-weixin'], {
+      cwd: process.cwd(),
+      env: { ...process.env, UNI_OUTPUT_DIR: outputDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const output = [error.stdout, error.stderr]
+      .filter(Boolean)
+      .map(value => value.toString())
+      .join('\n');
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    throw new Error(`隔离的微信小程序 Input 构建失败。\n${output}`);
+  }
+
+  return {
+    componentPath: path.join(outputDir, 'uni_modules/lucky-ui/components/lk-input/lk-input'),
+    tempRoot,
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * miniprogram-simulate 1.6.1 cannot evaluate Uni's generated array class binding for LkInput.
+ * Build isolated, fresh Uni MP output instead: the native input's disabled data key must be fed
+ * by the compiled merged-disabled ref or readonly. Real mounted SFC tests independently prove
+ * that the merged ref includes Form.disabled; this test protects only the MP native mapping.
+ */
+function runInputReadonlyBindingTest() {
+  const { componentPath, tempRoot } = buildFreshInputComponent();
+  try {
+    assert.ok(fs.existsSync(`${componentPath}.json`), '隔离构建未生成微信小程序 Input 产物。');
+
+    const wxml = fs.readFileSync(`${componentPath}.wxml`, 'utf8');
+    const javascript = fs.readFileSync(`${componentPath}.js`, 'utf8').replace(/\s+/g, '');
+    const nativeInput = wxml.match(/<input\b[^>]*?\sdisabled="\{\{([A-Za-z_$][\w$]*)\}\}"[^>]*>/);
+    assert.ok(nativeInput, '微信小程序原生 input 缺少编译后的 disabled 数据绑定。');
+
+    const disabledComputed = javascript.match(
+      /([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.computed\(\(\)=>[A-Za-z_$][\w$]*\.value\|\|[A-Za-z_$][\w$]*\.readonly\)/
+    );
+    assert.ok(disabledComputed, '微信小程序 Input 未编译出 mergedDisabled || readonly 映射。');
+
+    const disabledDataKey = escapeRegExp(nativeInput[1]);
+    const disabledComputedKey = escapeRegExp(disabledComputed[1]);
+    assert.match(
+      javascript,
+      new RegExp(`(?:[,{])${disabledDataKey}:${disabledComputedKey}\\.value(?:[,}])`),
+      '原生 input 的 disabled 绑定未连接到 mergedDisabled || readonly 计算值。'
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+module.exports = { runInputReadonlyBindingTest };

--- a/tests/miniprogram/run-miniprogram-tests.js
+++ b/tests/miniprogram/run-miniprogram-tests.js
@@ -1,5 +1,6 @@
 const { runButtonSnapshotTest, runButtonTapBindingTest } = require('./button.spec');
 const { runTimelineBasicTest, runTimelineStatusTest } = require('./timeline.spec');
+const { runInputReadonlyBindingTest } = require('./input.spec');
 
 function run() {
   try {
@@ -10,6 +11,8 @@ function run() {
     runTimelineBasicTest();
     runTimelineStatusTest();
     console.log('[test:mp] lk-timeline 小程序渲染测试通过。');
+    runInputReadonlyBindingTest();
+    console.log('[test:mp] lk-input readonly native disabled mapping passed.');
   } catch (error) {
     console.error('[test:mp] 小程序渲染测试失败。');
     console.error(error instanceof Error ? error.message : error);

--- a/tests/unit/form-disabled-components.spec.ts
+++ b/tests/unit/form-disabled-components.spec.ts
@@ -1,0 +1,4208 @@
+// @vitest-environment jsdom
+/* eslint-disable vue/one-component-per-file */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent, h, nextTick, provide, reactive, ref } from 'vue';
+import type { Component } from 'vue';
+import type { FormContext } from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import { formContextKey } from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import LkCalendar from '../../src/uni_modules/lucky-ui/components/lk-calendar/lk-calendar.vue';
+import LkCalendarPicker from '../../src/uni_modules/lucky-ui/components/lk-calendar-picker/lk-calendar-picker.vue';
+import LkCheckbox from '../../src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue';
+import LkCheckboxGroup from '../../src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox-group.vue';
+import LkForm from '../../src/uni_modules/lucky-ui/components/lk-form/lk-form.vue';
+import LkFormItem from '../../src/uni_modules/lucky-ui/components/lk-form/lk-form-item.vue';
+import LkInput from '../../src/uni_modules/lucky-ui/components/lk-input/lk-input.vue';
+import LkKeyboard from '../../src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue';
+import LkPicker from '../../src/uni_modules/lucky-ui/components/lk-picker/lk-picker.vue';
+import LkRadio from '../../src/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue';
+import LkRadioGroup from '../../src/uni_modules/lucky-ui/components/lk-radio/lk-radio-group.vue';
+import LkRate from '../../src/uni_modules/lucky-ui/components/lk-rate/lk-rate.vue';
+import LkSelectList from '../../src/uni_modules/lucky-ui/components/lk-select-list/lk-select-list.vue';
+import LkSlider from '../../src/uni_modules/lucky-ui/components/lk-slider/lk-slider.vue';
+import LkStepper from '../../src/uni_modules/lucky-ui/components/lk-stepper/lk-stepper.vue';
+import LkSwitch from '../../src/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue';
+import LkTextarea from '../../src/uni_modules/lucky-ui/components/lk-textarea/lk-textarea.vue';
+import LkUpload from '../../src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue';
+import type { UploadFile } from '../../src/uni_modules/lucky-ui/components/lk-upload/upload.props';
+import LkVerifyCode from '../../src/uni_modules/lucky-ui/components/lk-verify-code/lk-verify-code.vue';
+
+type TestNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: TestNode[];
+  parent: TestNode | null;
+  text?: string;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(nextResolve => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushTicks(count = 6) {
+  for (let index = 0; index < count; index += 1) await nextTick();
+}
+
+function createNode(type: string, text?: string): TestNode {
+  return { type, props: {}, children: [], parent: null, text };
+}
+
+const renderer = createRenderer<TestNode, TestNode>({
+  patchProp(node, key, _previous, value) {
+    node.props[key] = value;
+  },
+  insert(child, parent, anchor) {
+    child.parent = parent;
+    const index = anchor ? parent.children.indexOf(anchor) : -1;
+    if (index < 0) parent.children.push(child);
+    else parent.children.splice(index, 0, child);
+  },
+  remove(child) {
+    const index = child.parent?.children.indexOf(child) ?? -1;
+    if (index >= 0) child.parent?.children.splice(index, 1);
+  },
+  createElement(type) {
+    return createNode(type);
+  },
+  createText(text) {
+    return createNode('text', text);
+  },
+  createComment(text) {
+    return createNode('comment', text);
+  },
+  setText(node, text) {
+    node.text = text;
+  },
+  setElementText(node, text) {
+    node.children = [createNode('text', text)];
+    node.children[0].parent = node;
+  },
+  parentNode(node) {
+    return node.parent;
+  },
+  nextSibling(node) {
+    const index = node.parent?.children.indexOf(node) ?? -1;
+    return index >= 0 ? node.parent?.children[index + 1] || null : null;
+  },
+});
+
+function makeForm(): FormContext {
+  return reactive({
+    model: {},
+    rules: undefined,
+    showMessage: true,
+    disabled: false,
+    addField: vi.fn(),
+    removeField: vi.fn(),
+    invalidateValidation: vi.fn(),
+    validateField: vi.fn(),
+    emitFieldBlur: vi.fn(),
+    emitFieldChange: vi.fn(),
+    validate: vi.fn(),
+    resetFields: vi.fn(),
+    clearValidate: vi.fn(),
+    scrollToField: vi.fn(),
+  }) as unknown as FormContext;
+}
+
+function hasClass(node: TestNode, className: string): boolean {
+  const value = node.props.class;
+  return typeof value === 'string' && value.split(/\s+/).includes(className);
+}
+
+function findNode(root: TestNode, predicate: (node: TestNode) => boolean): TestNode {
+  if (predicate(root)) return root;
+  for (const child of root.children) {
+    try {
+      return findNode(child, predicate);
+    } catch {
+      // Continue searching sibling branches.
+    }
+  }
+  throw new Error('Expected rendered node was not found');
+}
+
+function findNodes(root: TestNode, predicate: (node: TestNode) => boolean): TestNode[] {
+  return [root, ...root.children.flatMap(child => findNodes(child, predicate))].filter(predicate);
+}
+
+function dispatch(node: TestNode, event: string, ...args: unknown[]) {
+  const handler = node.props[event];
+  if (Array.isArray(handler)) {
+    return Promise.all(handler.map(item => (item as (...values: unknown[]) => unknown)(...args)));
+  }
+  return (handler as (...values: unknown[]) => unknown)(...args);
+}
+
+function mountControl(
+  component: Component,
+  form: FormContext,
+  props: Record<string, unknown> | (() => Record<string, unknown>)
+) {
+  const root = createNode('root');
+  let exposed: Record<string, (...args: never[]) => unknown> | null = null;
+  const App = defineComponent({
+    setup() {
+      provide(formContextKey, form);
+      return () =>
+        h(component, {
+          ...(typeof props === 'function' ? props() : props),
+          ref: (value: unknown) => {
+            exposed = value as Record<string, (...args: never[]) => unknown> | null;
+          },
+        });
+    },
+  });
+  const app = renderer.createApp(App);
+  app.component('LkIcon', defineComponent({ name: 'LkIcon', render: () => h('lk-icon-stub') }));
+  app.component(
+    'LkModal',
+    defineComponent({
+      name: 'LkModal',
+      render: () => h('lk-modal-stub'),
+    })
+  );
+  app.mount(root);
+  return {
+    app,
+    root,
+    exposed: () => exposed,
+  };
+}
+
+function mountRender(form: FormContext, render: () => ReturnType<typeof h>) {
+  const root = createNode('root');
+  const App = defineComponent({
+    setup() {
+      provide(formContextKey, form);
+      return render;
+    },
+  });
+  const app = renderer.createApp(App);
+  app.component('LkIcon', defineComponent({ name: 'LkIcon', render: () => h('lk-icon-stub') }));
+  app.component(
+    'LkModal',
+    defineComponent({
+      name: 'LkModal',
+      render: () => h('lk-modal-stub'),
+    })
+  );
+  app.mount(root);
+  return { app, root };
+}
+
+function mountWithRealForm(
+  disabled: { value: boolean },
+  renderControl: () => ReturnType<typeof h>,
+  formProps: Record<string, unknown> = {}
+) {
+  const model = reactive({});
+  return mountRender(makeForm(), () =>
+    h(LkForm, { model, disabled: disabled.value, ...formProps }, { default: renderControl })
+  );
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.stubGlobal('uni', {
+    getSystemInfoSync: () => ({ windowWidth: 375, safeAreaInsets: { bottom: 0 } }),
+    createSelectorQuery: () => ({
+      in() {
+        return this;
+      },
+      select() {
+        return this;
+      },
+      boundingClientRect(callback: (value: { left: number; width: number }) => void) {
+        callback({ left: 0, width: 300 });
+        return this;
+      },
+      exec() {},
+    }),
+    vibrateShort: vi.fn(),
+    previewImage: vi.fn(),
+  });
+});
+
+describe('documented form controls inherit Form.disabled', () => {
+  it('keeps disjoint field runs independent while superseding only an overlapping field', async () => {
+    const firstA = deferred<boolean>();
+    const secondA = deferred<boolean>();
+    const resultB = deferred<boolean>();
+    let aCalls = 0;
+    const model = reactive({ a: 'a', b: 'b' });
+    const reports: string[] = [];
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          rules: {
+            a: {
+              trigger: 'change',
+              validator: () => {
+                aCalls += 1;
+                return aCalls === 1 ? firstA.promise : secondA.promise;
+              },
+            },
+            b: { trigger: 'change', validator: () => resultB.promise },
+          },
+          onValidateField: (prop: string, ok: boolean) => reports.push(`${prop}:${ok}`),
+        },
+        {
+          default: () => [
+            h(LkFormItem, { prop: 'a' }, { default: () => h(LkInput, { modelValue: model.a }) }),
+            h(LkFormItem, { prop: 'b' }, { default: () => h(LkInput, { modelValue: model.b }) }),
+          ],
+        }
+      )
+    );
+    await nextTick();
+    const inputs = findNodes(mounted.root, node => hasClass(node, 'lk-input__inner'));
+    const items = findNodes(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    const firstInputA = dispatch(inputs[0], 'onInput', { detail: { value: 'a1' } });
+    const inputB = dispatch(inputs[1], 'onInput', { detail: { value: 'b1' } });
+    const secondInputA = dispatch(inputs[0], 'onInput', { detail: { value: 'a2' } });
+    secondA.resolve(true);
+    resultB.resolve(false);
+    firstA.resolve(false);
+    await Promise.all([firstInputA, inputB, secondInputA]);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await nextTick();
+    await nextTick();
+
+    expect(items[0].props['data-validation-status']).toBe('success');
+    expect(items[1].props['data-validation-status']).toBe('error');
+    expect(reports).toEqual(['a:true', 'b:false']);
+    mounted.app.unmount();
+  });
+
+  it('supersedes a stateful form validation with a newer silent run', async () => {
+    const oldResult = deferred<Record<string, string> | null>();
+    const silentResult = deferred<Record<string, string> | null>();
+    let call = 0;
+    const model = reactive({ title: 'title' });
+    const validateField = vi.fn();
+    const validateEvent = vi.fn();
+    let formApi: { validate: (options?: { silent?: boolean }) => Promise<void> } | null = null;
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          customValidator: () => {
+            call += 1;
+            return call === 1 ? oldResult.promise : silentResult.promise;
+          },
+          onValidateField: validateField,
+          onValidate: validateEvent,
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+    const oldValidation = formApi?.validate() as Promise<void>;
+    const silentValidation = formApi?.validate({ silent: true }) as Promise<void>;
+
+    silentResult.resolve(null);
+    await expect(silentValidation).resolves.toBeUndefined();
+    oldResult.resolve({ title: 'old error' });
+    await expect(oldValidation).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    expect(item.props['data-validation-status']).toBe('idle');
+    expect(validateField).not.toHaveBeenCalled();
+    expect(validateEvent).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('rolls back still-owned form commits when a validation listener starts a newer run', async () => {
+    const model = reactive({ a: 'a', b: 'b' });
+    let formApi: {
+      validate: () => Promise<void>;
+      validateField: (prop: string) => Promise<void>;
+    } | null = null;
+    const reports: string[] = [];
+    let nested: Promise<void> | undefined;
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          rules: { a: { required: true }, b: { required: true } },
+          onValidateField: (prop: string) => {
+            reports.push(prop);
+            if (prop === 'a' && !nested) nested = formApi?.validateField('a');
+          },
+        },
+        {
+          default: () => [h(LkFormItem, { prop: 'a' }), h(LkFormItem, { prop: 'b' })],
+        }
+      )
+    );
+    await nextTick();
+    const items = findNodes(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    await expect(formApi?.validate()).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    await expect(nested).resolves.toBeUndefined();
+    expect(reports).toEqual(['a', 'a']);
+    expect(items[0].props['data-validation-status']).toBe('success');
+    expect(items[1].props['data-validation-status']).toBe('idle');
+    mounted.app.unmount();
+  });
+
+  it('validateField listener model mutation and reentry supersede the old owned commit', async () => {
+    const model = reactive({ title: 'before' });
+    let formApi: { validateField: (prop: string) => Promise<void> } | null = null;
+    let nested: Promise<void> | undefined;
+    const reports: string[] = [];
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          rules: { title: { required: true } },
+          onValidateField: () => {
+            reports.push(model.title);
+            if (reports.length !== 1) return;
+            model.title = 'after';
+            nested = formApi?.validateField('title');
+          },
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    const oldValidation = formApi?.validateField('title') as Promise<void>;
+    await expect(oldValidation).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    await expect(nested).resolves.toBeUndefined();
+
+    expect(model.title).toBe('after');
+    expect(reports).toEqual(['before', 'after']);
+    expect(item.props['data-validation-status']).toBe('success');
+    mounted.app.unmount();
+  });
+
+  it.each(['model', 'rules', 'prop', 'disabled'] as const)(
+    'real LkForm delivered %s source invalidates a pending validateField generation',
+    async source => {
+      const pending = deferred<boolean>();
+      const validator = vi.fn(() => pending.promise);
+      const model = reactive({ title: 'before', other: 'other' });
+      const rules = ref({ title: { validator } });
+      const fieldProp = ref('title');
+      const disabled = ref(false);
+      let formApi: { validateField: (prop: string) => Promise<void> } | null = null;
+      const validateFieldEvent = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          {
+            ref: (value: unknown) => {
+              formApi = value as typeof formApi;
+            },
+            model,
+            rules: rules.value,
+            disabled: disabled.value,
+            onValidateField: validateFieldEvent,
+          },
+          { default: () => h(LkFormItem, { prop: fieldProp.value }) }
+        )
+      );
+      await nextTick();
+      const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+      const validation = formApi?.validateField('title') as Promise<void>;
+      expect(validator).toHaveBeenCalledOnce();
+
+      if (source === 'model') model.title = 'changed';
+      if (source === 'rules') rules.value = { title: { validator: () => true } };
+      if (source === 'prop') fieldProp.value = 'other';
+      if (source === 'disabled') disabled.value = true;
+      await nextTick();
+      pending.resolve(true);
+
+      await expect(validation).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+      expect(validateFieldEvent).not.toHaveBeenCalled();
+      expect(item.props['data-validation-status']).toBe('idle');
+      mounted.app.unmount();
+    }
+  );
+
+  it('validateField listener delivered Form.disabled -> old promise rejects and owned commit rolls back', async () => {
+    const disabled = ref(false);
+    const model = reactive({ title: 'valid' });
+    let formApi: { validateField: (prop: string) => Promise<void> } | null = null;
+    const validateFieldEvent = vi.fn(() => {
+      disabled.value = true;
+    });
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          disabled: disabled.value,
+          rules: { title: { required: true } },
+          onValidateField: validateFieldEvent,
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    await expect(formApi?.validateField('title')).rejects.toMatchObject({
+      code: 'FORM_VALIDATION_SUPERSEDED',
+    });
+
+    expect(validateFieldEvent).toHaveBeenCalledOnce();
+    await nextTick();
+    await Promise.resolve();
+    expect(item.props['data-validation-status']).toBe('idle');
+    expect(
+      findNode(mounted.root, node => node.props['data-lk-form'] === true).props['data-disabled']
+    ).toBe('true');
+    mounted.app.unmount();
+  });
+
+  it('validate listener delivered Form.disabled -> form promise rejects and all owned commits roll back', async () => {
+    const disabled = ref(false);
+    const model = reactive({ title: 'valid' });
+    let formApi: { validate: () => Promise<void> } | null = null;
+    const validateEvent = vi.fn(() => {
+      disabled.value = true;
+    });
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          disabled: disabled.value,
+          rules: { title: { required: true } },
+          onValidate: validateEvent,
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    await expect(formApi?.validate()).rejects.toMatchObject({
+      code: 'FORM_VALIDATION_SUPERSEDED',
+    });
+
+    expect(validateEvent).toHaveBeenCalledOnce();
+    expect(item.props['data-validation-status']).toBe('idle');
+    expect(
+      findNode(mounted.root, node => node.props['data-lk-form'] === true).props['data-disabled']
+    ).toBe('true');
+    mounted.app.unmount();
+  });
+
+  it('automatic validate-field listener delivered Form.disabled -> owned commit rolls back', async () => {
+    const disabled = ref(false);
+    const model = reactive({ title: 'before' });
+    const validateFieldEvent = vi.fn(() => {
+      disabled.value = true;
+    });
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          disabled: disabled.value,
+          rules: { title: { trigger: 'change', validator: () => true } },
+          onValidateField: validateFieldEvent,
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'title' },
+              {
+                default: () =>
+                  h(LkInput, {
+                    modelValue: model.title,
+                    'onUpdate:modelValue': (value: string) => {
+                      model.title = value;
+                    },
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-input__inner')),
+      'onInput',
+      { detail: { value: 'typed' } }
+    );
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(validateFieldEvent).toHaveBeenCalledOnce();
+    await nextTick();
+    await Promise.resolve();
+    expect(item.props['data-validation-status']).toBe('idle');
+    mounted.app.unmount();
+  });
+
+  it('field-change listener delivered Form.disabled -> automatic validator never starts', async () => {
+    const disabled = ref(false);
+    const model = reactive({ title: 'before' });
+    const validator = vi.fn(() => true);
+    const validateFieldEvent = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          disabled: disabled.value,
+          rules: { title: { trigger: 'change', validator } },
+          onFieldChange: () => {
+            disabled.value = true;
+          },
+          onValidateField: validateFieldEvent,
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'title' },
+              {
+                default: () =>
+                  h(LkInput, {
+                    modelValue: model.title,
+                    'onUpdate:modelValue': (value: string) => {
+                      model.title = value;
+                    },
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-input__inner')),
+      'onInput',
+      { detail: { value: 'typed' } }
+    );
+    await nextTick();
+    await Promise.resolve();
+
+    expect(validator).not.toHaveBeenCalled();
+    expect(validateFieldEvent).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('automatic field validation listener model mutation rolls its still-owned commit back', async () => {
+    const model = reactive({ title: 'before' });
+    const reports: string[] = [];
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          rules: { title: { trigger: 'change', validator: () => true } },
+          onValidateField: () => {
+            reports.push(model.title);
+            model.title = 'listener-mutated';
+          },
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'title' },
+              {
+                default: () =>
+                  h(LkInput, {
+                    modelValue: model.title,
+                    'onUpdate:modelValue': (value: string) => {
+                      model.title = value;
+                    },
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-input__inner')),
+      'onInput',
+      {
+        detail: { value: 'typed' },
+      }
+    );
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(reports).toEqual(['typed']);
+    await nextTick();
+    await Promise.resolve();
+    expect(model.title).toBe('listener-mutated');
+    expect(item.props['data-validation-status']).toBe('idle');
+    mounted.app.unmount();
+  });
+
+  it.each(['disabled', 'reset'] as const)(
+    'validate-field reentry -> %s keeps the accepted idle lineage for both superseded runs',
+    async scenario => {
+      const disabled = ref(false);
+      const later = deferred<boolean>();
+      const model = reactive({ title: 'value' });
+      let validatorCalls = 0;
+      let formApi: {
+        validateField: (prop: string) => Promise<void>;
+        resetFields: (fields?: string[]) => void;
+      } | null = null;
+      let secondRun: Promise<void> | undefined;
+      const reports = vi.fn(() => {
+        if (secondRun) return;
+        secondRun = formApi?.validateField('title');
+        if (scenario === 'disabled') disabled.value = true;
+        else formApi?.resetFields(['title']);
+      });
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          {
+            ref: (value: unknown) => {
+              formApi = value as typeof formApi;
+            },
+            model,
+            disabled: disabled.value,
+            rules: {
+              title: {
+                validator: () => {
+                  validatorCalls += 1;
+                  return validatorCalls === 1 ? true : later.promise;
+                },
+              },
+            },
+            onValidateField: reports,
+          },
+          { default: () => h(LkFormItem, { prop: 'title' }) }
+        )
+      );
+      await nextTick();
+      const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+      const firstRun = formApi?.validateField('title') as Promise<void>;
+      await flushTicks(2);
+      expect(secondRun).toBeDefined();
+      later.resolve(true);
+      const [firstResult, secondResult] = await Promise.allSettled([firstRun, secondRun!]);
+      await flushTicks();
+
+      expect(firstResult.status).toBe('rejected');
+      expect(secondResult.status).toBe('rejected');
+      if (firstResult.status === 'rejected') {
+        expect(firstResult.reason).toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+      }
+      if (secondResult.status === 'rejected') {
+        expect(secondResult.reason).toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+      }
+      expect(reports).toHaveBeenCalledOnce();
+      expect(item.props['data-validation-status']).toBe('idle');
+      expect(item.props['data-validation-message']).toBe('');
+      mounted.app.unmount();
+    }
+  );
+
+  it.each(['change', 'blur'] as const)(
+    'automatic %s validation stops before rules when its source Input unmounts from the field event',
+    async trigger => {
+      const showInput = ref(true);
+      const model = reactive({ title: 'before' });
+      const validator = vi.fn(() => true);
+      const validateField = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          {
+            model,
+            rules: { title: { trigger, validator } },
+            onFieldChange: trigger === 'change' ? () => (showInput.value = false) : undefined,
+            onFieldBlur: trigger === 'blur' ? () => (showInput.value = false) : undefined,
+            onValidateField: validateField,
+          },
+          {
+            default: () =>
+              h(
+                LkFormItem,
+                { prop: 'title' },
+                {
+                  default: () =>
+                    showInput.value
+                      ? h(LkInput, {
+                          modelValue: model.title,
+                          'onUpdate:modelValue': (value: string) => (model.title = value),
+                        })
+                      : null,
+                }
+              ),
+          }
+        )
+      );
+      await nextTick();
+      const input = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+
+      if (trigger === 'change') {
+        await dispatch(input, 'onInput', { detail: { value: 'typed' } });
+      } else {
+        await dispatch(input, 'onBlur', { detail: { value: 'before' } });
+      }
+      await flushTicks();
+
+      expect(showInput.value).toBe(false);
+      expect(validator).not.toHaveBeenCalled();
+      expect(validateField).not.toHaveBeenCalled();
+      const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+      expect(item.props['data-validation-status']).toBe('idle');
+      mounted.app.unmount();
+    }
+  );
+
+  it('automatic change validation rolls back when only its source Input unmounts while rules await', async () => {
+    const showInput = ref(true);
+    const pending = deferred<boolean>();
+    const model = reactive({ title: 'before' });
+    const validator = vi.fn(() => pending.promise);
+    const laterRule = vi.fn(() => true);
+    const validateField = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          rules: {
+            title: [
+              { trigger: 'change', validator },
+              { trigger: 'change', validator: laterRule },
+            ],
+          },
+          onValidateField: validateField,
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'title' },
+              {
+                default: () =>
+                  showInput.value
+                    ? h(LkInput, {
+                        modelValue: model.title,
+                        'onUpdate:modelValue': (value: string) => (model.title = value),
+                      })
+                    : null,
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+    const interaction = dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-input__inner')),
+      'onInput',
+      { detail: { value: 'typed' } }
+    );
+    await flushTicks(8);
+    expect(validator).toHaveBeenCalledOnce();
+    expect(item.props['data-validation-status']).toBe('validating');
+
+    showInput.value = false;
+    await nextTick();
+    pending.resolve(true);
+    await interaction;
+    await flushTicks();
+
+    expect(validateField).not.toHaveBeenCalled();
+    expect(laterRule).not.toHaveBeenCalled();
+    expect(item.props['data-validation-status']).toBe('idle');
+    mounted.app.unmount();
+  });
+
+  it.each(['disabled', 'reset', 'unmount'] as const)(
+    'validation rule 1 pending -> %s prevents rule 2 side effects',
+    async scenario => {
+      const disabled = ref(false);
+      const showItem = ref(true);
+      const firstRule = deferred<boolean>();
+      const secondRule = vi.fn(() => true);
+      const model = reactive({ title: 'value' });
+      let formApi: {
+        validateField: (prop: string) => Promise<void>;
+        resetFields: () => void;
+      } | null = null;
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          {
+            ref: (value: unknown) => {
+              formApi = value as typeof formApi;
+            },
+            model,
+            disabled: disabled.value,
+            rules: {
+              title: [{ validator: () => firstRule.promise }, { validator: secondRule }],
+            },
+          },
+          { default: () => (showItem.value ? h(LkFormItem, { prop: 'title' }) : null) }
+        )
+      );
+      await nextTick();
+
+      const run = formApi?.validateField('title') as Promise<void>;
+      await flushTicks(2);
+      if (scenario === 'disabled') disabled.value = true;
+      else if (scenario === 'reset') formApi?.resetFields();
+      else showItem.value = false;
+      await nextTick();
+      firstRule.resolve(true);
+      await expect(run).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+      await flushTicks();
+
+      expect(secondRule).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it('validation rule 1 synchronously mutates the model generation -> rule 2 never starts', async () => {
+    const model = reactive({ title: 'value' });
+    let formApi: { validateField: (prop: string) => Promise<void> } | null = null;
+    const secondRule = vi.fn(() => true);
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          rules: {
+            title: [
+              {
+                validator: () => {
+                  model.title = 'mutated';
+                  return true;
+                },
+              },
+              { validator: secondRule },
+            ],
+          },
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+
+    await expect(formApi?.validateField('title')).rejects.toMatchObject({
+      code: 'FORM_VALIDATION_SUPERSEDED',
+    });
+    expect(secondRule).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('suppresses a delayed mini-program scroll after validation is superseded', async () => {
+    let resolveRect: ((rect: { top: number; height: number }) => void) | undefined;
+    const pageScrollTo = vi.fn();
+    vi.stubGlobal('uni', {
+      getSystemInfoSync: () => ({ windowHeight: 800 }),
+      pageScrollTo,
+      createSelectorQuery: () => ({
+        in() {
+          return this;
+        },
+        select() {
+          return this;
+        },
+        selectViewport() {
+          return this;
+        },
+        scrollOffset() {
+          return this;
+        },
+        boundingClientRect(callback: (rect: { top: number; height: number }) => void) {
+          resolveRect = callback;
+          return this;
+        },
+        exec() {},
+      }),
+    });
+    const model = reactive({ title: '' });
+    let formApi: { validate: () => Promise<void>; resetFields: () => void } | null = null;
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+          rules: { title: [{ required: true, message: 'required' }] },
+          scrollToError: true,
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+
+    await formApi?.validate().catch(() => undefined);
+    expect(resolveRect).toBeTypeOf('function');
+    formApi?.resetFields();
+    resolveRect?.({ top: 240, height: 40 });
+    await Promise.resolve();
+    await nextTick();
+
+    expect(pageScrollTo).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('manual scrollToField -> Form unmount -> delayed rect cannot reach pageScrollTo', async () => {
+    let resolveRect: ((rect: { top: number; height: number }) => void) | undefined;
+    const pageScrollTo = vi.fn();
+    vi.stubGlobal('uni', {
+      ...uni,
+      getSystemInfoSync: () => ({ windowHeight: 800 }),
+      pageScrollTo,
+      createSelectorQuery: () => ({
+        in() {
+          return this;
+        },
+        select() {
+          return this;
+        },
+        selectViewport() {
+          return this;
+        },
+        scrollOffset() {
+          return this;
+        },
+        boundingClientRect(callback: (rect: { top: number; height: number }) => void) {
+          resolveRect = callback;
+          return this;
+        },
+        exec() {},
+      }),
+    });
+    const model = reactive({ title: '' });
+    let formApi: { scrollToField: (prop: string) => void } | null = null;
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          ref: (value: unknown) => {
+            formApi = value as typeof formApi;
+          },
+          model,
+        },
+        { default: () => h(LkFormItem, { prop: 'title' }) }
+      )
+    );
+    await nextTick();
+
+    formApi?.scrollToField('title');
+    expect(resolveRect).toBeTypeOf('function');
+    mounted.app.unmount();
+    resolveRect?.({ top: 300, height: 40 });
+    await flushTicks();
+
+    expect(pageScrollTo).not.toHaveBeenCalled();
+  });
+
+  it.each(['disable', 'unmount'] as const)(
+    'FormItem tap listener %s -> nextTick blocks the following click event',
+    async scenario => {
+      const disabled = ref(false);
+      const showItem = ref(true);
+      const tap = vi.fn(() => {
+        if (scenario === 'disable') disabled.value = true;
+        else showItem.value = false;
+      });
+      const click = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          { model: {}, disabled: disabled.value },
+          {
+            default: () =>
+              showItem.value ? h(LkFormItem, { prop: 'title', onTap: tap, onClick: click }) : null,
+          }
+        )
+      );
+      await nextTick();
+      const item = findNode(mounted.root, node => hasClass(node, 'lk-form-item'));
+
+      await dispatch(item, 'onTap', { source: 'test' });
+      await nextTick();
+
+      expect(tap).toHaveBeenCalledOnce();
+      expect(click).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it('FormItem enabled tap -> nextTick emits click exactly once in order', async () => {
+    const order: string[] = [];
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model: {} },
+        {
+          default: () =>
+            h(LkFormItem, {
+              prop: 'title',
+              onTap: () => order.push('tap'),
+              onClick: () => order.push('click'),
+            }),
+        }
+      )
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-form-item')),
+      'onTap',
+      { source: 'test' }
+    );
+
+    expect(order).toEqual(['tap', 'click']);
+    mounted.app.unmount();
+  });
+
+  it('scrollToField scopes exact and duplicate props to their owning FormItem instances', async () => {
+    const pageScrollTo = vi.fn();
+    const scopes: unknown[] = [];
+    const tops = new Map<unknown, number>();
+    vi.stubGlobal('uni', {
+      ...uni,
+      getSystemInfoSync: () => ({ windowHeight: 800 }),
+      pageScrollTo,
+      createSelectorQuery: () => {
+        let scope: unknown;
+        return {
+          in(value: unknown) {
+            scope = value;
+            scopes.push(value);
+            if (!tops.has(value)) tops.set(value, tops.size * 1000 + 1000);
+            return this;
+          },
+          select(selector: string) {
+            expect(selector).toBe('.lk-form-item');
+            return this;
+          },
+          boundingClientRect(callback?: (rect: { top: number; height: number }) => void) {
+            if (callback && scope) callback({ top: tops.get(scope) ?? 0, height: 40 });
+            return this;
+          },
+          selectViewport() {
+            return this;
+          },
+          scrollOffset() {
+            return this;
+          },
+          exec(callback?: (results: unknown[]) => void) {
+            callback?.([{ scrollTop: 0 }]);
+          },
+        };
+      },
+    });
+    const firstModel = reactive({ username: '', name: '' });
+    const secondModel = reactive({ name: '' });
+    let firstApi: { scrollToField: (prop: string) => void } | null = null;
+    let secondApi: { scrollToField: (prop: string) => void } | null = null;
+    const mounted = mountRender(makeForm(), () =>
+      h('view', [
+        h(
+          LkForm,
+          {
+            ref: (value: unknown) => {
+              firstApi = value as typeof firstApi;
+            },
+            model: firstModel,
+          },
+          {
+            default: () => [h(LkFormItem, { prop: 'username' }), h(LkFormItem, { prop: 'name' })],
+          }
+        ),
+        h(
+          LkForm,
+          {
+            ref: (value: unknown) => {
+              secondApi = value as typeof secondApi;
+            },
+            model: secondModel,
+          },
+          { default: () => h(LkFormItem, { prop: 'name' }) }
+        ),
+      ])
+    );
+    await nextTick();
+
+    firstApi?.scrollToField('username');
+    firstApi?.scrollToField('name');
+    secondApi?.scrollToField('name');
+    await Promise.resolve();
+
+    expect(scopes).toHaveLength(3);
+    expect(new Set(scopes).size).toBe(3);
+    expect(pageScrollTo).toHaveBeenCalledTimes(3);
+    const scrollTops = pageScrollTo.mock.calls.map(([options]) => options.scrollTop as number);
+    expect(scrollTops[0]).toBeLessThan(scrollTops[1]);
+    expect(scrollTops[1]).toBeLessThan(scrollTops[2]);
+    mounted.app.unmount();
+  });
+
+  it('does not inherit an outer FormItem prop across a nested Form boundary', async () => {
+    const outerModel = reactive({ outer: '' });
+    const innerModel = reactive({ inner: '' });
+    const outerFieldChange = vi.fn();
+    const innerFieldChange = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model: outerModel, onFieldChange: outerFieldChange },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'outer' },
+              {
+                default: () =>
+                  h(
+                    LkForm,
+                    { model: innerModel, onFieldChange: innerFieldChange },
+                    { default: () => h(LkInput, { modelValue: innerModel.inner }) }
+                  ),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+    const inputRoot = findNode(mounted.root, node => hasClass(node, 'lk-input'));
+
+    expect(inputRoot.props['data-form-prop']).toBe('');
+    dispatch(control, 'onInput', { detail: { value: 'next' } });
+    expect(outerFieldChange).not.toHaveBeenCalled();
+    expect(innerFieldChange).not.toHaveBeenCalled();
+    expect(innerModel).not.toHaveProperty('outer');
+    mounted.app.unmount();
+  });
+
+  it.each([
+    {
+      name: 'Checkbox',
+      component: LkCheckbox,
+      props: { modelValue: false, name: 'accepted' },
+      selector: (node: TestNode) => node.props.role === 'checkbox',
+    },
+    {
+      name: 'Radio',
+      component: LkRadio,
+      props: { modelValue: 'a', name: 'b' },
+      selector: (node: TestNode) => node.props.role === 'radio',
+    },
+    {
+      name: 'Rate',
+      component: LkRate,
+      props: { modelValue: 0 },
+      selector: (node: TestNode) => hasClass(node, 'lk-rate__item'),
+    },
+    {
+      name: 'Stepper',
+      component: LkStepper,
+      props: { modelValue: 1 },
+      selector: (node: TestNode) => hasClass(node, 'lk-stepper__plus'),
+    },
+    {
+      name: 'Slider',
+      component: LkSlider,
+      props: { modelValue: 10 },
+      selector: (node: TestNode) => hasClass(node, 'lk-slider__track-container'),
+    },
+  ])('blocks $name model updates while Form is disabled', ({ component, props, selector }) => {
+    const form = makeForm();
+    form.disabled = true;
+    const update = vi.fn();
+    const change = vi.fn();
+    const mounted = mountControl(component, form, {
+      ...props,
+      'onUpdate:modelValue': update,
+      onChange: change,
+    });
+
+    dispatch(findNode(mounted.root, selector), 'onTap', {
+      detail: { x: 150 },
+      stopPropagation() {},
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    {
+      name: 'Checkbox',
+      component: LkCheckbox,
+      field: 'accepted',
+      initial: false as boolean | string,
+      expected: true as boolean | string,
+      controlProps: {},
+      role: 'checkbox',
+    },
+    {
+      name: 'Radio',
+      component: LkRadio,
+      field: 'choice',
+      initial: '' as boolean | string,
+      expected: 'accepted' as boolean | string,
+      controlProps: { name: 'accepted' },
+      role: 'radio',
+    },
+  ])(
+    'standalone $name update/change -> Form field-change -> change-rule validation',
+    async ({ component, field, initial, expected, controlProps, role }) => {
+      const model = reactive<Record<string, boolean | string>>({ [field]: initial });
+      const validator = vi.fn(() => true);
+      const fieldChange = vi.fn();
+      const validateField = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          {
+            model,
+            rules: { [field]: { trigger: 'change', validator } },
+            onFieldChange: fieldChange,
+            onValidateField: validateField,
+          },
+          {
+            default: () =>
+              h(
+                LkFormItem,
+                { prop: field },
+                {
+                  default: () =>
+                    h(component, {
+                      ...controlProps,
+                      prop: field,
+                      modelValue: model[field],
+                      'onUpdate:modelValue': (value: boolean | string) => {
+                        model[field] = value;
+                      },
+                    }),
+                }
+              ),
+          }
+        )
+      );
+      await nextTick();
+
+      await dispatch(
+        findNode(mounted.root, node => node.props.role === role),
+        'onTap',
+        {}
+      );
+      await nextTick();
+      await Promise.resolve();
+      await nextTick();
+
+      expect(model[field]).toBe(expected);
+      expect(fieldChange).toHaveBeenCalledWith(field, expected);
+      expect(validator).toHaveBeenCalledOnce();
+      expect(validateField).toHaveBeenCalledWith(field, true, null);
+      mounted.app.unmount();
+    }
+  );
+
+  it('Input compositionstart -> delivered readonly -> queued compositionupdate/end stay silent', async () => {
+    const readonly = ref(false);
+    const update = vi.fn();
+    const compositionUpdate = vi.fn();
+    const compositionEnd = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(LkInput, {
+        modelValue: '',
+        readonly: readonly.value,
+        'onUpdate:modelValue': update,
+        onCompositionupdate: compositionUpdate,
+        onCompositionend: compositionEnd,
+      })
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+
+    await dispatch(control, 'onCompositionstart', { detail: { value: '' } });
+    readonly.value = true;
+    await nextTick();
+    await dispatch(control, 'onCompositionupdate', { detail: { value: 'late' } });
+    await dispatch(control, 'onCompositionend', { detail: { value: 'late' } });
+
+    expect(compositionUpdate).not.toHaveBeenCalled();
+    expect(compositionEnd).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    { name: 'Input input', component: LkInput, controlClass: 'lk-input__inner', event: 'onInput' },
+    {
+      name: 'Textarea input',
+      component: LkTextarea,
+      controlClass: 'lk-textarea__inner',
+      event: 'onInput',
+    },
+    { name: 'Input clear', component: LkInput, controlClass: 'lk-input__clear', event: 'onTap' },
+    {
+      name: 'Textarea clear',
+      component: LkTextarea,
+      controlClass: 'lk-textarea__clear',
+      event: 'onTap',
+    },
+  ])('$name update listener delivers readonly -> all later business stages stop', async config => {
+    const readonly = ref(false);
+    const model = reactive({ value: 'seed' });
+    const update = vi.fn(() => {
+      readonly.value = true;
+    });
+    const input = vi.fn();
+    const change = vi.fn();
+    const clear = vi.fn();
+    const fieldChange = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model, onFieldChange: fieldChange },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'value' },
+              {
+                default: () =>
+                  h(config.component, {
+                    modelValue: model.value,
+                    readonly: readonly.value,
+                    clearable: true,
+                    'onUpdate:modelValue': update,
+                    onInput: input,
+                    onChange: change,
+                    onClear: clear,
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, config.controlClass));
+
+    await dispatch(
+      control,
+      config.event,
+      config.event === 'onInput'
+        ? { detail: { value: 'next' } }
+        : { stopPropagation() {}, preventDefault() {} }
+    );
+    await flushTicks();
+
+    expect(update).toHaveBeenCalledOnce();
+    expect(input).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+    expect(fieldChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Input update listener rebinds FormItem a -> b and supersedes the old field chain', async () => {
+    const fieldProp = ref('a');
+    const model = reactive({ a: 'A', b: 'B' });
+    let first = true;
+    const input = vi.fn();
+    const fieldChange = vi.fn();
+    const validateField = vi.fn();
+    const validateA = vi.fn(() => true);
+    const validateB = vi.fn(() => true);
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          rules: {
+            a: { trigger: 'change', validator: validateA },
+            b: { trigger: 'change', validator: validateB },
+          },
+          onFieldChange: fieldChange,
+          onValidateField: validateField,
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: fieldProp.value },
+              {
+                default: () =>
+                  h(LkInput, {
+                    modelValue: model[fieldProp.value as 'a' | 'b'],
+                    onInput: input,
+                    'onUpdate:modelValue': (value: string) => {
+                      model[fieldProp.value as 'a' | 'b'] = value;
+                      if (first) {
+                        first = false;
+                        fieldProp.value = 'b';
+                      }
+                    },
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+
+    await dispatch(control, 'onInput', { detail: { value: 'old-a' } });
+    await flushTicks();
+    expect(model.a).toBe('old-a');
+    expect(fieldProp.value).toBe('b');
+    expect(input).not.toHaveBeenCalled();
+    expect(fieldChange).not.toHaveBeenCalled();
+    expect(validateA).not.toHaveBeenCalled();
+    expect(validateB).not.toHaveBeenCalled();
+
+    await dispatch(control, 'onInput', { detail: { value: 'new-b' } });
+    await flushTicks();
+    expect(model.b).toBe('new-b');
+    expect(input).toHaveBeenCalledOnce();
+    expect(fieldChange).toHaveBeenCalledWith('b', 'new-b');
+    expect(validateA).not.toHaveBeenCalled();
+    expect(validateB).toHaveBeenCalledOnce();
+    expect(validateField).toHaveBeenCalledWith('b', true, null);
+    mounted.app.unmount();
+  });
+
+  it.each([
+    {
+      name: 'CheckboxGroup',
+      group: LkCheckboxGroup,
+      child: LkCheckbox,
+      modelValue: [] as string[],
+      childProps: { name: 'a' },
+      role: 'checkbox',
+    },
+    {
+      name: 'RadioGroup',
+      group: LkRadioGroup,
+      child: LkRadio,
+      modelValue: 'a',
+      childProps: { name: 'b' },
+      role: 'radio',
+    },
+  ])(
+    'respects delivered child and Form disabled edges for $name',
+    async ({ group, child, modelValue, childProps, role }) => {
+      const form = makeForm();
+      const childDisabled = ref(false);
+      const reenabledUpdate = vi.fn();
+      const reenabledMounted = mountRender(form, () =>
+        h(
+          group,
+          { modelValue, 'onUpdate:modelValue': reenabledUpdate },
+          {
+            default: () => h(child, { ...childProps, disabled: childDisabled.value }),
+          }
+        )
+      );
+      childDisabled.value = true;
+      await nextTick();
+      childDisabled.value = false;
+      await nextTick();
+      await dispatch(
+        findNode(reenabledMounted.root, node => node.props.role === role),
+        'onTap',
+        {}
+      );
+      expect(reenabledUpdate).toHaveBeenCalledOnce();
+      reenabledMounted.app.unmount();
+
+      form.disabled = true;
+      const groupUpdate = vi.fn();
+      const disabledMounted = mountRender(form, () =>
+        h(
+          group,
+          { modelValue, 'onUpdate:modelValue': groupUpdate },
+          { default: () => h(child, childProps) }
+        )
+      );
+      dispatch(
+        findNode(disabledMounted.root, node => node.props.role === role),
+        'onTap',
+        {}
+      );
+      expect(groupUpdate).not.toHaveBeenCalled();
+      disabledMounted.app.unmount();
+    }
+  );
+
+  it('stops Input input/change/Form validation after update:modelValue delivers real Form.disabled', async () => {
+    const disabled = ref(false);
+    const model = reactive({ title: '' });
+    const sequence: string[] = [];
+    const formChange = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model, disabled: disabled.value, onFieldChange: formChange },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'title' },
+              {
+                default: () =>
+                  h(LkInput, {
+                    modelValue: model.title,
+                    'onUpdate:modelValue': (value: string) => {
+                      sequence.push('update:modelValue');
+                      model.title = value;
+                      disabled.value = true;
+                    },
+                    onInput: () => sequence.push('input'),
+                    onChange: () => sequence.push('change'),
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+
+    await dispatch(control, 'onInput', { detail: { value: 'next' } });
+    await nextTick();
+
+    expect(model.title).toBe('next');
+    expect(sequence).toEqual(['update:modelValue']);
+    expect(formChange).not.toHaveBeenCalled();
+    expect(
+      findNode(mounted.root, node => node.props['data-lk-form'] === true).props['data-disabled']
+    ).toBe('true');
+    mounted.app.unmount();
+  });
+
+  it('Input blur proposal -> nextTick real Form.disabled -> no change/Form field-blur', async () => {
+    const disabled = ref(false);
+    const blur = vi.fn(() => {
+      disabled.value = true;
+    });
+    const change = vi.fn();
+    const fieldBlur = vi.fn();
+    const mounted = mountWithRealForm(
+      disabled,
+      () => h(LkInput, { modelValue: 'value', prop: 'title', onBlur: blur, onChange: change }),
+      { onFieldBlur: fieldBlur }
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-input__inner')),
+      'onBlur',
+      { detail: { value: 'value' } }
+    );
+    await nextTick();
+
+    expect(blur).toHaveBeenCalledOnce();
+    expect(change).not.toHaveBeenCalled();
+    expect(fieldBlur).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    { name: 'Input', component: LkInput, controlClass: 'lk-input__inner' },
+    { name: 'Textarea', component: LkTextarea, controlClass: 'lk-textarea__inner' },
+  ])(
+    '$name compositionstart -> delivered disable/enable -> stale compositionend cannot commit',
+    async ({ component, controlClass }) => {
+      const disabled = ref(false);
+      const model = reactive({ value: '' });
+      const update = vi.fn((value: string) => {
+        model.value = value;
+      });
+      const input = vi.fn();
+      const compositionEnd = vi.fn();
+      const formChange = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          { model, disabled: disabled.value, onFieldChange: formChange },
+          {
+            default: () =>
+              h(
+                LkFormItem,
+                { prop: 'value' },
+                {
+                  default: () =>
+                    h(component, {
+                      modelValue: model.value,
+                      'onUpdate:modelValue': update,
+                      onInput: input,
+                      onCompositionend: compositionEnd,
+                    }),
+                }
+              ),
+          }
+        )
+      );
+      await nextTick();
+      const control = findNode(mounted.root, node => hasClass(node, controlClass));
+
+      await dispatch(control, 'onCompositionstart', { detail: { value: '' } });
+      disabled.value = true;
+      await nextTick();
+      disabled.value = false;
+      await nextTick();
+      await dispatch(control, 'onCompositionend', { detail: { value: 'stale' } });
+      await nextTick();
+
+      expect(compositionEnd).not.toHaveBeenCalled();
+      expect(model.value).toBe('');
+      expect(update).not.toHaveBeenCalled();
+      expect(input).not.toHaveBeenCalled();
+      expect(formChange).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it.each([
+    { name: 'Input', component: LkInput, controlClass: 'lk-input__inner' },
+    { name: 'Textarea', component: LkTextarea, controlClass: 'lk-textarea__inner' },
+  ])(
+    '$name Uni H5 start -> full input -> fragment end commits the cached full value once',
+    async config => {
+      const model = reactive({ notes: 'abc' });
+      const update = vi.fn((value: string) => {
+        model.notes = value;
+      });
+      const input = vi.fn();
+      const formChange = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          { model, onFieldChange: formChange },
+          {
+            default: () =>
+              h(
+                LkFormItem,
+                { prop: 'notes' },
+                {
+                  default: () =>
+                    h(config.component, {
+                      modelValue: model.notes,
+                      'onUpdate:modelValue': update,
+                      onInput: input,
+                    }),
+                }
+              ),
+          }
+        )
+      );
+      await nextTick();
+      const control = findNode(mounted.root, node => hasClass(node, config.controlClass));
+
+      await dispatch(control, 'onCompositionstart', { detail: { value: '' } });
+      await dispatch(control, 'onInput', { detail: { value: 'abc汉' } });
+      expect(update).not.toHaveBeenCalled();
+      expect(input).not.toHaveBeenCalled();
+
+      await dispatch(control, 'onCompositionend', { detail: { value: '汉' } });
+      await nextTick();
+      await Promise.resolve();
+
+      expect(model.notes).toBe('abc汉');
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(input).toHaveBeenCalledTimes(1);
+      expect(formChange).toHaveBeenCalledTimes(1);
+      mounted.app.unmount();
+    }
+  );
+
+  it.each([
+    { name: 'Input', component: LkInput, controlClass: 'lk-input__inner' },
+    { name: 'Textarea', component: LkTextarea, controlClass: 'lk-textarea__inner' },
+  ])(
+    '$name late native confirm/compositionupdate/measurement events stay silent after Form disabled',
+    async ({ component, controlClass }) => {
+      const disabled = ref(false);
+      const confirm = vi.fn();
+      const compositionUpdate = vi.fn();
+      const keyboardHeightChange = vi.fn();
+      const lineChange = vi.fn();
+      const mounted = mountWithRealForm(disabled, () =>
+        h(component, {
+          modelValue: '',
+          onConfirm: confirm,
+          onCompositionupdate: compositionUpdate,
+          onKeyboardheightchange: keyboardHeightChange,
+          onLinechange: lineChange,
+        })
+      );
+      await nextTick();
+      const control = findNode(mounted.root, node => hasClass(node, controlClass));
+
+      await dispatch(control, 'onCompositionstart', { detail: { value: '' } });
+      disabled.value = true;
+      await nextTick();
+      await dispatch(control, 'onCompositionupdate', { detail: { value: 'late' } });
+      await dispatch(control, 'onConfirm', { detail: { value: 'late' } });
+      await dispatch(control, 'onKeyboardheightchange', { detail: { height: 240 } });
+      if (component === LkTextarea) {
+        await dispatch(control, 'onLinechange', { detail: { lineCount: 2 } });
+      }
+
+      expect(compositionUpdate).not.toHaveBeenCalled();
+      expect(confirm).not.toHaveBeenCalled();
+      expect(keyboardHeightChange).not.toHaveBeenCalled();
+      expect(lineChange).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it('keeps readonly Input focus and blur public on H5 without committing form events', () => {
+    const form = makeForm();
+    const focus = vi.fn();
+    const blur = vi.fn();
+    const change = vi.fn();
+    const mounted = mountControl(LkInput, form, {
+      modelValue: 'copy me',
+      readonly: true,
+      prop: 'title',
+      onFocus: focus,
+      onBlur: blur,
+      onChange: change,
+    });
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-input__inner'));
+
+    expect(control.props.disabled).toBe(false);
+    expect(control.props.readonly).toBe(true);
+    dispatch(control, 'onFocus', {});
+    dispatch(control, 'onBlur', {});
+
+    expect(focus).toHaveBeenCalledOnce();
+    expect(blur).toHaveBeenCalledOnce();
+    expect(change).not.toHaveBeenCalled();
+    expect(form.emitFieldBlur).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    { name: 'Input', component: LkInput, controlClass: 'lk-input__inner' },
+    { name: 'Textarea', component: LkTextarea, controlClass: 'lk-textarea__inner' },
+  ])(
+    '$name compositionstart -> compositionend listener disables real Form -> no commit chain',
+    async ({ component, controlClass }) => {
+      const disabled = ref(false);
+      const model = reactive({ value: '' });
+      const sequence: string[] = [];
+      const formChange = vi.fn();
+      const mounted = mountRender(makeForm(), () =>
+        h(
+          LkForm,
+          { model, disabled: disabled.value, onFieldChange: formChange },
+          {
+            default: () =>
+              h(
+                LkFormItem,
+                { prop: 'value' },
+                {
+                  default: () =>
+                    h(component, {
+                      modelValue: model.value,
+                      onCompositionend: () => {
+                        sequence.push('compositionend');
+                        disabled.value = true;
+                      },
+                      'onUpdate:modelValue': (value: string) => {
+                        model.value = value;
+                        sequence.push('update:modelValue');
+                      },
+                      onInput: () => sequence.push('input'),
+                    }),
+                }
+              ),
+          }
+        )
+      );
+      await nextTick();
+      const control = findNode(mounted.root, node => hasClass(node, controlClass));
+
+      await dispatch(control, 'onCompositionstart', { detail: { value: '' } });
+      await dispatch(control, 'onCompositionend', { detail: { value: 'blocked' } });
+      await nextTick();
+
+      expect(sequence).toEqual(['compositionend']);
+      expect(model.value).toBe('');
+      expect(formChange).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it('Textarea delayed blur proposal -> nextTick real Form.disabled -> no change/Form field-blur', async () => {
+    vi.useFakeTimers();
+    const disabled = ref(false);
+    const blur = vi.fn(() => {
+      disabled.value = true;
+    });
+    const change = vi.fn();
+    const fieldBlur = vi.fn();
+    const mounted = mountWithRealForm(
+      disabled,
+      () => h(LkTextarea, { modelValue: 'value', prop: 'notes', onBlur: blur, onChange: change }),
+      { onFieldBlur: fieldBlur }
+    );
+    await nextTick();
+    const control = findNode(mounted.root, node => hasClass(node, 'lk-textarea__inner'));
+
+    dispatch(control, 'onBlur', { detail: { value: 'value' } });
+    await vi.advanceTimersByTimeAsync(100);
+    await nextTick();
+
+    expect(blur).toHaveBeenCalledOnce();
+    expect(change).not.toHaveBeenCalled();
+    expect(fieldBlur).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    {
+      name: 'CheckboxGroup',
+      group: LkCheckboxGroup,
+      child: LkCheckbox,
+      modelValue: [] as string[],
+      childProps: { name: 'a' },
+      role: 'checkbox',
+    },
+    {
+      name: 'RadioGroup',
+      group: LkRadioGroup,
+      child: LkRadio,
+      modelValue: 'a',
+      childProps: { name: 'b' },
+      role: 'radio',
+    },
+  ])(
+    '$name click proposal -> nextTick real Form.disabled -> no model/change/Form field-change',
+    async ({ group, child, modelValue, childProps, role }) => {
+      const disabled = ref(false);
+      const update = vi.fn();
+      const change = vi.fn();
+      const fieldChange = vi.fn();
+      const click = vi.fn(() => {
+        disabled.value = true;
+      });
+      const mounted = mountWithRealForm(
+        disabled,
+        () =>
+          h(
+            group,
+            {
+              modelValue,
+              prop: 'choice',
+              'onUpdate:modelValue': update,
+              onChange: change,
+            },
+            { default: () => h(child, { ...childProps, onClick: click }) }
+          ),
+        { onFieldChange: fieldChange }
+      );
+      await nextTick();
+
+      await dispatch(
+        findNode(mounted.root, node => node.props.role === role),
+        'onTap',
+        {}
+      );
+      await nextTick();
+
+      expect(click).toHaveBeenCalledOnce();
+      expect(update).not.toHaveBeenCalled();
+      expect(change).not.toHaveBeenCalled();
+      expect(fieldChange).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it.each([
+    {
+      name: 'Switch',
+      component: LkSwitch,
+      props: { modelValue: false, prop: 'value' },
+      selector: (node: TestNode) => node.props.role === 'switch',
+    },
+    {
+      name: 'Stepper',
+      component: LkStepper,
+      props: { modelValue: 1, prop: 'value' },
+      selector: (node: TestNode) => hasClass(node, 'lk-stepper__plus'),
+    },
+  ])(
+    '$name before-change proposal -> nextTick real Form.disabled -> no model/change/Form field-change',
+    async ({ component, props, selector }) => {
+      const disabled = ref(false);
+      const update = vi.fn();
+      const change = vi.fn();
+      const fieldChange = vi.fn();
+      const beforeChange = vi.fn(() => {
+        disabled.value = true;
+      });
+      const mounted = mountWithRealForm(
+        disabled,
+        () =>
+          h(component, {
+            ...props,
+            'onUpdate:modelValue': update,
+            onBeforeChange: beforeChange,
+            onChange: change,
+          }),
+        { onFieldChange: fieldChange }
+      );
+      await nextTick();
+
+      await dispatch(findNode(mounted.root, selector), 'onTap', {
+        stopPropagation() {},
+        preventDefault() {},
+      });
+      await nextTick();
+
+      expect(beforeChange).toHaveBeenCalledOnce();
+      expect(update).not.toHaveBeenCalled();
+      expect(change).not.toHaveBeenCalled();
+      expect(fieldChange).not.toHaveBeenCalled();
+      mounted.app.unmount();
+    }
+  );
+
+  it('Stepper blur proposal -> nextTick real Form.disabled -> no before-change/model/change/Form field-change', async () => {
+    const disabled = ref(false);
+    const blur = vi.fn(() => {
+      disabled.value = true;
+    });
+    const beforeChange = vi.fn();
+    const update = vi.fn();
+    const change = vi.fn();
+    const fieldChange = vi.fn();
+    const mounted = mountWithRealForm(
+      disabled,
+      () =>
+        h(LkStepper, {
+          modelValue: 1,
+          prop: 'value',
+          onBlur: blur,
+          onBeforeChange: beforeChange,
+          'onUpdate:modelValue': update,
+          onChange: change,
+        }),
+      { onFieldChange: fieldChange }
+    );
+    await nextTick();
+
+    const input = findNode(mounted.root, node => hasClass(node, 'lk-stepper__input'));
+    dispatch(input, 'onInput', { detail: { value: '2' } });
+    await dispatch(input, 'onBlur', {});
+    await nextTick();
+
+    expect(blur).toHaveBeenCalledOnce();
+    expect(beforeChange).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+    expect(fieldChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Rate click proposal -> nextTick real Form.disabled -> no clear/model/change/Form field-change', async () => {
+    const disabled = ref(false);
+    const clear = vi.fn();
+    const update = vi.fn();
+    const change = vi.fn();
+    const fieldChange = vi.fn();
+    const click = vi.fn(() => {
+      disabled.value = true;
+    });
+    const mounted = mountWithRealForm(
+      disabled,
+      () =>
+        h(LkRate, {
+          modelValue: 1,
+          prop: 'rating',
+          allowClear: true,
+          onClick: click,
+          onClear: clear,
+          'onUpdate:modelValue': update,
+          onChange: change,
+        }),
+      { onFieldChange: fieldChange }
+    );
+    await nextTick();
+
+    await dispatch(
+      findNodes(mounted.root, node => hasClass(node, 'lk-rate__item'))[0],
+      'onTap',
+      {}
+    );
+    await nextTick();
+
+    expect(click).toHaveBeenCalledOnce();
+    expect(clear).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+    expect(fieldChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Rate validateEvent=false updates the value without Form field-change or validation', async () => {
+    const model = reactive({ rating: 0 });
+    const fieldChange = vi.fn();
+    const validator = vi.fn(() => true);
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          rules: { rating: { trigger: 'change', validator } },
+          onFieldChange: fieldChange,
+        },
+        {
+          default: () =>
+            h(
+              LkFormItem,
+              { prop: 'rating' },
+              {
+                default: () =>
+                  h(LkRate, {
+                    modelValue: model.rating,
+                    prop: 'rating',
+                    validateEvent: false,
+                    'onUpdate:modelValue': (value: number) => {
+                      model.rating = value;
+                    },
+                  }),
+              }
+            ),
+        }
+      )
+    );
+    await nextTick();
+
+    await dispatch(
+      findNodes(mounted.root, node => hasClass(node, 'lk-rate__item'))[0],
+      'onTap',
+      {}
+    );
+    await flushTicks();
+
+    expect(model.rating).toBe(1);
+    expect(fieldChange).not.toHaveBeenCalled();
+    expect(validator).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('SelectList update:modelValue commit -> nextTick real Form.disabled -> no change/select', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkSelectList, {
+        modelValue: '',
+        options: [{ label: 'A', value: 'a' }],
+        'onUpdate:modelValue': () => {
+          sequence.push('update:modelValue');
+          disabled.value = true;
+        },
+        onChange: () => sequence.push('change'),
+        onSelect: () => sequence.push('select'),
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-select-list__item')),
+      'onTap'
+    );
+    await nextTick();
+
+    expect(sequence).toEqual(['update:modelValue']);
+    mounted.app.unmount();
+  });
+
+  it('Slider update:modelValue commit -> nextTick real Form.disabled -> no input/click/change/Form field-change', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const fieldChange = vi.fn();
+    const mounted = mountWithRealForm(
+      disabled,
+      () =>
+        h(LkSlider, {
+          modelValue: 10,
+          prop: 'amount',
+          'onUpdate:modelValue': () => {
+            sequence.push('update:modelValue');
+            disabled.value = true;
+          },
+          onInput: () => sequence.push('input'),
+          onClick: () => sequence.push('click'),
+          onChange: () => sequence.push('change'),
+        }),
+      { onFieldChange: fieldChange }
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-slider__track-container')),
+      'onTap',
+      { detail: { x: 150 }, stopPropagation() {} }
+    );
+    await nextTick();
+
+    expect(sequence).toEqual(['update:modelValue']);
+    expect(fieldChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Slider change -> Form field-change listener delivers disabled -> no later dragend/drag-release', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const fieldChange = vi.fn(() => {
+      sequence.push('field-change');
+      disabled.value = true;
+    });
+    const mounted = mountWithRealForm(
+      disabled,
+      () =>
+        h(LkSlider, {
+          modelValue: 10,
+          prop: 'amount',
+          'onUpdate:modelValue': () => sequence.push('update:modelValue'),
+          onInput: () => sequence.push('input'),
+          onChange: () => sequence.push('change'),
+          onDragend: () => sequence.push('dragend'),
+          onDragRelease: () => sequence.push('drag-release'),
+        }),
+      { onFieldChange: fieldChange }
+    );
+    await nextTick();
+    const track = findNode(mounted.root, node => hasClass(node, 'lk-slider__track-container'));
+
+    await dispatch(track, 'onTouchstart', {
+      touches: [{ clientX: 150 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    await dispatch(track, 'onTouchend', {
+      changedTouches: [{ clientX: 150 }],
+      stopPropagation() {},
+      preventDefault() {},
+    });
+    await nextTick();
+
+    expect(fieldChange).toHaveBeenCalledOnce();
+    expect(sequence).toEqual(['update:modelValue', 'input', 'change', 'field-change']);
+    mounted.app.unmount();
+  });
+
+  it('Calendar update:modelValue commit -> nextTick real Form.disabled -> no select/change', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendar, {
+        modelValue: '2026-08-13',
+        viewDate: '2026-08-01',
+        minDate: '2026-08-01',
+        maxDate: '2026-08-31',
+        'onUpdate:modelValue': () => {
+          sequence.push('update:modelValue');
+          disabled.value = true;
+        },
+        onSelect: () => sequence.push('select'),
+        onChange: () => sequence.push('change'),
+      })
+    );
+    await nextTick();
+    const target = findNode(mounted.root, node => node.props['data-date'] === '2026-08-14');
+
+    await dispatch(target, 'onTap');
+    await nextTick();
+
+    expect(sequence).toEqual(['update:modelValue']);
+    mounted.app.unmount();
+  });
+
+  it('Calendar update:viewDate -> delivered Form.disabled clears switch timers and switching UI', async () => {
+    vi.useFakeTimers();
+    const disabled = ref(false);
+    const updateViewDate = vi.fn(() => {
+      disabled.value = true;
+    });
+    const monthChange = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendar, {
+        modelValue: '',
+        viewDate: '2026-08-01',
+        'onUpdate:viewDate': updateViewDate,
+        onMonthChange: monthChange,
+      })
+    );
+    await nextTick();
+    const gridWrap = findNode(mounted.root, node => hasClass(node, 'lk-calendar__grid-wrap'));
+
+    dispatch(gridWrap, 'onTouchstart', { touches: [{ clientX: 240, clientY: 20 }] });
+    dispatch(gridWrap, 'onTouchmove', { touches: [{ clientX: 20, clientY: 20 }] });
+    dispatch(gridWrap, 'onTouchend');
+    expect(updateViewDate).toHaveBeenCalledOnce();
+
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(400);
+    const grid = findNode(mounted.root, node => hasClass(node, 'lk-calendar__grid'));
+    expect(disabled.value).toBe(true);
+    expect(hasClass(grid, 'is-switching')).toBe(false);
+    expect(hasClass(grid, 'is-switching-next')).toBe(false);
+    expect(monthChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Calendar update:viewDate listener reentrant next supersedes the old panel event chain', async () => {
+    const disabled = ref(false);
+    const viewDate = ref('2026-01-01');
+    let nextPanel: (() => void) | undefined;
+    let reentered = false;
+    const updates: string[] = [];
+    const months: string[] = [];
+    const panels: Array<{ year: number; month: number }> = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(
+        LkCalendar,
+        {
+          viewDate: viewDate.value,
+          'onUpdate:viewDate': (value: string) => {
+            updates.push(value);
+            viewDate.value = value;
+            if (!reentered) {
+              reentered = true;
+              nextPanel?.();
+            }
+          },
+          onMonthChange: (value: string) => months.push(value),
+          onPanelChange: (value: { year: number; month: number }) => panels.push(value),
+        },
+        {
+          header: (slot: { next: () => void }) => {
+            nextPanel = slot.next;
+            return h('calendar-header-stub');
+          },
+        }
+      )
+    );
+    await nextTick();
+
+    nextPanel?.();
+    await flushTicks(10);
+
+    expect(updates).toEqual(['2026-02', '2026-03']);
+    expect(months).toEqual(['2026-03']);
+    expect(panels).toEqual([{ year: 2026, month: 3 }]);
+    mounted.app.unmount();
+  });
+
+  it('Calendar controlled viewDate override after update supersedes all old panel events', async () => {
+    const disabled = ref(false);
+    const viewDate = ref('2026-01-01');
+    let nextPanel: (() => void) | undefined;
+    const monthChange = vi.fn();
+    const weekChange = vi.fn();
+    const panelChange = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(
+        LkCalendar,
+        {
+          viewDate: viewDate.value,
+          'onUpdate:viewDate': () => {
+            viewDate.value = '2030-05-01';
+          },
+          onMonthChange: monthChange,
+          onWeekChange: weekChange,
+          onPanelChange: panelChange,
+        },
+        {
+          header: (slot: { next: () => void }) => {
+            nextPanel = slot.next;
+            return h('calendar-header-stub');
+          },
+        }
+      )
+    );
+    await nextTick();
+
+    nextPanel?.();
+    await flushTicks(8);
+
+    expect(viewDate.value).toBe('2030-05-01');
+    expect(monthChange).not.toHaveBeenCalled();
+    expect(weekChange).not.toHaveBeenCalled();
+    expect(panelChange).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Slider immediate unmount cancels its deferred mount measurement before SelectorQuery', async () => {
+    const createSelectorQuery = vi.fn(() => ({
+      in() {
+        return this;
+      },
+      select() {
+        return this;
+      },
+      boundingClientRect() {
+        return this;
+      },
+      exec() {},
+    }));
+    vi.stubGlobal('uni', { ...uni, createSelectorQuery });
+    const mounted = mountControl(LkSlider, makeForm(), { modelValue: 10 });
+
+    mounted.app.unmount();
+    await flushTicks();
+
+    expect(createSelectorQuery).not.toHaveBeenCalled();
+  });
+
+  it('Picker update:modelValue commit -> nextTick real Form.disabled -> no change/confirm/close', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkPicker, {
+        visible: true,
+        modelValue: 'a',
+        columns: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ],
+        'onUpdate:modelValue': () => {
+          sequence.push('update:modelValue');
+          disabled.value = true;
+        },
+        onChange: () => sequence.push('change'),
+        onConfirm: () => sequence.push('confirm'),
+        'onUpdate:visible': () => sequence.push('update:visible'),
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--confirm')),
+      'onTap'
+    );
+    await nextTick();
+
+    expect(sequence).toEqual(['update:modelValue']);
+    mounted.app.unmount();
+  });
+
+  it('Picker cancel proposal -> nextTick delivered Form.disabled -> closing update remains allowed', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkPicker, {
+        id: 'picker-cancel-host',
+        visible: true,
+        modelValue: 'a',
+        columns: [{ label: 'A', value: 'a' }],
+        onCancel: () => {
+          sequence.push('cancel');
+          disabled.value = true;
+        },
+        'onUpdate:visible': () => {
+          const host = findNode(mounted.root, node => node.props.id === 'picker-cancel-host');
+          sequence.push(`update:visible:${String(host.props['aria-disabled'])}`);
+        },
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--cancel')),
+      'onTap'
+    );
+
+    expect(sequence).toEqual(['cancel', 'update:visible:true']);
+    mounted.app.unmount();
+  });
+
+  it('Picker cancel listener unmount -> no ghost closing update after nextTick', async () => {
+    const disabled = ref(false);
+    const updateVisible = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkPicker, {
+        visible: true,
+        modelValue: 'a',
+        columns: [{ label: 'A', value: 'a' }],
+        onCancel: () => mounted.app.unmount(),
+        'onUpdate:visible': updateVisible,
+      })
+    );
+    await nextTick();
+    const cancel = findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--cancel'));
+
+    await dispatch(cancel, 'onTap');
+
+    expect(updateVisible).not.toHaveBeenCalled();
+  });
+
+  it('Picker confirm listener delivers Form.disabled -> accepted value still closes', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkPicker, {
+        visible: true,
+        modelValue: 'a',
+        columns: [{ label: 'A', value: 'a' }],
+        'onUpdate:modelValue': () => sequence.push('update:modelValue'),
+        onChange: () => sequence.push('change'),
+        onConfirm: () => {
+          sequence.push('confirm');
+          disabled.value = true;
+        },
+        'onUpdate:visible': () => sequence.push('update:visible'),
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--confirm')),
+      'onTap'
+    );
+
+    expect(sequence).toEqual(['update:modelValue', 'change', 'confirm', 'update:visible']);
+    mounted.app.unmount();
+  });
+
+  it('Picker confirm listener unmount -> no ghost closing update', async () => {
+    const disabled = ref(false);
+    const updateVisible = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkPicker, {
+        visible: true,
+        modelValue: 'a',
+        columns: [{ label: 'A', value: 'a' }],
+        onConfirm: () => mounted.app.unmount(),
+        'onUpdate:visible': updateVisible,
+      })
+    );
+    await nextTick();
+    const confirm = findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--confirm'));
+
+    await dispatch(confirm, 'onTap');
+
+    expect(updateVisible).not.toHaveBeenCalled();
+  });
+
+  it('CalendarPicker update:modelValue commit -> nextTick real Form.disabled -> no change/confirm/close', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        show: true,
+        modelValue: '2026-08-13',
+        viewDate: '2026-08-01',
+        minDate: '2026-08-01',
+        maxDate: '2026-08-31',
+        'onUpdate:modelValue': () => {
+          sequence.push('update:modelValue');
+          disabled.value = true;
+        },
+        onChange: () => sequence.push('change'),
+        onConfirm: () => sequence.push('confirm'),
+        onClose: () => sequence.push('close'),
+      })
+    );
+    await nextTick();
+    const footer = findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__footer'));
+    const confirm = findNode(footer, node => node.type === 'button');
+
+    await dispatch(confirm, 'onTap', {});
+    await nextTick();
+
+    expect(sequence).toEqual(['update:modelValue']);
+    mounted.app.unmount();
+  });
+
+  it('CalendarPicker closing update -> nextTick delivered Form.disabled -> close remains allowed', async () => {
+    const disabled = ref(false);
+    const show = ref(true);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        id: 'calendar-picker-close-host',
+        show: show.value,
+        modelValue: '2026-08-13',
+        'onUpdate:show': () => {
+          sequence.push('update:show');
+          disabled.value = true;
+        },
+        onClose: () => {
+          const host = findNode(
+            mounted.root,
+            node => node.props.id === 'calendar-picker-close-host'
+          );
+          sequence.push(`close:${String(host.props['aria-disabled'])}`);
+        },
+      })
+    );
+    await nextTick();
+
+    show.value = false;
+    await nextTick();
+    await nextTick();
+    await Promise.resolve();
+
+    expect(sequence).toEqual(['update:show', 'close:true']);
+    mounted.app.unmount();
+  });
+
+  it('CalendarPicker closing update listener unmount -> no ghost close after nextTick', async () => {
+    const disabled = ref(false);
+    const show = ref(true);
+    const close = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        show: show.value,
+        modelValue: '2026-08-13',
+        'onUpdate:show': () => mounted.app.unmount(),
+        onClose: close,
+      })
+    );
+    await nextTick();
+
+    show.value = false;
+    await nextTick();
+    await nextTick();
+    await Promise.resolve();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('CalendarPicker confirm listener delivers Form.disabled -> accepted value still closes', async () => {
+    const disabled = ref(false);
+    const show = ref(true);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        show: show.value,
+        modelValue: '2026-08-13',
+        viewDate: '2026-08-01',
+        minDate: '2026-08-01',
+        maxDate: '2026-08-31',
+        'onUpdate:modelValue': () => sequence.push('update:modelValue'),
+        onChange: () => sequence.push('change'),
+        onConfirm: () => {
+          sequence.push('confirm');
+          disabled.value = true;
+        },
+        'onUpdate:show': value => {
+          sequence.push(`update:show:${String(value)}`);
+          show.value = value;
+        },
+        onClose: () => sequence.push('close'),
+      })
+    );
+    await nextTick();
+    sequence.length = 0;
+    const footer = findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__footer'));
+
+    await dispatch(
+      findNode(footer, node => node.type === 'button'),
+      'onTap',
+      {}
+    );
+    await nextTick();
+    await nextTick();
+
+    expect(sequence).toEqual([
+      'update:modelValue',
+      'change',
+      'confirm',
+      'update:show:false',
+      'close',
+    ]);
+    mounted.app.unmount();
+  });
+
+  it('CalendarPicker confirm listener unmount -> no ghost closing update/close', async () => {
+    const disabled = ref(false);
+    const updateShow = vi.fn();
+    const close = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        show: true,
+        modelValue: '2026-08-13',
+        onConfirm: () => mounted.app.unmount(),
+        'onUpdate:show': updateShow,
+        onClose: close,
+      })
+    );
+    await nextTick();
+    updateShow.mockClear();
+    const footer = findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__footer'));
+
+    await dispatch(
+      findNode(footer, node => node.type === 'button'),
+      'onTap',
+      {}
+    );
+    await nextTick();
+
+    expect(updateShow).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('Upload clickPreview proposal -> nextTick real Form.disabled -> no native preview', async () => {
+    const disabled = ref(false);
+    const previewImage = vi.spyOn(uni, 'previewImage');
+    const clickPreview = vi.fn(() => {
+      disabled.value = true;
+    });
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        modelValue: [
+          { uid: 'preview', name: 'preview.png', url: 'preview.png', status: 'success' },
+        ],
+        showUpload: false,
+        onClickPreview: clickPreview,
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-upload__item')),
+      'onTap'
+    );
+    await nextTick();
+
+    expect(clickPreview).toHaveBeenCalledOnce();
+    expect(previewImage).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each([
+    { direction: 'open -> controlled close', initial: false, proposed: true },
+    { direction: 'close -> controlled reopen', initial: true, proposed: false },
+  ])('CalendarPicker $direction supersedes the stale show event', async testCase => {
+    const disabled = ref(false);
+    const show = ref(testCase.initial);
+    const open = vi.fn();
+    const close = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkCalendarPicker, {
+        modelValue: '2026-01-01',
+        show: show.value,
+        'onUpdate:show': (value: boolean) => {
+          show.value = value === testCase.proposed ? !value : value;
+        },
+        onOpen: open,
+        onClose: close,
+      })
+    );
+    await nextTick();
+
+    if (testCase.proposed) {
+      await dispatch(
+        findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__trigger')),
+        'onTap'
+      );
+    } else {
+      await dispatch(
+        findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__close')),
+        'onTap'
+      );
+    }
+    await flushTicks(8);
+
+    if (testCase.proposed) expect(open).not.toHaveBeenCalled();
+    else expect(close).not.toHaveBeenCalled();
+    expect(show.value).toBe(testCase.initial);
+    mounted.app.unmount();
+  });
+
+  it('Keyboard input proposal -> nextTick real Form.disabled -> no model commit and id stays on host', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const update = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkKeyboard, {
+        id: 'real-keyboard-host',
+        visible: true,
+        modelValue: '',
+        vibrate: false,
+        onKeyPress: () => sequence.push('key-press'),
+        onInput: () => {
+          sequence.push('input');
+          disabled.value = true;
+        },
+        'onUpdate:modelValue': update,
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => node.props['data-key'] === '1'),
+      'onTap'
+    );
+    await nextTick();
+
+    expect(sequence).toEqual(['key-press', 'input']);
+    expect(update).not.toHaveBeenCalled();
+    expect(
+      findNode(mounted.root, node => node.props.id === 'real-keyboard-host').props['data-disabled']
+    ).toBe('true');
+    mounted.app.unmount();
+  });
+
+  it('Keyboard closing update -> nextTick delivered Form.disabled -> close remains allowed', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkKeyboard, {
+        id: 'keyboard-close-host',
+        visible: true,
+        modelValue: '',
+        showClose: true,
+        'onUpdate:visible': () => {
+          sequence.push('update:visible');
+          disabled.value = true;
+        },
+        onClose: () => {
+          const host = findNode(mounted.root, node => node.props.id === 'keyboard-close-host');
+          sequence.push(`close:${String(host.props['data-disabled'])}`);
+        },
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-keyboard__close')),
+      'onTap'
+    );
+
+    expect(sequence).toEqual(['update:visible', 'close:true']);
+    mounted.app.unmount();
+  });
+
+  it('Keyboard closing update listener unmount -> no ghost close after nextTick', async () => {
+    const disabled = ref(false);
+    const close = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkKeyboard, {
+        visible: true,
+        modelValue: '',
+        showClose: true,
+        'onUpdate:visible': () => mounted.app.unmount(),
+        onClose: close,
+      })
+    );
+    await nextTick();
+    const closeButton = findNode(mounted.root, node => hasClass(node, 'lk-keyboard__close'));
+
+    await dispatch(closeButton, 'onTap');
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('Keyboard confirm listener delivers Form.disabled -> accepted value still closes', async () => {
+    const disabled = ref(false);
+    const sequence: string[] = [];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkKeyboard, {
+        visible: true,
+        modelValue: '123',
+        showConfirm: true,
+        onConfirm: () => {
+          sequence.push('confirm');
+          disabled.value = true;
+        },
+        'onUpdate:visible': value => sequence.push(`update:visible:${String(value)}`),
+        onClose: () => sequence.push('close'),
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-keyboard__done')),
+      'onTap'
+    );
+
+    expect(sequence).toEqual(['confirm', 'update:visible:false', 'close']);
+    mounted.app.unmount();
+  });
+
+  it('Keyboard confirm listener unmount -> no ghost closing update/close', async () => {
+    const disabled = ref(false);
+    const updateVisible = vi.fn();
+    const close = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkKeyboard, {
+        visible: true,
+        modelValue: '123',
+        showConfirm: true,
+        onConfirm: () => mounted.app.unmount(),
+        'onUpdate:visible': updateVisible,
+        onClose: close,
+      })
+    );
+    await nextTick();
+    const confirm = findNode(mounted.root, node => hasClass(node, 'lk-keyboard__done'));
+
+    await dispatch(confirm, 'onTap');
+
+    expect(updateVisible).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('VerifyCode send proposal -> nextTick real Form.disabled -> no countdown and id stays on host', async () => {
+    vi.useFakeTimers();
+    const disabled = ref(false);
+    const send = vi.fn(() => {
+      disabled.value = true;
+    });
+    const countdownEnd = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkVerifyCode, {
+        id: 'real-verify-host',
+        modelValue: '',
+        countdown: true,
+        countdownDuration: 1,
+        onSend: send,
+        onCountdownEnd: countdownEnd,
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-verify-code__countdown-btn')),
+      'onTap'
+    );
+    await nextTick();
+    vi.advanceTimersByTime(2000);
+
+    expect(send).toHaveBeenCalledOnce();
+    expect(countdownEnd).not.toHaveBeenCalled();
+    expect(
+      findNode(mounted.root, node => node.props.id === 'real-verify-host').props['data-disabled']
+    ).toBe('true');
+    mounted.app.unmount();
+  });
+
+  it('VerifyCode exposed setValue/clear stay programmatic under inherited Form.disabled', async () => {
+    const disabled = ref(true);
+    const model = reactive({ code: '' });
+    let verifyApi: { clear: () => void; setValue: (code: string) => void } | null = null;
+    const update = vi.fn((value: string) => {
+      model.code = value;
+    });
+    const finish = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model, disabled: disabled.value },
+        {
+          default: () =>
+            h(LkVerifyCode, {
+              ref: (value: unknown) => {
+                verifyApi = value as typeof verifyApi;
+              },
+              modelValue: model.code,
+              'onUpdate:modelValue': update,
+              onFinish: finish,
+            }),
+        }
+      )
+    );
+    await nextTick();
+
+    verifyApi?.setValue('123456');
+    await nextTick();
+    expect(model.code).toBe('123456');
+    expect(update).toHaveBeenLastCalledWith('123456');
+    expect(finish).toHaveBeenCalledWith('123456');
+
+    verifyApi?.clear();
+    await nextTick();
+    expect(model.code).toBe('');
+    expect(update).toHaveBeenLastCalledWith('');
+    mounted.app.unmount();
+  });
+
+  it('Upload exposed retry/remove/clear/confirm remain programmatic under inherited Form.disabled', async () => {
+    const disabled = ref(true);
+    const model = reactive({ files: [] as UploadFile[] });
+    const files = ref<UploadFile[]>([
+      { uid: 'programmatic-fail', name: 'fail.png', url: 'fail.png', status: 'fail' },
+    ]);
+    let uploadApi: {
+      retryUpload: (index: number) => Promise<void>;
+      removeFile: (index: number) => Promise<void>;
+      clearFiles: () => Promise<void>;
+      confirmRemove: (index: number) => void;
+    } | null = null;
+    let callbacks: { onSuccess: (response: unknown) => Promise<void> } | undefined;
+    const abort = vi.fn();
+    const retry = vi.fn();
+    const deleted = vi.fn();
+    const clear = vi.fn();
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        { model, disabled: disabled.value },
+        {
+          default: () =>
+            h(LkUpload, {
+              ref: (value: unknown) => {
+                uploadApi = value as typeof uploadApi;
+              },
+              modelValue: files.value,
+              action: '/upload',
+              customRequest: (options: { onSuccess: (response: unknown) => Promise<void> }) => {
+                callbacks = options;
+                return { abort };
+              },
+              'onUpdate:modelValue': (value: UploadFile[]) => {
+                files.value = value.map(file => ({ ...file }));
+              },
+              onRetry: retry,
+              onDelete: deleted,
+              onClear: clear,
+            }),
+        }
+      )
+    );
+    await nextTick();
+
+    await uploadApi?.retryUpload(0);
+    expect(callbacks).toBeDefined();
+    expect(retry).toHaveBeenCalledOnce();
+    expect(files.value[0].status).toBe('uploading');
+
+    await uploadApi?.removeFile(0);
+    expect(abort).toHaveBeenCalledOnce();
+    expect(deleted).toHaveBeenCalledOnce();
+    expect(files.value).toEqual([]);
+
+    files.value = [{ uid: 'clear-me', name: 'clear.png', url: 'clear.png', status: 'ready' }];
+    await nextTick();
+    await uploadApi?.clearFiles();
+    expect(clear).toHaveBeenCalledOnce();
+    expect(files.value).toEqual([]);
+
+    files.value = [{ uid: 'confirm-me', name: 'confirm.png', url: 'confirm.png', status: 'ready' }];
+    await nextTick();
+    uploadApi?.confirmRemove(0);
+    await nextTick();
+    expect(findNode(mounted.root, node => node.type === 'lk-modal-stub').props.modelValue).toBe(
+      true
+    );
+    mounted.app.unmount();
+  });
+
+  it('blocks CalendarPicker opening while Form is disabled', () => {
+    const form = makeForm();
+    form.disabled = true;
+    const updateShow = vi.fn();
+    const open = vi.fn();
+    const mounted = mountControl(LkCalendarPicker, form, {
+      modelValue: '',
+      show: false,
+      'onUpdate:show': updateShow,
+      onOpen: open,
+    });
+
+    dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-calendar-picker__trigger')),
+      'onTap'
+    );
+    expect(updateShow).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('blocks SelectList model and business events while Form is disabled', async () => {
+    const form = makeForm();
+    form.disabled = true;
+    const update = vi.fn();
+    const change = vi.fn();
+    const mounted = mountControl(LkSelectList, form, {
+      modelValue: '',
+      options: [{ label: 'A', value: 'a' }],
+      'onUpdate:modelValue': update,
+      onChange: change,
+    });
+    const option = findNode(mounted.root, node => hasClass(node, 'lk-select-list__item'));
+
+    await dispatch(option, 'onTap');
+    expect(update).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+
+    form.disabled = false;
+    await nextTick();
+    await dispatch(option, 'onTap');
+    expect(update).toHaveBeenCalledWith('a');
+    expect(change).toHaveBeenCalledOnce();
+    mounted.app.unmount();
+  });
+
+  it('supersedes a pending Switch beforeChange across disable and re-enable', async () => {
+    const form = makeForm();
+    let resolveBeforeChange: ((value: boolean) => void) | undefined;
+    const update = vi.fn();
+    const cancel = vi.fn();
+    const mounted = mountControl(LkSwitch, form, {
+      modelValue: false,
+      beforeChange: () => new Promise<boolean>(resolve => (resolveBeforeChange = resolve)),
+      'onUpdate:modelValue': update,
+      onChangeCancel: cancel,
+    });
+    const control = findNode(mounted.root, node => node.props.role === 'switch');
+
+    dispatch(control, 'onTap', {});
+    form.disabled = true;
+    form.disabled = false;
+    resolveBeforeChange?.(true);
+    await nextTick();
+    await Promise.resolve();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('invalidates a pending Switch interaction when the component unmounts', async () => {
+    const form = makeForm();
+    let resolveBeforeChange: ((value: boolean) => void) | undefined;
+    const update = vi.fn();
+    const mounted = mountControl(LkSwitch, form, {
+      modelValue: false,
+      prop: 'enabled',
+      beforeChange: () => new Promise<boolean>(resolve => (resolveBeforeChange = resolve)),
+      'onUpdate:modelValue': update,
+    });
+    const control = findNode(mounted.root, node => node.props.role === 'switch');
+
+    dispatch(control, 'onTap', {});
+    mounted.app.unmount();
+    resolveBeforeChange?.(true);
+    await Promise.resolve();
+    await nextTick();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(form.emitFieldChange).not.toHaveBeenCalled();
+  });
+
+  it('Switch click-listener reentry supersedes the older chain before async beforeChange', async () => {
+    const form = makeForm();
+    const winner = deferred<boolean>();
+    const beforeChange = vi.fn(() => winner.promise);
+    const update = vi.fn();
+    const change = vi.fn();
+    let reentered = false;
+    let nested: Promise<void> | undefined;
+    const mounted = mountControl(LkSwitch, form, {
+      modelValue: false,
+      prop: 'enabled',
+      beforeChange,
+      onClick: () => {
+        if (reentered) return;
+        reentered = true;
+        nested = dispatch(
+          findNode(mounted.root, node => node.props.role === 'switch'),
+          'onTap',
+          {}
+        ) as Promise<void>;
+      },
+      'onUpdate:modelValue': update,
+      onChange: change,
+    });
+    const control = findNode(mounted.root, node => node.props.role === 'switch');
+
+    const older = dispatch(control, 'onTap', {}) as Promise<void>;
+    await vi.waitFor(() => expect(beforeChange).toHaveBeenCalledTimes(1));
+
+    winner.resolve(true);
+    await nested;
+    await older;
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(form.emitFieldChange).toHaveBeenCalledTimes(1);
+    mounted.app.unmount();
+  });
+
+  it('does not revive a Stepper long press after a listener disables and re-enables Form', async () => {
+    vi.useFakeTimers();
+    const form = makeForm();
+    const update = vi.fn();
+    const mounted = mountControl(LkStepper, form, {
+      modelValue: 1,
+      longPress: true,
+      onBeforeChange: () => {
+        form.disabled = true;
+      },
+      'onUpdate:modelValue': update,
+    });
+    const plus = findNode(mounted.root, node => hasClass(node, 'lk-stepper__plus'));
+
+    dispatch(plus, 'onTouchstartPassive', {});
+    form.disabled = false;
+    await nextTick();
+    vi.advanceTimersByTime(1200);
+
+    expect(update).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Stepper latest beforeChange run wins when two async proposals resolve newer then older', async () => {
+    const form = makeForm();
+    const first = deferred<boolean>();
+    const second = deferred<boolean>();
+    const beforeChange = vi
+      .fn<() => Promise<boolean>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    const update = vi.fn();
+    const change = vi.fn();
+    const plus = vi.fn();
+    const mounted = mountControl(LkStepper, form, {
+      modelValue: 1,
+      beforeChange,
+      'onUpdate:modelValue': update,
+      onChange: change,
+      onPlus: plus,
+      prop: 'count',
+    });
+    const plusButton = findNode(mounted.root, node => hasClass(node, 'lk-stepper__plus'));
+
+    const older = dispatch(plusButton, 'onTap', { stopPropagation() {} }) as Promise<void>;
+    await vi.waitFor(() => expect(beforeChange).toHaveBeenCalledTimes(1));
+    const newer = dispatch(plusButton, 'onTap', { stopPropagation() {} }) as Promise<void>;
+    await vi.waitFor(() => expect(beforeChange).toHaveBeenCalledTimes(2));
+
+    second.resolve(true);
+    await newer;
+    first.resolve(true);
+    await older;
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(2);
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(plus).toHaveBeenCalledTimes(1);
+    expect(form.emitFieldChange).toHaveBeenCalledTimes(1);
+    mounted.app.unmount();
+  });
+
+  it('Slider touchend invalidates a touchstart still awaiting selector measurement', async () => {
+    const form = makeForm();
+    const update = vi.fn();
+    const dragStart = vi.fn();
+    const mounted = mountControl(LkSlider, form, {
+      modelValue: 10,
+      'onUpdate:modelValue': update,
+      onDragstart: dragStart,
+    });
+    await nextTick();
+
+    let resolveRect: ((rect: { left: number; width: number }) => void) | undefined;
+    const currentUni = uni;
+    vi.stubGlobal('uni', {
+      ...currentUni,
+      createSelectorQuery: () => ({
+        in() {
+          return this;
+        },
+        select() {
+          return this;
+        },
+        boundingClientRect(callback: (rect: { left: number; width: number }) => void) {
+          resolveRect = callback;
+          return this;
+        },
+        exec() {},
+      }),
+    });
+    const track = findNode(mounted.root, node => hasClass(node, 'lk-slider__track-container'));
+
+    const pendingStart = dispatch(track, 'onTouchstart', {
+      touches: [{ clientX: 150 }],
+      stopPropagation() {},
+      preventDefault() {},
+    }) as Promise<void>;
+    await dispatch(track, 'onTouchend', { stopPropagation() {}, preventDefault() {} });
+    resolveRect?.({ left: 0, width: 300 });
+    await pendingStart;
+
+    expect(update).not.toHaveBeenCalled();
+    expect(dragStart).not.toHaveBeenCalled();
+    expect(
+      hasClass(
+        findNode(mounted.root, node => hasClass(node, 'lk-slider')),
+        'is-dragging'
+      )
+    ).toBe(false);
+    mounted.app.unmount();
+  });
+
+  it('Slider reentrant track click supersedes the older post-update event chain', async () => {
+    const disabled = ref(false);
+    const model = reactive({ volume: 10 });
+    const sequence: string[] = [];
+    let reentered = false;
+    let nested: Promise<void> | undefined;
+    const mounted = mountRender(makeForm(), () =>
+      h(
+        LkForm,
+        {
+          model,
+          disabled: disabled.value,
+          onFieldChange: (_prop: string, value: number) => sequence.push(`form:${value}`),
+        },
+        {
+          default: () =>
+            h(LkSlider, {
+              modelValue: model.volume,
+              prop: 'volume',
+              'onUpdate:modelValue': (value: number) => {
+                sequence.push(`update:${value}`);
+                if (!reentered) {
+                  reentered = true;
+                  nested = dispatch(
+                    findNode(mounted.root, node => hasClass(node, 'lk-slider__track-container')),
+                    'onTap',
+                    {
+                      detail: { x: 240 },
+                      stopPropagation() {},
+                    }
+                  ) as Promise<void>;
+                }
+              },
+              onInput: (value: number) => sequence.push(`input:${value}`),
+              onClick: (value: number) => sequence.push(`click:${value}`),
+              onChange: (value: number) => sequence.push(`change:${value}`),
+            }),
+        }
+      )
+    );
+    await nextTick();
+    const track = findNode(mounted.root, node => hasClass(node, 'lk-slider__track-container'));
+
+    const older = dispatch(track, 'onTap', {
+      detail: { x: 60 },
+      stopPropagation() {},
+    }) as Promise<void>;
+    await older;
+    await nested;
+    await nextTick();
+
+    // Controlled parent intentionally ignores both updates; the winning local run must still own
+    // every later event and must not be clobbered by the stale first run's continuation.
+    expect(model.volume).toBe(10);
+    expect(sequence).toEqual([
+      'update:20',
+      'update:80',
+      'input:80',
+      'click:80',
+      'change:80',
+      'form:80',
+    ]);
+    mounted.app.unmount();
+  });
+
+  it('cancels Calendar swipe generations without emitting panel changes', async () => {
+    const form = makeForm();
+    const updateViewDate = vi.fn();
+    const mounted = mountControl(LkCalendar, form, {
+      modelValue: '',
+      viewDate: '2026-08-01',
+      'onUpdate:viewDate': updateViewDate,
+    });
+    const grid = findNode(mounted.root, node => hasClass(node, 'lk-calendar__grid-wrap'));
+
+    dispatch(grid, 'onTouchstart', { touches: [{ clientX: 200, clientY: 20 }] });
+    form.disabled = true;
+    form.disabled = false;
+    await nextTick();
+    dispatch(grid, 'onTouchmove', { touches: [{ clientX: 20, clientY: 20 }] });
+    dispatch(grid, 'onTouchend');
+
+    expect(updateViewDate).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('keeps Picker cancel available while blocking selection and confirm', async () => {
+    const form = makeForm();
+    form.disabled = true;
+    const pick = vi.fn();
+    const confirm = vi.fn();
+    const visible = vi.fn();
+    const mounted = mountControl(LkPicker, form, {
+      visible: true,
+      columns: [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ],
+      modelValue: 'a',
+      onPick: pick,
+      onConfirm: confirm,
+      'onUpdate:visible': visible,
+    });
+    await nextTick();
+    const secondItem = findNodes(mounted.root, node => hasClass(node, 'lk-picker__item'))[1];
+    expect(secondItem).toBeDefined();
+    const confirmButton = findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--confirm'));
+    const cancelButton = findNode(mounted.root, node => hasClass(node, 'lk-picker__btn--cancel'));
+
+    dispatch(secondItem, 'onTap');
+    dispatch(confirmButton, 'onTap');
+    expect(pick).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    await dispatch(cancelButton, 'onTap');
+    expect(visible).toHaveBeenCalledWith(false);
+    mounted.app.unmount();
+  });
+
+  it('blocks Keyboard values and confirm but preserves close', async () => {
+    const form = makeForm();
+    form.disabled = true;
+    const update = vi.fn();
+    const confirm = vi.fn();
+    const close = vi.fn();
+    const mounted = mountControl(LkKeyboard, form, {
+      visible: true,
+      modelValue: '',
+      showClose: true,
+      showConfirm: true,
+      'onUpdate:modelValue': update,
+      onConfirm: confirm,
+      onClose: close,
+    });
+    const key = findNode(mounted.root, node => hasClass(node, 'lk-keyboard__key'));
+    const confirmButton = findNode(mounted.root, node => hasClass(node, 'lk-keyboard__done'));
+    const closeButton = findNode(mounted.root, node => hasClass(node, 'lk-keyboard__close'));
+
+    dispatch(key, 'onTap');
+    dispatch(confirmButton, 'onTap');
+    expect(update).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    await dispatch(closeButton, 'onTap');
+    expect(close).toHaveBeenCalledOnce();
+    mounted.app.unmount();
+  });
+
+  it('stops VerifyCode countdown when send synchronously disables Form', () => {
+    vi.useFakeTimers();
+    const form = makeForm();
+    const countdownEnd = vi.fn();
+    const mounted = mountControl(LkVerifyCode, form, {
+      modelValue: '',
+      countdown: true,
+      countdownDuration: 1,
+      onSend: () => {
+        form.disabled = true;
+      },
+      onCountdownEnd: countdownEnd,
+    });
+    const countdown = findNode(mounted.root, node =>
+      hasClass(node, 'lk-verify-code__countdown-btn')
+    );
+
+    dispatch(countdown, 'onTap');
+    vi.advanceTimersByTime(2000);
+    expect(countdownEnd).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Upload uploading update -> controlled parent removes uid -> no request factory or change', async () => {
+    const disabled = ref(false);
+    const files = ref<UploadFile[]>([
+      { uid: 'cancel-before-request', name: 'cancel.png', url: 'cancel.png', status: 'fail' },
+    ]);
+    let uploadApi: { retryUpload: (index: number) => Promise<void> } | null = null;
+    const customRequest = vi.fn();
+    const change = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        action: '/upload',
+        customRequest,
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          if (value[0]?.status === 'uploading') files.value = [];
+        },
+        onChange: change,
+      })
+    );
+    await nextTick();
+
+    await uploadApi?.retryUpload(0);
+    await nextTick();
+
+    expect(files.value).toEqual([]);
+    expect(customRequest).not.toHaveBeenCalled();
+    expect(change).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Upload success update -> controlled parent removes uid -> no ghost change/success', async () => {
+    const disabled = ref(false);
+    const files = ref<UploadFile[]>([
+      { uid: 'cancel-at-success', name: 'success.png', url: 'success.png', status: 'fail' },
+    ]);
+    let uploadApi: { retryUpload: (index: number) => Promise<void> } | null = null;
+    let callbacks: { onSuccess: (response: unknown) => Promise<void> } | undefined;
+    const abort = vi.fn();
+    const changes: string[] = [];
+    const success = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        action: '/upload',
+        customRequest: (options: NonNullable<typeof callbacks>) => {
+          callbacks = options;
+          return { abort };
+        },
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          if (value[0]?.status === 'success') files.value = [];
+          else files.value = value.map(file => ({ ...file }));
+        },
+        onChange: (value: UploadFile[]) => changes.push(value[0]?.status || 'empty'),
+        onSuccess: success,
+      })
+    );
+    await nextTick();
+
+    await uploadApi?.retryUpload(0);
+    expect(callbacks).toBeDefined();
+    expect(changes).toEqual(['uploading']);
+
+    await callbacks?.onSuccess({ ok: true });
+    await nextTick();
+
+    expect(files.value).toEqual([]);
+    expect(abort).toHaveBeenCalledOnce();
+    expect(changes).toEqual(['uploading']);
+    expect(success).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it('Upload afterRead mutates component-owned files, publishes them, and feeds customRequest without touching parent inputs', async () => {
+    let chooseSuccess:
+      | ((result: {
+          tempFilePaths: string[];
+          tempFiles: Array<{ size: number; name: string; type: string }>;
+        }) => void)
+      | undefined;
+    vi.stubGlobal('uni', {
+      ...uni,
+      chooseImage: (options: { success: typeof chooseSuccess }) => {
+        chooseSuccess = options.success;
+      },
+    });
+    const disabled = ref(false);
+    const initial: UploadFile = {
+      uid: 'parent-seed',
+      name: 'seed.png',
+      url: 'seed.png',
+      status: 'ready',
+      progress: 12,
+    };
+    const snapshot = { ...initial };
+    const files = ref<UploadFile[]>([initial]);
+    let uploadApi: { chooseFile: () => Promise<void> } | null = null;
+    let requestFile: UploadFile | undefined;
+    const afterRead = vi.fn((target: UploadFile | UploadFile[]) => {
+      const file = Array.isArray(target) ? target[0] : target;
+      file.url = 'processed://selected.png';
+      file.message = 'processed';
+    });
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        action: '/upload',
+        afterRead,
+        customRequest: (options: { file: UploadFile }) => {
+          requestFile = options.file;
+        },
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          files.value = value.map(file => ({ ...file }));
+        },
+      })
+    );
+    await nextTick();
+
+    await uploadApi?.chooseFile();
+    expect(chooseSuccess).toBeTypeOf('function');
+    chooseSuccess?.({
+      tempFilePaths: ['selected.png'],
+      tempFiles: [{ size: 10, name: 'selected.png', type: 'image/png' }],
+    });
+    await flushTicks(30);
+
+    expect(initial).toEqual(snapshot);
+    expect(files.value[0]).not.toBe(initial);
+    expect(afterRead).toHaveBeenCalledOnce();
+    expect(requestFile).toBeDefined();
+    expect(requestFile).not.toBe(initial);
+    expect(requestFile?.url).toBe('processed://selected.png');
+    expect(files.value.find(file => file.uid === requestFile?.uid)).toMatchObject({
+      url: 'processed://selected.png',
+      message: expect.stringMatching(/upload|上传/i),
+      status: 'uploading',
+    });
+    mounted.app.unmount();
+  });
+
+  it('Upload controlled parent removes the selected uid at first update -> no afterRead hook or request', async () => {
+    let chooseSuccess:
+      | ((result: {
+          tempFilePaths: string[];
+          tempFiles: Array<{ size: number; name: string; type: string }>;
+        }) => void)
+      | undefined;
+    vi.stubGlobal('uni', {
+      ...uni,
+      chooseImage: (options: { success: typeof chooseSuccess }) => {
+        chooseSuccess = options.success;
+      },
+    });
+    const disabled = ref(false);
+    const files = ref<UploadFile[]>([]);
+    let uploadApi: { chooseFile: () => Promise<void> } | null = null;
+    const afterRead = vi.fn();
+    const customRequest = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        action: '/upload',
+        afterRead,
+        customRequest,
+        'onUpdate:modelValue': () => {
+          files.value = [];
+        },
+      })
+    );
+    await nextTick();
+
+    await uploadApi?.chooseFile();
+    chooseSuccess?.({
+      tempFilePaths: ['rejected.png'],
+      tempFiles: [{ size: 10, name: 'rejected.png', type: 'image/png' }],
+    });
+    await flushTicks(12);
+
+    expect(files.value).toEqual([]);
+    expect(afterRead).not.toHaveBeenCalled();
+    expect(customRequest).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each(['success', 'fail'] as const)(
+    'Upload same-stack progress -> %s lets only the terminal stage publish after uploading',
+    async terminal => {
+      const disabled = ref(false);
+      const files = ref<UploadFile[]>([
+        { uid: `stage-${terminal}`, name: 'stage.png', url: 'stage.png', status: 'fail' },
+      ]);
+      let uploadApi: { retryUpload: (index: number) => Promise<void> } | null = null;
+      const updates: string[] = [];
+      const changes: string[] = [];
+      const success = vi.fn();
+      const fail = vi.fn();
+      const mounted = mountWithRealForm(disabled, () =>
+        h(LkUpload, {
+          ref: (value: unknown) => {
+            uploadApi = value as typeof uploadApi;
+          },
+          modelValue: files.value,
+          action: '/upload',
+          customRequest: (options: {
+            onProgress: (progress: number) => void;
+            onSuccess: (response: unknown) => void;
+            onFail: (error: unknown) => void;
+          }) => {
+            options.onProgress(50);
+            if (terminal === 'success') options.onSuccess({ ok: true });
+            else options.onFail(new Error('failed'));
+          },
+          'onUpdate:modelValue': (value: UploadFile[]) => {
+            updates.push(value[0]?.status || 'empty');
+            files.value = value.map(file => ({ ...file }));
+          },
+          onChange: (value: UploadFile[]) => changes.push(value[0]?.status || 'empty'),
+          onSuccess: success,
+          onFail: fail,
+        })
+      );
+      await nextTick();
+
+      await uploadApi?.retryUpload(0);
+      await flushTicks(12);
+
+      expect(updates).toEqual(['uploading', terminal]);
+      expect(changes).toEqual(['uploading', terminal]);
+      expect(success).toHaveBeenCalledTimes(terminal === 'success' ? 1 : 0);
+      expect(fail).toHaveBeenCalledTimes(terminal === 'fail' ? 1 : 0);
+      expect(files.value[0].progress).toBe(terminal === 'success' ? 100 : 50);
+      mounted.app.unmount();
+    }
+  );
+
+  it('Upload fail listener retries same uid -> stale autoRemove never deletes the new attempt', async () => {
+    vi.useFakeTimers();
+    const disabled = ref(false);
+    const files = ref<UploadFile[]>([
+      { uid: 'retry-after-fail', name: 'retry.png', url: 'retry.png', status: 'fail' },
+    ]);
+    let uploadApi: { retryUpload: (index: number) => Promise<void> } | null = null;
+    const callbacks: Array<{
+      onFail: (error: unknown) => void;
+      onSuccess: (value: unknown) => void;
+    }> = [];
+    const aborts = [vi.fn(), vi.fn()];
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        action: '/upload',
+        autoRemoveFail: true,
+        customRequest: (options: {
+          onFail: (error: unknown) => void;
+          onSuccess: (value: unknown) => void;
+        }) => {
+          const index = callbacks.length;
+          callbacks.push(options);
+          return { abort: aborts[index] };
+        },
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          files.value = value.map(file => ({ ...file }));
+        },
+        onFail: () => {
+          void uploadApi?.retryUpload(0);
+        },
+      })
+    );
+    await nextTick();
+
+    await uploadApi?.retryUpload(0);
+    await callbacks[0].onFail(new Error('first failed'));
+    await flushTicks(20);
+    expect(callbacks).toHaveLength(2);
+    expect(files.value[0].status).toBe('uploading');
+    vi.advanceTimersByTime(2000);
+    await flushTicks();
+    expect(files.value).toHaveLength(1);
+    expect(files.value[0].status).toBe('uploading');
+    expect(aborts[1]).not.toHaveBeenCalled();
+
+    callbacks[1].onSuccess({ ok: true });
+    await flushTicks();
+    vi.advanceTimersByTime(2000);
+    expect(files.value).toHaveLength(1);
+    expect(files.value[0].status).toBe('success');
+    mounted.app.unmount();
+  });
+
+  it.each(['reorder', 'removed'] as const)(
+    'Upload removeFile keeps uid ownership when parent list is %s during beforeDelete',
+    async scenario => {
+      const disabled = ref(false);
+      const decision = deferred<boolean>();
+      const a: UploadFile = { uid: 'delete-a', name: 'a.png', url: 'a.png', status: 'ready' };
+      const b: UploadFile = { uid: 'delete-b', name: 'b.png', url: 'b.png', status: 'ready' };
+      const files = ref<UploadFile[]>([a, b]);
+      let uploadApi: { removeFile: (index: number) => Promise<void> } | null = null;
+      const updates = vi.fn((value: UploadFile[]) => {
+        files.value = value.map(file => ({ ...file }));
+      });
+      const deleted = vi.fn();
+      const mounted = mountWithRealForm(disabled, () =>
+        h(LkUpload, {
+          ref: (value: unknown) => {
+            uploadApi = value as typeof uploadApi;
+          },
+          modelValue: files.value,
+          beforeDelete: () => decision.promise,
+          'onUpdate:modelValue': updates,
+          onDelete: deleted,
+        })
+      );
+      await nextTick();
+
+      const removal = uploadApi?.removeFile(0);
+      files.value = scenario === 'reorder' ? [b, a] : [b];
+      await nextTick();
+      decision.resolve(true);
+      await removal;
+      await flushTicks();
+
+      expect(files.value.map(file => file.uid)).toEqual(['delete-b']);
+      if (scenario === 'reorder') {
+        expect(deleted).toHaveBeenCalledWith(expect.objectContaining({ uid: 'delete-a' }), {
+          index: 1,
+        });
+      } else {
+        expect(updates).not.toHaveBeenCalled();
+        expect(deleted).not.toHaveBeenCalled();
+      }
+      mounted.app.unmount();
+    }
+  );
+
+  it('Upload confirmRemove stores uid so parent reorder cannot redirect deletion by index', async () => {
+    const disabled = ref(false);
+    const a: UploadFile = { uid: 'confirm-a', name: 'a.png', url: 'a.png', status: 'ready' };
+    const b: UploadFile = { uid: 'confirm-b', name: 'b.png', url: 'b.png', status: 'ready' };
+    const files = ref<UploadFile[]>([a, b]);
+    let uploadApi: { confirmRemove: (index: number) => void } | null = null;
+    const deleted = vi.fn();
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        ref: (value: unknown) => {
+          uploadApi = value as typeof uploadApi;
+        },
+        modelValue: files.value,
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          files.value = value.map(file => ({ ...file }));
+        },
+        onDelete: deleted,
+      })
+    );
+    await nextTick();
+
+    uploadApi?.confirmRemove(0);
+    files.value = [b, a];
+    await nextTick();
+    await dispatch(
+      findNode(mounted.root, node => node.type === 'lk-modal-stub'),
+      'onConfirm'
+    );
+    await flushTicks();
+
+    expect(files.value.map(file => file.uid)).toEqual(['confirm-b']);
+    expect(deleted).toHaveBeenCalledWith(expect.objectContaining({ uid: 'confirm-a' }), {
+      index: 1,
+    });
+    mounted.app.unmount();
+  });
+
+  it('Upload clickPreview listener removes target uid -> no stale native preview', async () => {
+    const previewImage = vi.fn();
+    vi.stubGlobal('uni', { ...uni, previewImage });
+    const disabled = ref(false);
+    const files = ref<UploadFile[]>([
+      { uid: 'preview-a', name: 'a.png', url: 'a.png', status: 'ready' },
+      { uid: 'preview-b', name: 'b.png', url: 'b.png', status: 'ready' },
+    ]);
+    const mounted = mountWithRealForm(disabled, () =>
+      h(LkUpload, {
+        modelValue: files.value,
+        onClickPreview: (file: UploadFile) => {
+          files.value = files.value.filter(item => item.uid !== file.uid);
+        },
+      })
+    );
+    await nextTick();
+
+    await dispatch(
+      findNode(mounted.root, node => hasClass(node, 'lk-upload__item')),
+      'onTap'
+    );
+    await flushTicks();
+
+    expect(files.value.map(file => file.uid)).toEqual(['preview-b']);
+    expect(previewImage).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+
+  it.each(['progress', 'success', 'fail', 'disabled rollback'] as const)(
+    'Upload %s keeps a controlled parent object immutable when update:modelValue is ignored',
+    async scenario => {
+      const disabled = ref(false);
+      const initial: UploadFile = {
+        uid: `immutable-${scenario}`,
+        name: 'immutable.png',
+        url: 'immutable.png',
+        status: 'fail',
+        progress: 17,
+        message: 'seed failure',
+        response: { seed: true },
+      };
+      const snapshot: UploadFile = {
+        ...initial,
+        response: { seed: true },
+      };
+      const controlled = [initial];
+      const updates: UploadFile[][] = [];
+      let uploadApi: { retryUpload: (index: number) => Promise<void> } | null = null;
+      let requestFile: UploadFile | undefined;
+      let customCallbacks:
+        | {
+            onProgress: (progress: number) => Promise<void>;
+            onSuccess: (response: unknown) => Promise<void>;
+            onFail: (error: unknown) => Promise<void>;
+          }
+        | undefined;
+      const mounted = mountWithRealForm(disabled, () =>
+        h(LkUpload, {
+          ref: (value: unknown) => {
+            uploadApi = value as typeof uploadApi;
+          },
+          modelValue: controlled,
+          action: '/upload',
+          previewImage: false,
+          customRequest: (options: {
+            file: UploadFile;
+            onProgress: (progress: number) => Promise<void>;
+            onSuccess: (response: unknown) => Promise<void>;
+            onFail: (error: unknown) => Promise<void>;
+          }) => {
+            requestFile = options.file;
+            customCallbacks = options;
+          },
+          'onUpdate:modelValue': (value: UploadFile[]) => {
+            updates.push(value);
+            // Intentionally ignore the controlled update.
+          },
+        })
+      );
+      await nextTick();
+
+      await uploadApi?.retryUpload(0);
+
+      expect(customCallbacks).toBeDefined();
+      expect(requestFile).not.toBe(initial);
+      expect(initial).toEqual(snapshot);
+
+      if (scenario === 'progress') await customCallbacks?.onProgress(63);
+      if (scenario === 'success') await customCallbacks?.onSuccess({ ok: true });
+      if (scenario === 'fail') await customCallbacks?.onFail(new Error('network'));
+      if (scenario === 'disabled rollback') {
+        disabled.value = true;
+        await nextTick();
+      }
+
+      expect(controlled).toEqual([snapshot]);
+      expect(controlled[0]).toBe(initial);
+      expect(initial).toEqual(snapshot);
+      expect(updates.length).toBeGreaterThan(0);
+      expect(updates.every(value => value[0] !== initial)).toBe(true);
+      mounted.app.unmount();
+    }
+  );
+
+  it.each(['customRequest', 'uni.uploadFile'] as const)(
+    'Upload exposed removeFile aborts %s once and ignores every late callback',
+    async transport => {
+      const form = makeForm();
+      const files = ref<UploadFile[]>([
+        { uid: `remove-${transport}`, name: 'remove.png', url: 'remove.png', status: 'fail' },
+      ]);
+      const abort = vi.fn();
+      let callbacks:
+        | {
+            onProgress: (progress: number) => Promise<void>;
+            onSuccess: (response: unknown) => Promise<void>;
+            onFail: (error: unknown) => Promise<void>;
+          }
+        | undefined;
+      let native:
+        | {
+            success: (response: { data: unknown }) => Promise<void>;
+            fail: (error: unknown) => Promise<void>;
+          }
+        | undefined;
+      let nativeProgress: ((response: { progress: number }) => Promise<void>) | undefined;
+      if (transport === 'uni.uploadFile') {
+        vi.stubGlobal('uni', {
+          ...uni,
+          uploadFile: vi.fn(options => {
+            native = options;
+            return {
+              abort,
+              onProgressUpdate(callback: (response: { progress: number }) => Promise<void>) {
+                nativeProgress = callback;
+              },
+            };
+          }),
+        });
+      }
+      const updates: UploadFile[][] = [];
+      const change = vi.fn();
+      const progress = vi.fn();
+      const success = vi.fn();
+      const fail = vi.fn();
+      const deleted = vi.fn();
+      const mounted = mountControl(LkUpload, form, () => ({
+        modelValue: files.value,
+        action: '/upload',
+        customRequest:
+          transport === 'customRequest'
+            ? (options: NonNullable<typeof callbacks>) => {
+                callbacks = options;
+                return { abort };
+              }
+            : undefined,
+        'onUpdate:modelValue': (value: UploadFile[]) => {
+          files.value = value.map(file => ({ ...file }));
+          updates.push(files.value);
+        },
+        onChange: change,
+        onProgress: progress,
+        onSuccess: success,
+        onFail: fail,
+        onDelete: deleted,
+      }));
+
+      await mounted.exposed()?.retryUpload(0 as never);
+      await nextTick();
+      await mounted.exposed()?.removeFile(0 as never);
+      await nextTick();
+      expect(files.value).toEqual([]);
+      expect(abort).toHaveBeenCalledOnce();
+      expect(deleted).toHaveBeenCalledOnce();
+      const counts = {
+        updates: updates.length,
+        change: change.mock.calls.length,
+        progress: progress.mock.calls.length,
+        success: success.mock.calls.length,
+        fail: fail.mock.calls.length,
+      };
+
+      if (callbacks) {
+        await callbacks.onProgress(82);
+        await callbacks.onSuccess({ ok: true });
+        await callbacks.onFail(new Error('late'));
+      }
+      if (native) {
+        await nativeProgress?.({ progress: 82 });
+        await native.success({ data: { ok: true } });
+        await native.fail(new Error('late'));
+      }
+
+      expect(files.value).toEqual([]);
+      expect(updates).toHaveLength(counts.updates);
+      expect(change).toHaveBeenCalledTimes(counts.change);
+      expect(progress).toHaveBeenCalledTimes(counts.progress);
+      expect(success).toHaveBeenCalledTimes(counts.success);
+      expect(fail).toHaveBeenCalledTimes(counts.fail);
+      mounted.app.unmount();
+    }
+  );
+
+  it('Upload progress listener reentrant remove claims cancellation before removal events', async () => {
+    const form = makeForm();
+    const files = ref<UploadFile[]>([
+      { uid: 'progress-remove', name: 'remove.png', url: 'remove.png', status: 'fail' },
+    ]);
+    const abort = vi.fn();
+    let callbacks:
+      | {
+          onProgress: (progress: number) => Promise<void>;
+          onSuccess: (response: unknown) => Promise<void>;
+          onFail: (error: unknown) => Promise<void>;
+        }
+      | undefined;
+    const changes: UploadFile[][] = [];
+    let uploadApi: {
+      retryUpload: (index: number) => Promise<void>;
+      removeFile: (index: number) => Promise<void>;
+    } | null = null;
+    const mounted = mountControl(LkUpload, form, () => ({
+      modelValue: files.value,
+      action: '/upload',
+      customRequest: (options: NonNullable<typeof callbacks>) => {
+        callbacks = options;
+        return { abort };
+      },
+      'onUpdate:modelValue': (value: UploadFile[]) => {
+        files.value = value.map(file => ({ ...file }));
+      },
+      onChange: (value: UploadFile[]) => changes.push(value),
+      onProgress: () => {
+        void uploadApi?.removeFile(0);
+      },
+    }));
+    uploadApi = mounted.exposed() as typeof uploadApi;
+
+    await uploadApi?.retryUpload(0);
+    const pendingProgress = callbacks?.onProgress(45);
+    await pendingProgress;
+    await nextTick();
+    await Promise.resolve();
+
+    expect(files.value).toEqual([]);
+    expect(abort).toHaveBeenCalledOnce();
+    expect(changes.at(-1)).toEqual([]);
+    const changeCount = changes.length;
+    await callbacks?.onSuccess({ late: true });
+    expect(changes).toHaveLength(changeCount);
+    mounted.app.unmount();
+  });
+
+  it('rolls controlled Upload clones back to ready when disabled mid-flight', async () => {
+    const form = makeForm();
+    const initial: UploadFile = {
+      uid: 'file-1',
+      name: 'file.png',
+      url: 'file.png',
+      status: 'fail',
+      progress: 20,
+      message: 'failed',
+    };
+    const parentFiles = ref([initial]);
+    let customCallbacks: { onSuccess: (value: unknown) => void } | undefined;
+    const updates: UploadFile[][] = [];
+    const change = vi.fn();
+    const mounted = mountControl(LkUpload, form, () => ({
+      modelValue: parentFiles.value,
+      action: '/upload',
+      customRequest: (options: { onSuccess: (value: unknown) => void }) => {
+        customCallbacks = options;
+      },
+      'onUpdate:modelValue': (value: UploadFile[]) => {
+        parentFiles.value = value.map(file => ({ ...file }));
+        updates.push(parentFiles.value);
+      },
+      onChange: change,
+    }));
+
+    await mounted.exposed()?.retryUpload(0 as never);
+    await nextTick();
+    expect(updates.at(-1)?.[0].status).toBe('uploading');
+    expect(parentFiles.value[0]).not.toBe(initial);
+
+    form.disabled = true;
+    await nextTick();
+    expect(updates.at(-1)?.[0]).toMatchObject({
+      uid: 'file-1',
+      status: 'fail',
+      progress: 20,
+      message: 'failed',
+    });
+    const updateCount = updates.length;
+    const changeCount = change.mock.calls.length;
+    await customCallbacks?.onSuccess({ ok: true });
+    expect(updates).toHaveLength(updateCount);
+    expect(change).toHaveBeenCalledTimes(changeCount);
+    mounted.app.unmount();
+  });
+
+  it('does not schedule Upload auto-removal after a fail listener delivers Form.disabled', async () => {
+    vi.useFakeTimers();
+    const form = makeForm();
+    const parentFiles = ref<UploadFile[]>([
+      { uid: 'file-2', name: 'retry.png', url: 'retry.png', status: 'fail' },
+    ]);
+    let customCallbacks: { onFail: (error: unknown) => void } | undefined;
+    const mounted = mountControl(LkUpload, form, () => ({
+      modelValue: parentFiles.value,
+      action: '/upload',
+      autoRemoveFail: true,
+      customRequest: (options: { onFail: (error: unknown) => void }) => {
+        customCallbacks = options;
+      },
+      'onUpdate:modelValue': (value: UploadFile[]) => {
+        parentFiles.value = value.map(file => ({ ...file }));
+      },
+      onFail: () => {
+        form.disabled = true;
+      },
+    }));
+
+    await mounted.exposed()?.retryUpload(0 as never);
+    await customCallbacks?.onFail(new Error('failed'));
+    await nextTick();
+    vi.advanceTimersByTime(2000);
+
+    expect(parentFiles.value).toHaveLength(1);
+    expect(parentFiles.value[0].status).toBe('fail');
+    mounted.app.unmount();
+  });
+
+  it('closes a pending Upload delete confirmation when Form becomes disabled', async () => {
+    const form = makeForm();
+    const files = ref<UploadFile[]>([
+      { uid: 'file-delete', name: 'delete.png', url: 'delete.png', status: 'ready' },
+    ]);
+    const update = vi.fn((value: UploadFile[]) => {
+      files.value = value.map(file => ({ ...file }));
+    });
+    const deleted = vi.fn();
+    const mounted = mountControl(LkUpload, form, () => ({
+      modelValue: files.value,
+      previewImage: false,
+      'onUpdate:modelValue': update,
+      onDelete: deleted,
+    }));
+
+    mounted.exposed()?.confirmRemove(0 as never);
+    await nextTick();
+    const modal = findNode(mounted.root, node => node.type === 'lk-modal-stub');
+    expect(modal.props.modelValue).toBe(true);
+
+    form.disabled = true;
+    await nextTick();
+    expect(modal.props.modelValue).toBe(false);
+    expect(files.value).toHaveLength(1);
+    expect(update).not.toHaveBeenCalled();
+    expect(deleted).not.toHaveBeenCalled();
+    mounted.app.unmount();
+  });
+});

--- a/tests/unit/lk-form-validation.spec.ts
+++ b/tests/unit/lk-form-validation.spec.ts
@@ -1,0 +1,576 @@
+import { describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import type {
+  FormContext,
+  FormItemContext,
+  FormRule,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import {
+  createFormItemValidationController,
+  watchFormItemInitialValueSources,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/form.validation';
+import {
+  captureFormItemInitialValues,
+  restoreFormItemInitialValues,
+  validateRegisteredFormFields,
+  type FormValidateStatus,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/form.utils';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(nextResolve => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function createForm(options: {
+  model: Record<string, unknown>;
+  rules?: Record<string, FormRule | FormRule[]>;
+  customValidator?: FormContext['customValidator'];
+}): FormContext {
+  return {
+    model: options.model,
+    rules: options.rules,
+    customValidator: options.customValidator,
+    showMessage: true,
+    disabled: false,
+    addField: vi.fn(),
+    removeField: vi.fn(),
+    invalidateValidation: vi.fn(),
+    validateField: vi.fn(),
+    emitFieldBlur: vi.fn(),
+    emitFieldChange: vi.fn(),
+    validate: vi.fn(),
+    resetFields: vi.fn(),
+    clearValidate: vi.fn(),
+    scrollToField: vi.fn(),
+  };
+}
+
+function createController(
+  form: FormContext,
+  prop: string | string[] = 'title',
+  onState?: (status: FormValidateStatus, message: string) => void
+) {
+  let status: FormValidateStatus = 'idle';
+  let message = '';
+  const setState = vi.fn((nextStatus: FormValidateStatus, nextMessage: string) => {
+    status = nextStatus;
+    message = nextMessage;
+    onState?.(nextStatus, nextMessage);
+  });
+  const controller = createFormItemValidationController({
+    getForm: () => form,
+    getProp: () => prop,
+    getStatus: () => status,
+    getMessage: () => message,
+    setState,
+    fallbackMessage: () => 'Invalid',
+  });
+  return {
+    controller,
+    setState,
+    getStatus: () => status,
+    getMessage: () => message,
+  };
+}
+
+describe('form item validation generations', () => {
+  it.each([
+    {
+      label: 'a pass / b fail',
+      aValid: true,
+      bValid: false,
+      expected: [
+        { prop: 'a', ok: true, errorFields: [] },
+        { prop: 'b', ok: false, errorFields: ['b'] },
+      ],
+    },
+    {
+      label: 'a fail / b pass',
+      aValid: false,
+      bValid: true,
+      expected: [
+        { prop: 'a', ok: false, errorFields: ['a'] },
+        { prop: 'b', ok: true, errorFields: [] },
+      ],
+    },
+    {
+      label: 'a fail / b fail',
+      aValid: false,
+      bValid: false,
+      expected: [
+        { prop: 'a', ok: false, errorFields: ['a'] },
+        { prop: 'b', ok: false, errorFields: ['b'] },
+      ],
+    },
+  ])('validates every grouped prop and reports exact results: $label', async testCase => {
+    const validateA = vi.fn(async () => testCase.aValid);
+    const validateB = vi.fn(async () => testCase.bValid);
+    const form = createForm({
+      model: { a: 'a', b: 'b' },
+      rules: {
+        a: { message: 'A invalid', validator: validateA },
+        b: { message: 'B invalid', validator: validateB },
+      },
+    });
+    const state = createController(form, ['a', 'b']);
+    const field: FormItemContext = {
+      prop: ['a', 'b'],
+      setValidateStatus: vi.fn(),
+      beginValidation: state.controller.begin,
+      isValidationCurrent: state.controller.isCurrent,
+      captureValidationGeneration: state.controller.captureGeneration,
+      commitValidation: state.controller.commitGeneration,
+      rollbackValidation: state.controller.rollbackGeneration,
+      releaseValidation: state.controller.releaseGeneration,
+      getValidationProps: state.controller.getValidationProps,
+      invalidateValidation: state.controller.invalidate,
+      validate: state.controller.validate,
+      validateGeneration: state.controller.validateGeneration,
+      reset: vi.fn(),
+    };
+    const result = await validateRegisteredFormFields({
+      fields: [field],
+      model: form.model,
+    });
+
+    expect(result.errors.map(error => error.field)).toEqual(
+      testCase.expected.filter(item => !item.ok).map(item => item.prop)
+    );
+    expect(
+      result.reports.map(({ prop, ok, errors }) => ({
+        prop,
+        ok,
+        errorFields: (errors || []).map(error => error.field),
+      }))
+    ).toEqual(testCase.expected);
+    expect(validateA).toHaveBeenCalledOnce();
+    expect(validateB).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a newer blur result when an older change result resolves last', async () => {
+    const oldResult = deferred<boolean>();
+    const newResult = deferred<boolean>();
+    const model = { title: 'old' };
+    const form = createForm({
+      model,
+      rules: {
+        title: {
+          message: 'Rejected',
+          validator: value => (value === 'old' ? oldResult.promise : newResult.promise),
+        },
+      },
+    });
+    const state = createController(form);
+
+    const oldValidation = state.controller.validate('change');
+    model.title = 'new';
+    const newValidation = state.controller.validate('blur');
+
+    newResult.resolve(true);
+    await expect(newValidation).resolves.toBe('validated');
+    expect(state.getStatus()).toBe('success');
+
+    oldResult.resolve(false);
+    await expect(oldValidation).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('success');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('stops before later rules when a pending rule is superseded', async () => {
+    const firstResult = deferred<boolean>();
+    const laterValidator = vi.fn(() => true);
+    const form = createForm({
+      model: { title: 'value' },
+      rules: {
+        title: [{ validator: () => firstResult.promise }, { validator: laterValidator }],
+      },
+    });
+    const state = createController(form);
+
+    const pending = state.controller.validate('change');
+    state.controller.invalidate(true);
+    firstResult.resolve(true);
+
+    await expect(pending).resolves.toBe('stale');
+    expect(laterValidator).not.toHaveBeenCalled();
+    expect(state.getStatus()).toBe('idle');
+  });
+
+  it('returns the generation owned before a validating-state observer starts a newer run', async () => {
+    const oldResult = deferred<boolean>();
+    const newResult = deferred<boolean>();
+    let nestedValidation: Promise<'validated' | 'skipped' | 'stale'> | undefined;
+    let validationCall = 0;
+    const form = createForm({
+      model: { title: 'value' },
+      rules: {
+        title: {
+          validator: () => {
+            validationCall += 1;
+            return validationCall === 1 ? oldResult.promise : newResult.promise;
+          },
+        },
+      },
+    });
+    const state = createController(form, 'title', status => {
+      if (status !== 'validating' || nestedValidation) return;
+      nestedValidation = Promise.resolve('skipped');
+      validationCall += 1;
+      nestedValidation = state.controller.validate();
+    });
+
+    const oldValidation = state.controller.validate();
+    newResult.resolve(true);
+    await expect(nestedValidation).resolves.toBe('validated');
+    oldResult.resolve(false);
+
+    await expect(oldValidation).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('success');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('rolls back only the stale commit when a synchronous state observer invalidates it', async () => {
+    let shouldInvalidate = false;
+    const form = createForm({
+      model: { title: 'valid' },
+      rules: { title: { validator: () => true } },
+    });
+    const state = createController(form, 'title', status => {
+      if (status === 'success' && shouldInvalidate) state.controller.invalidate();
+    });
+    shouldInvalidate = true;
+
+    await expect(state.controller.validate()).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('idle');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('sync success observer reentry inherits the pre-commit idle lineage', async () => {
+    const nestedRule = deferred<boolean>();
+    let nested: Promise<'validated' | 'skipped' | 'stale'> | undefined;
+    let calls = 0;
+    const form = createForm({
+      model: { title: 'value' },
+      rules: {
+        title: {
+          validator: () => {
+            calls += 1;
+            return calls === 1 ? true : nestedRule.promise;
+          },
+        },
+      },
+    });
+    const state = createController(form, 'title', status => {
+      if (status !== 'success' || nested) return;
+      nested = state.controller.validate();
+      state.controller.invalidate(true);
+    });
+
+    await expect(state.controller.validate()).resolves.toBe('stale');
+    nestedRule.resolve(true);
+    await expect(nested).resolves.toBe('stale');
+
+    expect(state.getStatus()).toBe('idle');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('keeps a newer custom-validator success when an older error resolves last', async () => {
+    const oldResult = deferred<Record<string, string> | null>();
+    const newResult = deferred<Record<string, string> | null>();
+    const model = { title: 'old' };
+    const form = createForm({
+      model,
+      customValidator: currentModel => {
+        return currentModel.title === 'old' ? oldResult.promise : newResult.promise;
+      },
+    });
+    const state = createController(form);
+
+    const oldValidation = state.controller.validate('change');
+    model.title = 'new';
+    const newValidation = state.controller.validate('change');
+    newResult.resolve(null);
+    await expect(newValidation).resolves.toBe('validated');
+
+    oldResult.resolve({ title: 'Old error' });
+    await expect(oldValidation).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('success');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('clears only still-current custom fields when a direct item validation supersedes the form run', async () => {
+    const oldFormResult = deferred<Record<string, string> | null>();
+    let validationCall = 0;
+    const form = createForm({
+      model: { a: 'a', b: 'b' },
+      customValidator: () => {
+        validationCall += 1;
+        return validationCall === 1 ? oldFormResult.promise : null;
+      },
+    });
+    const a = createController(form, 'a');
+    const b = createController(form, 'b');
+    const makeField = (
+      prop: string,
+      state: ReturnType<typeof createController>
+    ): FormItemContext => ({
+      prop,
+      setValidateStatus(nextStatus, message) {
+        state.setState(nextStatus, message || '');
+      },
+      beginValidation: state.controller.begin,
+      isValidationCurrent: state.controller.isCurrent,
+      captureValidationGeneration: state.controller.captureGeneration,
+      commitValidation: state.controller.commitGeneration,
+      rollbackValidation: state.controller.rollbackGeneration,
+      releaseValidation: state.controller.releaseGeneration,
+      getValidationProps: state.controller.getValidationProps,
+      invalidateValidation: state.controller.invalidate,
+      validate: state.controller.validate,
+      validateGeneration: state.controller.validateGeneration,
+      reset: vi.fn(),
+    });
+    const aField = makeField('a', a);
+    const bField = makeField('b', b);
+    const oldFormValidation = validateRegisteredFormFields({
+      fields: [aField, bField],
+      model: form.model,
+      customValidator: form.customValidator,
+    });
+    expect(a.getStatus()).toBe('idle');
+    expect(b.getStatus()).toBe('idle');
+    expect(a.setState).not.toHaveBeenCalled();
+    expect(b.setState).not.toHaveBeenCalled();
+
+    await expect(a.controller.validate()).resolves.toBe('validated');
+    expect(a.getStatus()).toBe('success');
+    oldFormResult.resolve({ a: 'Old A error', b: 'Old B error' });
+
+    const error = await oldFormValidation.catch(reason => reason);
+    expect(error).toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    expect(a.getStatus()).toBe('success');
+    expect(a.getMessage()).toBe('');
+    expect(b.getStatus()).toBe('idle');
+    expect(b.getMessage()).toBe('');
+  });
+
+  it('does not let an older form-wide custom begin supersede a newer direct field run', async () => {
+    const oldAResult = deferred<Record<string, string> | null>();
+    let validationCall = 0;
+    const form = createForm({
+      model: { a: 'a', b: 'b' },
+      customValidator: () => {
+        validationCall += 1;
+        return validationCall === 1 ? oldAResult.promise : null;
+      },
+    });
+    let directB: Promise<'validated' | 'skipped' | 'stale'> | undefined;
+    let armDirectB = false;
+    const b = createController(form, 'b');
+    const a = createController(form, 'a', status => {
+      if (armDirectB && status === 'idle' && !directB) directB = b.controller.validate();
+    });
+    const makeField = (
+      prop: string,
+      state: ReturnType<typeof createController>
+    ): FormItemContext => ({
+      prop,
+      setValidateStatus: state.controller.setStatus,
+      beginValidation: state.controller.begin,
+      isValidationCurrent: state.controller.isCurrent,
+      captureValidationGeneration: state.controller.captureGeneration,
+      commitValidation: state.controller.commitGeneration,
+      rollbackValidation: state.controller.rollbackGeneration,
+      releaseValidation: state.controller.releaseGeneration,
+      getValidationProps: state.controller.getValidationProps,
+      invalidateValidation: state.controller.invalidate,
+      validate: state.controller.validate,
+      validateGeneration: state.controller.validateGeneration,
+      reset: vi.fn(),
+    });
+    const oldDirectA = a.controller.validate();
+    armDirectB = true;
+
+    const formWide = validateRegisteredFormFields({
+      fields: [makeField('a', a), makeField('b', b)],
+      model: form.model,
+      customValidator: form.customValidator,
+    });
+
+    await expect(formWide).rejects.toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    await expect(directB).resolves.toBe('validated');
+    oldAResult.resolve(null);
+    await expect(oldDirectA).resolves.toBe('stale');
+    expect(a.getStatus()).toBe('idle');
+    expect(b.getStatus()).toBe('success');
+  });
+
+  it('rejects a stale silent custom result after a direct item validation starts', async () => {
+    const oldSilentResult = deferred<Record<string, string> | null>();
+    let validationCall = 0;
+    const form = createForm({
+      model: { title: 'current' },
+      customValidator: () => {
+        validationCall += 1;
+        return validationCall === 1 ? oldSilentResult.promise : null;
+      },
+    });
+    const state = createController(form);
+    const field: FormItemContext = {
+      prop: 'title',
+      setValidateStatus(nextStatus, message) {
+        state.setState(nextStatus, message || '');
+      },
+      beginValidation: state.controller.begin,
+      isValidationCurrent: state.controller.isCurrent,
+      captureValidationGeneration: state.controller.captureGeneration,
+      commitValidation: state.controller.commitGeneration,
+      rollbackValidation: state.controller.rollbackGeneration,
+      releaseValidation: state.controller.releaseGeneration,
+      getValidationProps: state.controller.getValidationProps,
+      invalidateValidation: state.controller.invalidate,
+      validate: state.controller.validate,
+      validateGeneration: state.controller.validateGeneration,
+      reset: vi.fn(),
+    };
+    const oldSilentValidation = validateRegisteredFormFields({
+      fields: [field],
+      model: form.model,
+      customValidator: form.customValidator,
+      validateOptions: { silent: true },
+    });
+    expect(state.getStatus()).toBe('idle');
+    expect(state.setState).not.toHaveBeenCalled();
+
+    await expect(state.controller.validate()).resolves.toBe('validated');
+    expect(state.getStatus()).toBe('success');
+    oldSilentResult.resolve({ title: 'Old silent error' });
+
+    const error = await oldSilentValidation.catch(reason => reason);
+    expect(error).toMatchObject({ code: 'FORM_VALIDATION_SUPERSEDED' });
+    expect(state.getStatus()).toBe('success');
+    expect(state.getMessage()).toBe('');
+  });
+
+  it('does not restore a pending error after reset or disable invalidates it', async () => {
+    const firstResult = deferred<Record<string, string> | null>();
+    const secondResult = deferred<Record<string, string> | null>();
+    const model = { title: 'initial' };
+    let activeResult = firstResult;
+    const form = createForm({ model, customValidator: () => activeResult.promise });
+    const state = createController(form);
+
+    model.title = 'edited';
+    const beforeReset = state.controller.validate('change');
+    state.controller.invalidate(true);
+    model.title = 'initial';
+    firstResult.resolve({ title: 'Reset old error' });
+    await expect(beforeReset).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('idle');
+
+    activeResult = secondResult;
+    const beforeDisable = state.controller.validate('change');
+    form.disabled = true;
+    state.controller.invalidate(true);
+    secondResult.resolve({ title: 'Disabled old error' });
+    await expect(beforeDisable).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('idle');
+  });
+
+  it('validates only the silent field subset without changing visible state', async () => {
+    const titleValidator = vi.fn(async () => false);
+    const notesValidator = vi.fn(async () => false);
+    const form = createForm({
+      model: { title: '', notes: '' },
+      rules: {
+        title: { message: 'Title required', validator: titleValidator },
+        notes: { message: 'Notes required', validator: notesValidator },
+      },
+    });
+    const state = createController(form, ['title', 'notes']);
+
+    await expect(
+      state.controller.validate(undefined, { fields: ['title'], silent: true })
+    ).rejects.toEqual([expect.objectContaining({ field: 'title', message: 'Title required' })]);
+    expect(titleValidator).toHaveBeenCalledOnce();
+    expect(notesValidator).not.toHaveBeenCalled();
+    expect(state.setState).not.toHaveBeenCalled();
+    expect(state.getStatus()).toBe('idle');
+  });
+
+  it('marks a silent result stale when form state changes while it is pending', async () => {
+    const result = deferred<boolean>();
+    const form = createForm({
+      model: { title: 'old' },
+      rules: { title: { validator: () => result.promise } },
+    });
+    const state = createController(form);
+
+    const pending = state.controller.validate(undefined, { silent: true });
+    state.controller.invalidate();
+    result.resolve(false);
+
+    await expect(pending).resolves.toBe('stale');
+    expect(state.setState).not.toHaveBeenCalled();
+  });
+
+  it('lets a newer silent run supersede a pending stateful run without changing stable UI', async () => {
+    const oldResult = deferred<boolean>();
+    const newResult = deferred<boolean>();
+    let call = 0;
+    const form = createForm({
+      model: { title: 'current' },
+      rules: {
+        title: {
+          validator: () => {
+            call += 1;
+            return call === 1 ? oldResult.promise : newResult.promise;
+          },
+        },
+      },
+    });
+    const state = createController(form);
+
+    state.controller.setStatus('error', 'stable error');
+    const oldValidation = state.controller.validate();
+    expect(state.getStatus()).toBe('validating');
+    const silentValidation = state.controller.validate(undefined, { silent: true });
+    expect(state.getStatus()).toBe('error');
+    expect(state.getMessage()).toBe('stable error');
+
+    newResult.resolve(true);
+    await expect(silentValidation).resolves.toBe('validated');
+    oldResult.resolve(false);
+    await expect(oldValidation).resolves.toBe('stale');
+    expect(state.getStatus()).toBe('error');
+    expect(state.getMessage()).toBe('stable error');
+  });
+
+  it('rebuilds the reset snapshot synchronously for model and prop identity changes', () => {
+    const model = ref<Record<string, unknown>>({ title: 'first' });
+    const prop = ref<string | string[] | undefined>('title');
+    let initialValues = captureFormItemInitialValues(model.value, prop.value);
+    const rebuild = () => {
+      initialValues = captureFormItemInitialValues(model.value, prop.value);
+    };
+    const scope = effectScope();
+    scope.run(() => {
+      watchFormItemInitialValueSources({
+        model: () => model.value,
+        prop: () => prop.value,
+        rebuild,
+      });
+    });
+
+    model.value = { notes: 'next baseline' };
+    prop.value = 'notes';
+    model.value.notes = 'edited after identity switch';
+    restoreFormItemInitialValues(model.value, initialValues, ['notes']);
+
+    expect(model.value).toEqual({ notes: 'next baseline' });
+    scope.stop();
+  });
+});

--- a/tests/unit/lk-form.spec.ts
+++ b/tests/unit/lk-form.spec.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  captureFormItemInitialValues,
+  cloneFormValue,
   filterFormRulesByTrigger,
   getFormFieldRules,
   isEmptyFormValue,
@@ -8,24 +10,48 @@ import {
   resolveFormClass,
   resolveFormItemClass,
   resolveFormItemLabelStyle,
+  resolveFormItemProps,
   resolveFormItemRequired,
-  resolveFormItemResetValue,
+  resolveFormControlProp,
   resolveTargetFormFields,
+  restoreFormItemInitialValues,
+  validateRegisteredFormFields,
   validateFormValue,
 } from '../../src/uni_modules/lucky-ui/components/lk-form/form.utils';
-import type { FormItemContext, FormRule } from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import type {
+  FormItemContext,
+  FormRule,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import { isFormValidationSupersededError } from '../../src/uni_modules/lucky-ui/components/lk-form/context';
 
 describe('lk-form validation rules', () => {
+  const generationMethods = {
+    beginValidation: () => 1,
+    isValidationCurrent: () => true,
+    captureValidationGeneration: () => 1,
+    commitValidation: () => 1,
+    rollbackValidation: () => undefined,
+    releaseValidation: () => undefined,
+    getValidationProps: (_trigger?: 'blur' | 'change', fields?: string[]) => fields || [],
+    invalidateValidation: () => undefined,
+    validateGeneration: async () => 'validated' as const,
+  };
+
   it('normalizes field rules and filters them by trigger', () => {
     const blurRule: FormRule = { required: true, trigger: 'blur' };
     const changeRule: FormRule = { min: 2, trigger: ['change'] };
     const sharedRule: FormRule = { max: 6 };
 
     expect(normalizeFormRules(blurRule)).toEqual([blurRule]);
-    expect(getFormFieldRules({ name: [blurRule, changeRule, sharedRule] }, 'name'))
-      .toEqual([blurRule, changeRule, sharedRule]);
-    expect(filterFormRulesByTrigger([blurRule, changeRule, sharedRule], 'blur'))
-      .toEqual([blurRule, sharedRule]);
+    expect(getFormFieldRules({ name: [blurRule, changeRule, sharedRule] }, 'name')).toEqual([
+      blurRule,
+      changeRule,
+      sharedRule,
+    ]);
+    expect(filterFormRulesByTrigger([blurRule, changeRule, sharedRule], 'blur')).toEqual([
+      blurRule,
+      sharedRule,
+    ]);
   });
 
   it('detects empty values consistently for required fields', () => {
@@ -46,24 +72,28 @@ describe('lk-form validation rules', () => {
       { validator: async () => 'Rejected by server' },
     ];
 
-    await expect(validateFormValue({
-      field: 'username',
-      value: 'bb',
-      rules,
-      model: { username: 'bb' },
-      fallbackMessage: 'Invalid',
-    })).resolves.toEqual([
+    await expect(
+      validateFormValue({
+        field: 'username',
+        value: 'bb',
+        rules,
+        model: { username: 'bb' },
+        fallbackMessage: 'Invalid',
+      })
+    ).resolves.toEqual([
       { field: 'username', message: 'Too short', rule: rules[1] },
       { field: 'username', message: 'Only a', rule: rules[2] },
       { field: 'username', message: 'Rejected by server', rule: rules[3] },
     ]);
 
-    await expect(validateFormValue({
-      field: 'age',
-      value: 17,
-      rules: [{ min: 18, message: 'Adult only' }],
-      fallbackMessage: 'Invalid',
-    })).resolves.toEqual([
+    await expect(
+      validateFormValue({
+        field: 'age',
+        value: 17,
+        rules: [{ min: 18, message: 'Adult only' }],
+        fallbackMessage: 'Invalid',
+      })
+    ).resolves.toEqual([
       { field: 'age', message: 'Adult only', rule: { min: 18, message: 'Adult only' } },
     ]);
   });
@@ -75,19 +105,22 @@ describe('lk-form validation rules', () => {
       },
     };
 
-    await expect(validateFormValue({
-      field: 'code',
-      value: '1234',
-      rules: [rule],
-      fallbackMessage: 'Invalid',
-    })).resolves.toEqual([{ field: 'code', message: 'Network error', rule }]);
+    await expect(
+      validateFormValue({
+        field: 'code',
+        value: '1234',
+        rules: [rule],
+        fallbackMessage: 'Invalid',
+      })
+    ).resolves.toEqual([{ field: 'code', message: 'Network error', rule }]);
   });
 
   it('resolves target fields and external validation errors', () => {
     const makeField = (prop: string): FormItemContext => ({
       prop,
       setValidateStatus: () => undefined,
-      validate: async () => undefined,
+      ...generationMethods,
+      validate: async () => 'validated',
       reset: () => undefined,
     });
     const fields = [makeField('name'), makeField('age')];
@@ -100,42 +133,348 @@ describe('lk-form validation rules', () => {
     expect(normalizeValidateErrors(null)).toEqual([]);
   });
 
-  it('resolves reset values by current field value type', () => {
-    expect(resolveFormItemResetValue(['a'])).toEqual([]);
-    expect(resolveFormItemResetValue(true)).toBe(false);
-    expect(resolveFormItemResetValue(5)).toBe(0);
-    expect(resolveFormItemResetValue(null)).toBeNull();
-    expect(resolveFormItemResetValue(undefined)).toBeNull();
-    expect(resolveFormItemResetValue('hello')).toBe('');
-    expect(resolveFormItemResetValue({ value: 1 })).toBe('');
+  it('restores mount-time values without sharing nested references', () => {
+    const model: Record<string, unknown> = {
+      title: 'Initial title',
+      settings: { tags: ['initial'], enabled: true },
+    };
+    const initialValues = captureFormItemInitialValues(model, ['title', 'settings', 'missing']);
+
+    model.title = 'Edited title';
+    model.settings = { tags: ['edited'], enabled: false };
+    model.missing = 'created later';
+    restoreFormItemInitialValues(model, initialValues);
+
+    expect(model).toEqual({
+      title: 'Initial title',
+      settings: { tags: ['initial'], enabled: true },
+    });
+
+    (model.settings as { tags: string[] }).tags.push('mutated after reset');
+    restoreFormItemInitialValues(model, initialValues);
+    expect(model.settings).toEqual({ tags: ['initial'], enabled: true });
+  });
+
+  it('deep-clones cyclic JSON-like field values', () => {
+    const source: { name: string; self?: unknown } = { name: 'root' };
+    source.self = source;
+    const cloned = cloneFormValue(source);
+
+    expect(cloned).not.toBe(source);
+    expect(cloned.self).toBe(cloned);
+  });
+
+  it('inherits only an unambiguous FormItem prop', () => {
+    expect(resolveFormControlProp('explicit', 'item')).toBe('explicit');
+    expect(resolveFormControlProp('', 'item')).toBe('item');
+    expect(resolveFormControlProp('', ['item'])).toBe('item');
+    expect(resolveFormControlProp('', ['first', 'second'])).toBeUndefined();
+    expect(resolveFormItemProps(['first', 'first', 'second'], ['second'])).toEqual(['second']);
+  });
+
+  it('keeps silent and fields validation free of unrelated state and events', async () => {
+    const titleStatus = vi.fn();
+    const notesStatus = vi.fn();
+    const makeField = (
+      prop: string,
+      setValidateStatus: ReturnType<typeof vi.fn>
+    ): FormItemContext => ({
+      prop,
+      setValidateStatus,
+      ...generationMethods,
+      validate: async () => 'validated',
+      reset: () => undefined,
+    });
+    const fields = [makeField('title', titleStatus), makeField('notes', notesStatus)];
+
+    await expect(
+      validateRegisteredFormFields({
+        fields,
+        model: { title: '', notes: '' },
+        customValidator: () => ({ title: 'Title required', notes: 'Notes required' }),
+        validateOptions: { fields: ['title'], silent: true },
+      })
+    ).resolves.toEqual({
+      errors: [{ field: 'title', message: 'Title required' }],
+      stale: false,
+    });
+
+    expect(titleStatus).not.toHaveBeenCalled();
+    expect(notesStatus).not.toHaveBeenCalled();
+  });
+
+  it('passes silent target options through default field validation', async () => {
+    const validateTitle = vi.fn(async () => {
+      throw [{ field: 'title', message: 'Title required' }];
+    });
+    const validateNotes = vi.fn(async () => 'validated' as const);
+    const makeField = (prop: string, validate: FormItemContext['validate']): FormItemContext => ({
+      prop,
+      setValidateStatus: () => undefined,
+      ...generationMethods,
+      validate,
+      validateGeneration: validate,
+      reset: () => undefined,
+    });
+
+    const errors = await validateRegisteredFormFields({
+      fields: [makeField('title', validateTitle), makeField('notes', validateNotes)],
+      model: { title: '', notes: '' },
+      validateOptions: { fields: ['title'], silent: true },
+    });
+
+    expect(errors).toEqual({
+      errors: [{ field: 'title', message: 'Title required' }],
+      stale: false,
+    });
+    expect(validateTitle).toHaveBeenCalledWith(1, undefined, {
+      fields: ['title'],
+      silent: true,
+    });
+    expect(validateNotes).not.toHaveBeenCalled();
+  });
+
+  it('does not report success when a field has no matching validation rule', async () => {
+    const field: FormItemContext = {
+      prop: 'title',
+      setValidateStatus: () => undefined,
+      ...generationMethods,
+      validate: async () => 'skipped',
+      reset: () => undefined,
+    };
+
+    await expect(
+      validateRegisteredFormFields({
+        fields: [field],
+        model: { title: 'unchanged' },
+      })
+    ).resolves.toEqual({ errors: [], stale: false });
+  });
+
+  it('rejects a superseded imperative validation without reporting stale fields', async () => {
+    let resolveValidation!: (result: 'validated') => void;
+    const deferredValidation = new Promise<'validated'>(resolve => {
+      resolveValidation = resolve;
+    });
+    let current = true;
+    const field: FormItemContext = {
+      prop: 'title',
+      setValidateStatus: vi.fn(),
+      ...generationMethods,
+      getValidationProps: () => ['title'],
+      validate: () => deferredValidation,
+      validateGeneration: () => deferredValidation,
+      reset: vi.fn(),
+    };
+
+    const pending = validateRegisteredFormFields({
+      fields: [field],
+      model: { title: 'old' },
+      isCurrent: () => current,
+    });
+    current = false;
+    resolveValidation('validated');
+
+    const error = await pending.catch(reason => reason);
+    expect(isFormValidationSupersededError(error)).toBe(true);
+    expect(error).toMatchObject({
+      name: 'FormValidationSupersededError',
+      code: 'FORM_VALIDATION_SUPERSEDED',
+    });
+    expect(field.setValidateStatus).not.toHaveBeenCalled();
+  });
+
+  it('keeps form-wide field state and reports atomic when a later field is superseded', async () => {
+    let current = true;
+    let resolveSecond!: (result: 'validated') => void;
+    let markSecondStarted!: () => void;
+    const secondValidation = new Promise<'validated'>(resolve => {
+      resolveSecond = resolve;
+    });
+    const secondStarted = new Promise<void>(resolve => {
+      markSecondStarted = resolve;
+    });
+    const firstStatus = vi.fn();
+    const secondStatus = vi.fn();
+    const makeField = (options: {
+      prop: string;
+      status: ReturnType<typeof vi.fn>;
+      validate: FormItemContext['validate'];
+    }): FormItemContext => ({
+      prop: options.prop,
+      setValidateStatus: options.status,
+      beginValidation: () => 1,
+      isValidationCurrent: () => true,
+      captureValidationGeneration: () => 1,
+      commitValidation: (_generation, errors) => {
+        options.status(errors.length ? 'error' : 'success', errors[0]?.message || '');
+        return true;
+      },
+      rollbackValidation: vi.fn(),
+      releaseValidation: vi.fn(),
+      getValidationProps: () => [options.prop],
+      invalidateValidation: vi.fn(),
+      validate: options.validate,
+      validateGeneration: options.validate,
+      reset: vi.fn(),
+    });
+    const firstField = makeField({
+      prop: 'a',
+      status: firstStatus,
+      validate: async () => {
+        throw [{ field: 'a', message: 'A invalid' }];
+      },
+    });
+    const secondField = makeField({
+      prop: 'b',
+      status: secondStatus,
+      validate: () => {
+        markSecondStarted();
+        return secondValidation;
+      },
+    });
+
+    const pending = validateRegisteredFormFields({
+      fields: [firstField, secondField],
+      model: { a: '', b: '' },
+      isCurrent: () => current,
+    });
+    await secondStarted;
+    current = false;
+    resolveSecond('validated');
+
+    const error = await pending.catch(reason => reason);
+    expect(isFormValidationSupersededError(error)).toBe(true);
+    expect(firstStatus).not.toHaveBeenCalled();
+    expect(secondStatus).not.toHaveBeenCalled();
+  });
+
+  it('rolls back earlier committed field state when a later commit supersedes the form run', async () => {
+    let current = true;
+    const states = { a: 'idle', b: 'idle' };
+    let revisionA = 0;
+    let revisionB = 0;
+    const rollbackA = vi.fn((_generation: number, commitToken?: number) => {
+      if (commitToken === revisionA) states.a = 'idle';
+    });
+    const rollbackB = vi.fn((_generation: number, commitToken?: number) => {
+      if (commitToken === revisionB) states.b = 'idle';
+    });
+    const makeField = (
+      prop: 'a' | 'b',
+      commit: FormItemContext['commitValidation'],
+      rollback: FormItemContext['rollbackValidation']
+    ): FormItemContext => ({
+      prop,
+      setValidateStatus: vi.fn(),
+      beginValidation: () => 1,
+      isValidationCurrent: () => true,
+      captureValidationGeneration: () => 1,
+      commitValidation: commit,
+      rollbackValidation: rollback,
+      releaseValidation: vi.fn(),
+      getValidationProps: () => [prop],
+      invalidateValidation: vi.fn(),
+      validate: async () => 'validated',
+      validateGeneration: async () => 'validated',
+      reset: vi.fn(),
+    });
+    const a = makeField(
+      'a',
+      () => {
+        states.a = 'success';
+        revisionA += 1;
+        return revisionA;
+      },
+      rollbackA
+    );
+    const b = makeField(
+      'b',
+      () => {
+        states.b = 'success';
+        revisionB += 1;
+        current = false;
+        return revisionB;
+      },
+      rollbackB
+    );
+    const error = await validateRegisteredFormFields({
+      fields: [a, b],
+      model: { a: 'a', b: 'b' },
+      isCurrent: () => current,
+    }).catch(reason => reason);
+
+    expect(isFormValidationSupersededError(error)).toBe(true);
+    expect(states).toEqual({ a: 'idle', b: 'idle' });
+    expect(rollbackA).toHaveBeenCalledWith(1, 1);
+    expect(rollbackB).toHaveBeenCalledWith(1, 1);
+  });
+
+  it('does not begin custom validation for a FormItem without props', async () => {
+    const beginValidation = vi.fn(() => 1);
+    const customValidator = vi.fn(() => ({ orphan: 'ignored' }));
+    const field: FormItemContext = {
+      prop: undefined,
+      setValidateStatus: vi.fn(),
+      beginValidation,
+      isValidationCurrent: () => true,
+      captureValidationGeneration: () => 0,
+      commitValidation: () => 1,
+      rollbackValidation: vi.fn(),
+      releaseValidation: vi.fn(),
+      getValidationProps: () => [],
+      invalidateValidation: vi.fn(),
+      validate: async () => 'skipped',
+      validateGeneration: async () => 'skipped',
+      reset: vi.fn(),
+    };
+
+    await expect(
+      validateRegisteredFormFields({
+        fields: [field],
+        model: {},
+        customValidator,
+      })
+    ).resolves.toEqual({ errors: [], stale: false });
+    expect(beginValidation).not.toHaveBeenCalled();
+    expect(customValidator).not.toHaveBeenCalled();
+    expect(field.setValidateStatus).not.toHaveBeenCalled();
   });
 
   it('builds form and form item display metadata', () => {
-    expect(resolveFormClass({ border: true, card: false, customClass: 'custom' })).toEqual([
+    expect(
+      resolveFormClass({ border: true, card: false, disabled: true, customClass: 'custom' })
+    ).toEqual([
       'lk-form',
-      { 'lk-form--border': true, 'lk-form--card': false },
+      { 'lk-form--border': true, 'lk-form--card': false, 'is-disabled': true },
       'custom',
     ]);
 
     expect(resolveFormItemLabelStyle(160)).toEqual({ width: '160rpx' });
     expect(resolveFormItemLabelStyle('6em')).toEqual({ width: '6em' });
-    expect(resolveFormItemRequired({
-      explicitRequired: undefined,
-      rules: [{ required: true }],
-    })).toBe(true);
-    expect(resolveFormItemRequired({
-      explicitRequired: false,
-      rules: [{ required: true }],
-    })).toBe(false);
+    expect(
+      resolveFormItemRequired({
+        explicitRequired: undefined,
+        rules: [{ required: true }],
+      })
+    ).toBe(true);
+    expect(
+      resolveFormItemRequired({
+        explicitRequired: false,
+        rules: [{ required: true }],
+      })
+    ).toBe(false);
 
-    expect(resolveFormItemClass({
-      customClass: 'x',
-      status: 'error',
-      labelAlign: 'top',
-      topLayout: true,
-      border: true,
-      link: true,
-    })).toEqual([
+    expect(
+      resolveFormItemClass({
+        customClass: 'x',
+        status: 'error',
+        labelAlign: 'top',
+        topLayout: true,
+        border: true,
+        link: true,
+      })
+    ).toEqual([
       'x',
       'is-error',
       'lk-form-item--top',

--- a/tests/unit/lk-input.spec.ts
+++ b/tests/unit/lk-input.spec.ts
@@ -7,6 +7,7 @@ import {
   resolveInputClass,
   resolveInputCount,
   resolveInputNativeState,
+  shouldCommitInputBlur,
   shouldShowPasswordToggle,
   shouldShowSuffix,
   shouldShowTrailingBalance,
@@ -36,34 +37,52 @@ describe('lk-input value and display rules', () => {
     expect(hasInputValue(undefined)).toBe(false);
   });
 
+  it('does not commit change or form blur for readonly and disabled blur', () => {
+    expect(shouldCommitInputBlur({ disabled: false, readonly: false })).toBe(true);
+    expect(shouldCommitInputBlur({ disabled: false, readonly: true })).toBe(false);
+    expect(shouldCommitInputBlur({ disabled: true, readonly: false })).toBe(false);
+  });
+
   it('resolves native password state for cross-platform input props', () => {
-    expect(resolveInputNativeState({ type: 'password', passwordVisible: false }))
-      .toEqual({ nativeType: 'text', nativePassword: true });
-    expect(resolveInputNativeState({ type: 'password', passwordVisible: true }))
-      .toEqual({ nativeType: 'text', nativePassword: false });
-    expect(resolveInputNativeState({ type: 'number', passwordVisible: false }))
-      .toEqual({ nativeType: 'number', nativePassword: false });
+    expect(resolveInputNativeState({ type: 'password', passwordVisible: false })).toEqual({
+      nativeType: 'text',
+      nativePassword: true,
+    });
+    expect(resolveInputNativeState({ type: 'password', passwordVisible: true })).toEqual({
+      nativeType: 'text',
+      nativePassword: false,
+    });
+    expect(resolveInputNativeState({ type: 'number', passwordVisible: false })).toEqual({
+      nativeType: 'number',
+      nativePassword: false,
+    });
   });
 
   it('builds count text from showCount and showWordLimit aliases', () => {
-    expect(resolveInputCount({
-      value: 'hello',
-      maxlength: 10,
-      showCount: false,
-      showWordLimit: true,
-    })).toBe('5/10');
-    expect(resolveInputCount({
-      value: 123,
-      maxlength: -1,
-      showCount: true,
-      showWordLimit: false,
-    })).toBe('3');
-    expect(resolveInputCount({
-      value: 'hidden',
-      maxlength: 10,
-      showCount: false,
-      showWordLimit: false,
-    })).toBe('');
+    expect(
+      resolveInputCount({
+        value: 'hello',
+        maxlength: 10,
+        showCount: false,
+        showWordLimit: true,
+      })
+    ).toBe('5/10');
+    expect(
+      resolveInputCount({
+        value: 123,
+        maxlength: -1,
+        showCount: true,
+        showWordLimit: false,
+      })
+    ).toBe('3');
+    expect(
+      resolveInputCount({
+        value: 'hidden',
+        maxlength: 10,
+        showCount: false,
+        showWordLimit: false,
+      })
+    ).toBe('');
   });
 
   it('prioritizes password toggle over suffix content', () => {
@@ -76,59 +95,69 @@ describe('lk-input value and display rules', () => {
     });
 
     expect(passwordToggle).toBe(true);
-    expect(shouldShowPasswordToggle({
-      showPassword: true,
-      type: 'password',
-      disabled: true,
-      readonly: false,
-      fake: false,
-    })).toBe(false);
-    expect(shouldShowSuffix({
-      hasSuffixSlot: true,
-      suffixIcon: 'calendar-fill',
-      showPasswordToggle: passwordToggle,
-    })).toBe(false);
+    expect(
+      shouldShowPasswordToggle({
+        showPassword: true,
+        type: 'password',
+        disabled: true,
+        readonly: false,
+        fake: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldShowSuffix({
+        hasSuffixSlot: true,
+        suffixIcon: 'calendar-fill',
+        showPasswordToggle: passwordToggle,
+      })
+    ).toBe(false);
   });
 
   it('adds trailing balance for centered input controls that need right-side affordances', () => {
-    expect(shouldShowTrailingBalance({
-      inputAlign: 'center',
-      prefixIcon: '',
-      hasPrefixSlot: false,
-      showPasswordToggle: false,
-      showSuffix: false,
-      value: 0,
-      clearable: true,
-      count: '',
-    })).toBe(true);
+    expect(
+      shouldShowTrailingBalance({
+        inputAlign: 'center',
+        prefixIcon: '',
+        hasPrefixSlot: false,
+        showPasswordToggle: false,
+        showSuffix: false,
+        value: 0,
+        clearable: true,
+        count: '',
+      })
+    ).toBe(true);
 
-    expect(shouldShowTrailingBalance({
-      inputAlign: 'center',
-      prefixIcon: 'search',
-      hasPrefixSlot: false,
-      showPasswordToggle: false,
-      showSuffix: false,
-      value: 'abc',
-      clearable: true,
-      count: '',
-    })).toBe(false);
+    expect(
+      shouldShowTrailingBalance({
+        inputAlign: 'center',
+        prefixIcon: 'search',
+        hasPrefixSlot: false,
+        showPasswordToggle: false,
+        showSuffix: false,
+        value: 'abc',
+        clearable: true,
+        count: '',
+      })
+    ).toBe(false);
   });
 
   it('builds root classes and fake display text', () => {
-    expect(resolveInputClass({
-      size: 'lg',
-      disabled: true,
-      readonly: false,
-      fake: true,
-      value: 'selected',
-      borderless: true,
-      inputAlign: 'center',
-      prefixIcon: 'search',
-      trailingBalance: true,
-      count: '1/10',
-      error: true,
-      customClass: 'custom',
-    })).toEqual([
+    expect(
+      resolveInputClass({
+        size: 'lg',
+        disabled: true,
+        readonly: false,
+        fake: true,
+        value: 'selected',
+        borderless: true,
+        inputAlign: 'center',
+        prefixIcon: 'search',
+        trailingBalance: true,
+        count: '1/10',
+        error: true,
+        customClass: 'custom',
+      })
+    ).toEqual([
       'lk-input',
       'lk-input--lg',
       {

--- a/tests/unit/lk-textarea.spec.ts
+++ b/tests/unit/lk-textarea.spec.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyTextareaMaxlength,
+  createTextareaBlurController,
   isTextareaNativeFocused,
   readTextareaValue,
   resolveTextareaClass,
   resolveTextareaCount,
   resolveTextareaPlaceholder,
+  shouldCommitTextareaBlur,
   shouldShowTextareaClear,
   shouldShowTextareaFooter,
 } from '../../src/uni_modules/lucky-ui/components/lk-textarea/textarea.utils';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('lk-textarea value and display rules', () => {
   it('reads values from textarea event payloads', () => {
@@ -36,54 +42,114 @@ describe('lk-textarea value and display rules', () => {
     expect(isTextareaNativeFocused({ focus: false, autofocus: true })).toBe(true);
   });
 
+  it('cancels stale blur callbacks on refocus, reschedule and dispose', () => {
+    vi.useFakeTimers();
+    const controller = createTextareaBlurController();
+    const firstBlur = vi.fn();
+    const secondBlur = vi.fn();
+
+    controller.schedule(firstBlur);
+    controller.cancel();
+    vi.advanceTimersByTime(100);
+    expect(firstBlur).not.toHaveBeenCalled();
+
+    controller.schedule(firstBlur);
+    controller.schedule(secondBlur);
+    vi.advanceTimersByTime(100);
+    expect(firstBlur).not.toHaveBeenCalled();
+    expect(secondBlur).toHaveBeenCalledOnce();
+
+    controller.schedule(firstBlur);
+    controller.dispose();
+    vi.runAllTimers();
+    expect(firstBlur).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps readonly and disabled blur out of change and form validation commits', () => {
+    expect(shouldCommitTextareaBlur({ disabled: false, readonly: false })).toBe(true);
+    expect(shouldCommitTextareaBlur({ disabled: false, readonly: true })).toBe(false);
+    expect(shouldCommitTextareaBlur({ disabled: true, readonly: false })).toBe(false);
+  });
+
+  it('can cancel a pending blur when readonly becomes true or clear is tapped', () => {
+    vi.useFakeTimers();
+    const controller = createTextareaBlurController();
+    const formBlur = vi.fn();
+
+    controller.schedule(formBlur);
+    controller.cancel();
+    vi.advanceTimersByTime(100);
+    expect(formBlur).not.toHaveBeenCalled();
+
+    controller.schedule(formBlur);
+    controller.cancel();
+    vi.advanceTimersByTime(100);
+    expect(formBlur).not.toHaveBeenCalled();
+  });
+
   it('guards clear button visibility by value and interaction state', () => {
-    expect(shouldShowTextareaClear({
-      clearable: true,
-      value: 'text',
-      disabled: false,
-      readonly: false,
-    })).toBe(true);
-    expect(shouldShowTextareaClear({
-      clearable: true,
-      value: '',
-      disabled: false,
-      readonly: false,
-    })).toBe(false);
-    expect(shouldShowTextareaClear({
-      clearable: true,
-      value: 'text',
-      disabled: true,
-      readonly: false,
-    })).toBe(false);
+    expect(
+      shouldShowTextareaClear({
+        clearable: true,
+        value: 'text',
+        disabled: false,
+        readonly: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldShowTextareaClear({
+        clearable: true,
+        value: '',
+        disabled: false,
+        readonly: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldShowTextareaClear({
+        clearable: true,
+        value: 'text',
+        disabled: true,
+        readonly: false,
+      })
+    ).toBe(false);
   });
 
   it('shows footer for bounded counts or footer slot', () => {
-    expect(shouldShowTextareaFooter({
-      showCount: true,
-      maxlength: 100,
-      hasFooterSlot: false,
-    })).toBe(true);
-    expect(shouldShowTextareaFooter({
-      showCount: true,
-      maxlength: -1,
-      hasFooterSlot: false,
-    })).toBe(false);
-    expect(shouldShowTextareaFooter({
-      showCount: false,
-      maxlength: -1,
-      hasFooterSlot: true,
-    })).toBe(true);
+    expect(
+      shouldShowTextareaFooter({
+        showCount: true,
+        maxlength: 100,
+        hasFooterSlot: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldShowTextareaFooter({
+        showCount: true,
+        maxlength: -1,
+        hasFooterSlot: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldShowTextareaFooter({
+        showCount: false,
+        maxlength: -1,
+        hasFooterSlot: true,
+      })
+    ).toBe(true);
   });
 
   it('builds root classes from variant and state', () => {
-    expect(resolveTextareaClass({
-      variant: 'filled',
-      disabled: true,
-      focused: true,
-      autoHeight: true,
-      label: '备注',
-      customClass: 'custom',
-    })).toEqual([
+    expect(
+      resolveTextareaClass({
+        variant: 'filled',
+        disabled: true,
+        focused: true,
+        autoHeight: true,
+        label: '备注',
+        customClass: 'custom',
+      })
+    ).toEqual([
       'lk-textarea',
       'lk-textarea--filled',
       {

--- a/tests/unit/use-form-field.spec.ts
+++ b/tests/unit/use-form-field.spec.ts
@@ -1,0 +1,217 @@
+/* eslint-disable vue/one-component-per-file */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createRenderer,
+  defineComponent,
+  h,
+  nextTick,
+  provide,
+  reactive,
+  readonly,
+  ref,
+} from 'vue';
+import type {
+  FormContext,
+  FormItemContext,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import {
+  formContextKey,
+  formItemContextKey,
+} from '../../src/uni_modules/lucky-ui/components/lk-form/context';
+import { useFormField } from '../../src/uni_modules/lucky-ui/components/lk-form/useFormField';
+
+type TestNode = Record<string, unknown>;
+
+const testRenderer = createRenderer<TestNode, TestNode>({
+  patchProp() {},
+  insert() {},
+  remove() {},
+  createElement() {
+    return {};
+  },
+  createText() {
+    return {};
+  },
+  createComment() {
+    return {};
+  },
+  setText() {},
+  setElementText() {},
+  parentNode() {
+    return null;
+  },
+  nextSibling() {
+    return null;
+  },
+});
+
+describe('useFormField', () => {
+  it('inherits FormItem prop, merges disabled state and gates validation events', async () => {
+    const emitFieldBlur = vi.fn();
+    const emitFieldChange = vi.fn();
+    const ownDisabled = ref(false);
+    const explicitProp = ref('');
+    const validateEvent = ref(true);
+    const validateStatus = ref<'idle' | 'validating' | 'success' | 'error'>('error');
+    let bridge: ReturnType<typeof useFormField> | undefined;
+
+    const form = reactive({
+      model: { title: '' },
+      rules: undefined,
+      showMessage: true,
+      disabled: false,
+      addField: vi.fn(),
+      removeField: vi.fn(),
+      invalidateValidation: vi.fn(),
+      validateField: vi.fn(),
+      emitFieldBlur,
+      emitFieldChange,
+      validate: vi.fn(),
+      resetFields: vi.fn(),
+      clearValidate: vi.fn(),
+      scrollToField: vi.fn(),
+    }) as unknown as FormContext;
+    const formItem: FormItemContext = {
+      prop: 'title',
+      validateStatus: readonly(validateStatus),
+      setValidateStatus: vi.fn(),
+      beginValidation: () => 1,
+      isValidationCurrent: () => true,
+      captureValidationGeneration: () => 1,
+      commitValidation: () => 1,
+      rollbackValidation: vi.fn(),
+      getValidationProps: () => ['title'],
+      invalidateValidation: vi.fn(),
+      validate: async () => 'validated',
+      reset: vi.fn(),
+    };
+
+    const Child = defineComponent({
+      setup() {
+        bridge = useFormField({
+          prop: () => explicitProp.value,
+          disabled: () => ownDisabled.value,
+          validateEvent: () => validateEvent.value,
+          inheritFormItemProp: true,
+        });
+        return () => null;
+      },
+    });
+    const App = defineComponent({
+      setup() {
+        provide(formContextKey, form);
+        provide(formItemContextKey, formItem);
+        return () => h(Child);
+      },
+    });
+    const app = testRenderer.createApp(App);
+    app.mount({});
+
+    expect(bridge?.prop.value).toBe('title');
+    expect(bridge?.hasError.value).toBe(true);
+    bridge?.emitChange('first');
+    bridge?.emitBlur();
+    expect(emitFieldChange).toHaveBeenCalledOnce();
+    expect(emitFieldChange).toHaveBeenLastCalledWith(
+      'title',
+      'first',
+      expect.objectContaining({
+        isCurrent: expect.any(Function),
+        awaitCurrent: expect.any(Function),
+      })
+    );
+    expect(emitFieldBlur).toHaveBeenCalledOnce();
+    expect(emitFieldBlur).toHaveBeenLastCalledWith(
+      'title',
+      expect.objectContaining({
+        isCurrent: expect.any(Function),
+        awaitCurrent: expect.any(Function),
+      })
+    );
+
+    ownDisabled.value = true;
+    await nextTick();
+    bridge?.emitChange('blocked-own');
+    ownDisabled.value = false;
+    form.disabled = true;
+    await nextTick();
+    bridge?.emitChange('blocked-form');
+    expect(emitFieldChange).toHaveBeenCalledOnce();
+
+    form.disabled = false;
+    validateEvent.value = false;
+    await nextTick();
+    bridge?.emitChange('blocked-validation');
+    expect(emitFieldChange).toHaveBeenCalledOnce();
+
+    validateEvent.value = true;
+    explicitProp.value = 'explicit';
+    await nextTick();
+    bridge?.emitChange('second');
+    expect(emitFieldChange).toHaveBeenCalledTimes(2);
+    expect(emitFieldChange).toHaveBeenLastCalledWith(
+      'explicit',
+      'second',
+      expect.objectContaining({
+        isCurrent: expect.any(Function),
+        awaitCurrent: expect.any(Function),
+      })
+    );
+
+    app.unmount();
+  });
+
+  it('keeps FormItem prop inheritance opt-in and invalidates separately delivered disabled edges', async () => {
+    const emitFieldChange = vi.fn();
+    const ownDisabled = ref(false);
+    let bridge: ReturnType<typeof useFormField> | undefined;
+    const form = reactive({
+      model: { title: '' },
+      showMessage: true,
+      disabled: false,
+      addField: vi.fn(),
+      removeField: vi.fn(),
+      invalidateValidation: vi.fn(),
+      validateField: vi.fn(),
+      emitFieldBlur: vi.fn(),
+      emitFieldChange,
+      validate: vi.fn(),
+      resetFields: vi.fn(),
+      clearValidate: vi.fn(),
+      scrollToField: vi.fn(),
+    }) as unknown as FormContext;
+    const formItem = { prop: 'title' } as FormItemContext;
+    const Child = defineComponent({
+      setup() {
+        bridge = useFormField({
+          disabled: () => ownDisabled.value,
+        });
+        return () => null;
+      },
+    });
+    const App = defineComponent({
+      setup() {
+        provide(formContextKey, form);
+        provide(formItemContextKey, formItem);
+        return () => h(Child);
+      },
+    });
+    const app = testRenderer.createApp(App);
+    app.mount({});
+
+    expect(bridge?.prop.value).toBeUndefined();
+    bridge?.emitChange('no-implicit-validation');
+    expect(emitFieldChange).not.toHaveBeenCalled();
+
+    const interaction = bridge?.captureInteraction();
+    form.disabled = true;
+    await nextTick();
+    expect(bridge?.disabled.value).toBe(true);
+    form.disabled = false;
+    await nextTick();
+    expect(bridge?.disabled.value).toBe(false);
+    expect(bridge?.isInteractionCurrent(interaction as number)).toBe(false);
+
+    app.unmount();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,26 @@
 import path from 'node:path';
+import { createRequire } from 'node:module';
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
+const require = createRequire(import.meta.url);
+const uniPluginRequire = createRequire(require.resolve('@dcloudio/vite-plugin-uni/package.json'));
+const vue = (uniPluginRequire('@vitejs/plugin-vue') as { default: () => Plugin }).default;
+
 export default defineConfig({
+  plugins: [
+    vue({
+      // Real mounted regressions compile only Lucky UI component SFCs; demo/docs SFCs and every
+      // unrelated unit fixture keep the pre-existing test transform path.
+      include: /src[\\/]uni_modules[\\/]lucky-ui[\\/]components[\\/].*\.vue$/,
+      template: {
+        compilerOptions: {
+          // Keep the SFC test compiler override limited to the Uni native element used by fixtures.
+          isCustomElement: tag => tag === 'scroll-view',
+        },
+      },
+    }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## 变更内容
- 统一表单控件继承 Form.disabled 的行为
- 防止异步事件链在禁用、重置或卸载后继续提交
- 完善表单验证、输入控件及小程序回归测试
- 兼容主线 Keyboard 精简 UI 与 Picker 内联提交语义

## 验证
- 203 个定向单元测试通过
- pnpm run type-check 通过