### PR TITLE
fix(ci): enforce strict compatibility checks

### DIFF
--- a/.github/workflows/uni-compat.yml
+++ b/.github/workflows/uni-compat.yml
@@ -71,8 +71,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Unit Tests
+        run: pnpm run test:unit
+
       - name: Compatibility Check
-        run: pnpm run compat-check
+        run: pnpm run compat-check:strict
 
       - name: ESLint
         run: pnpm run lint:eslint

--- a/scripts/compat-check.js
+++ b/scripts/compat-check.js
@@ -156,9 +156,11 @@ function scanContent(filePath, content) {
     if (isIgnorableLine(line)) return;
 
     if (mpReachable) {
-      findings.push(...matchRules(ERROR_RULES, ext, line, filePath, lineNo, 'error', {
-        isComponentClick: isComponentClickLine(lines, index),
-      }));
+      findings.push(
+        ...matchRules(ERROR_RULES, ext, line, filePath, lineNo, 'error', {
+          isComponentClick: isComponentClickLine(lines, index),
+        })
+      );
     }
 
     findings.push(...matchRules(WARN_RULES, ext, line, filePath, lineNo, 'warn'));
@@ -188,9 +190,10 @@ function applyDirective(stack, directive) {
   }
 
   stack.push({
-    mpReachable: directive.type === 'ifdef'
-      ? expressionAllowsMp(directive.expression)
-      : !expressionRequiresMp(directive.expression),
+    mpReachable:
+      directive.type === 'ifdef'
+        ? expressionAllowsMp(directive.expression)
+        : !expressionRequiresMp(directive.expression),
   });
 }
 
@@ -276,7 +279,9 @@ function formatFinding(finding, cwd = process.cwd()) {
 
 function printResult(result, strict = false) {
   if (result.missingRoot) {
-    console.warn(`[compat-check] 未找到 ${result.root}，跳过检查。`);
+    const message = `[compat-check] 未找到扫描目录：${result.root}`;
+    if (strict) console.error(`${message}；strict 模式失败。`);
+    else console.warn(`${message}；跳过检查。`);
     return;
   }
 
@@ -302,7 +307,7 @@ function main() {
   const result = runCompatCheck(options);
   printResult(result, options.strict);
 
-  if (options.strict && result.errorCount > 0) {
+  if (options.strict && (result.missingRoot || result.errorCount > 0)) {
     process.exitCode = 1;
   }
 }

--- a/tests/unit/compat-check.spec.ts
+++ b/tests/unit/compat-check.spec.ts
@@ -1,11 +1,29 @@
+import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
+const COMPAT_SCRIPT_PATH = fileURLToPath(new URL('../../scripts/compat-check.js', import.meta.url));
+const WORKFLOW_PATH = fileURLToPath(
+  new URL('../../.github/workflows/uni-compat.yml', import.meta.url)
+);
+const PACKAGE_PATH = fileURLToPath(new URL('../../package.json', import.meta.url));
 const { expressionAllowsMp, scanContent } = require('../../scripts/compat-check.js') as {
   expressionAllowsMp: (expression: string) => boolean;
   scanContent: (filePath: string, content: string) => Array<{ id: string; level: string }>;
 };
+
+function runCompatCheck(root: string, strict: boolean) {
+  return spawnSync(
+    process.execPath,
+    [COMPAT_SCRIPT_PATH, '--root', root, ...(strict ? ['--strict'] : [])],
+    { encoding: 'utf8' }
+  );
+}
 
 describe('compat-check rules', () => {
   it('understands UniApp platform guards for mini-program reachability', () => {
@@ -18,32 +36,41 @@ describe('compat-check rules', () => {
     const nativeFindings = scanContent('sample.vue', '<template><view @click="tap" /></template>');
     expect(nativeFindings.some(item => item.id === 'no-click-template')).toBe(true);
 
-    const componentFindings = scanContent('sample.vue', '<template><lk-button @click="submit" /></template>');
+    const componentFindings = scanContent(
+      'sample.vue',
+      '<template><lk-button @click="submit" /></template>'
+    );
     expect(componentFindings.some(item => item.id === 'no-click-template')).toBe(false);
   });
 
   it('requires browser APIs and dynamic components to be isolated from mini programs', () => {
-    const unsafe = scanContent('sample.vue', [
-      '<script setup>',
-      'document.createElement("div");',
-      '</script>',
-      '<template><component :is="current" /></template>',
-    ].join('\n'));
+    const unsafe = scanContent(
+      'sample.vue',
+      [
+        '<script setup>',
+        'document.createElement("div");',
+        '</script>',
+        '<template><component :is="current" /></template>',
+      ].join('\n')
+    );
     expect(unsafe.map(item => item.id)).toContain('no-browser-dom');
     expect(unsafe.map(item => item.id)).toContain('no-dynamic-component-mp');
 
-    const guarded = scanContent('sample.vue', [
-      '<script setup>',
-      '// #ifdef H5',
-      'document.createElement("div");',
-      '// #endif',
-      '</script>',
-      '<template>',
-      '<!-- #ifdef H5 || APP-PLUS -->',
-      '<component :is="current" />',
-      '<!-- #endif -->',
-      '</template>',
-    ].join('\n'));
+    const guarded = scanContent(
+      'sample.vue',
+      [
+        '<script setup>',
+        '// #ifdef H5',
+        'document.createElement("div");',
+        '// #endif',
+        '</script>',
+        '<template>',
+        '<!-- #ifdef H5 || APP-PLUS -->',
+        '<component :is="current" />',
+        '<!-- #endif -->',
+        '</template>',
+      ].join('\n')
+    );
     expect(guarded.filter(item => item.level === 'error')).toEqual([]);
   });
 
@@ -56,5 +83,57 @@ describe('compat-check rules', () => {
 
     const safe = scanContent('sample.scss', '.lk-input { &.is-error { color: red; } }');
     expect(safe.map(item => item.id)).not.toContain('no-global-parent-selector');
+  });
+
+  it('keeps report mode non-blocking while strict mode blocks only errors', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'lucky-ui-compat-'));
+
+    try {
+      const unsafePath = join(fixtureRoot, 'unsafe.vue');
+      writeFileSync(unsafePath, '<template><div>unsafe</div></template>\n', 'utf8');
+
+      const reportOnly = runCompatCheck(fixtureRoot, false);
+      expect(reportOnly.status).toBe(0);
+      expect(`${reportOnly.stdout}${reportOnly.stderr}`).toContain('error 1');
+
+      const strictError = runCompatCheck(fixtureRoot, true);
+      expect(strictError.status).toBe(1);
+      expect(`${strictError.stdout}${strictError.stderr}`).toContain('strict 模式将因 error 失败');
+
+      unlinkSync(unsafePath);
+      writeFileSync(join(fixtureRoot, 'warning.scss'), '.fixture { position: fixed; }\n', 'utf8');
+
+      const strictWarning = runCompatCheck(fixtureRoot, true);
+      expect(strictWarning.status).toBe(0);
+      expect(`${strictWarning.stdout}${strictWarning.stderr}`).toContain('error 0 条，warn 1 条');
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the strict scan root does not exist', () => {
+    const missingRoot = join(tmpdir(), `lucky-ui-compat-missing-${process.pid}-${Date.now()}`);
+
+    const reportOnly = runCompatCheck(missingRoot, false);
+    expect(reportOnly.status).toBe(0);
+    expect(`${reportOnly.stdout}${reportOnly.stderr}`).toContain('未找到扫描目录');
+
+    const strict = runCompatCheck(missingRoot, true);
+    expect(strict.status).toBe(1);
+    expect(`${strict.stdout}${strict.stderr}`).toContain('strict 模式失败');
+  });
+
+  it('keeps the package alias strict and runs its contract in the compatibility workflow', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+    const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['compat-check:strict']).toBe(
+      'node scripts/compat-check.js --strict'
+    );
+    expect(workflow).toContain('run: pnpm run test:unit');
+    expect(workflow).toContain('run: pnpm run compat-check:strict');
+    expect(workflow).not.toMatch(/run:\s+pnpm run compat-check\s*$/m);
   });
 });


### PR DESCRIPTION
## 变更内容

- CI 兼容性任务执行全量单元测试
- Compatibility Check 切换到 strict 模式
- strict 模式在扫描根目录缺失时明确失败
- 扩充兼容检查器的指令分支和缺失目录回归测试

## 验证

- tests/unit/compat-check.spec.ts：7/7 通过
- pnpm run compat-check:strict 通过（0 error，57 warn）