### PR TITLE
chore(tooling): 现代化 Vue 类型检查

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "predev:h5": "pnpm run compat-check",
     "predev:mp-weixin": "pnpm run compat-check",
     "compat:matrix": "pnpm run compat-check:strict && pnpm run type-check && pnpm run build:h5 && pnpm run build:mp:all && pnpm run test:mp",
-    "type-check": "vue-tsc --noEmit",
+    "type-check": "vue-tsc --noEmit --incremental --tsBuildInfoFile node_modules/.cache/lucky-ui/vue-tsc.tsbuildinfo",
+    "type-check:watch": "vue-tsc --noEmit --watch --incremental --tsBuildInfoFile node_modules/.cache/lucky-ui/vue-tsc.tsbuildinfo",
     "type-check:changed": "node scripts/type-check-changed.js",
     "lint": "pnpm run lint:eslint && pnpm run lint:stylelint",
     "lint:eslint": "eslint --ext .js,.ts,.vue src",
@@ -93,7 +94,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",
     "@vue/runtime-core": "^3.4.21",
-    "@vue/tsconfig": "^0.1.3",
+    "@vue/tsconfig": "^0.9.1",
     "bootstrap-icons": "^1.13.1",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
@@ -112,16 +113,11 @@
     "stylelint-config-standard-vue": "^1.0.0",
     "svgo": "^4.0.1",
     "svgtofont": "^6.4.0",
-    "typescript": "^4.9.4",
+    "typescript": "^5.9.3",
     "vite": "5.4.21",
     "vitepress": "^1.5.0",
     "vitest": "^2.1.9",
     "vue-eslint-parser": "^10.2.0",
-    "vue-tsc": "^1.0.24"
-  },
-  "pnpm": {
-    "overrides": {
-      "postcss": "^8.5.6"
-    }
+    "vue-tsc": "^3.3.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,61 +13,61 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-app-harmony':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-app-plus':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-alipay':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-baidu':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-jd':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-kuaishou':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-lark':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-qq':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-toutiao':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-xhs':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-quickapp-webview':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       pinia:
         specifier: 2.3.1
-        version: 2.3.1(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5))
+        version: 2.3.1(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3))
       vue:
         specifier: ^3.4.21
-        version: 3.5.18(typescript@4.9.5)
+        version: 3.5.18(typescript@5.9.3)
       vue-i18n:
         specifier: ^9.1.9
-        version: 9.14.5(vue@3.5.18(typescript@4.9.5))
+        version: 9.14.5(vue@3.5.18(typescript@5.9.3))
       vuex:
         specifier: ^4.1.0
-        version: 4.1.0(vue@3.5.18(typescript@4.9.5))
+        version: 4.1.0(vue@3.5.18(typescript@5.9.3))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -77,16 +77,16 @@ importers:
         version: 3.4.19
       '@dcloudio/uni-automator':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-stacktracey':
         specifier: 3.0.0-4030620241128001
         version: 3.0.0-4030620241128001
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-4030620241128001
-        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+        version: 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -95,16 +95,16 @@ importers:
         version: 1.59.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.46.3
-        version: 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5))(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+        version: 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.46.3
-        version: 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+        version: 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
       '@vue/runtime-core':
         specifier: ^3.4.21
         version: 3.5.18
       '@vue/tsconfig':
-        specifier: ^0.1.3
-        version: 0.1.3(@types/node@24.2.0)
+        specifier: ^0.9.1
+        version: 0.9.1(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3))
       bootstrap-icons:
         specifier: ^1.13.1
         version: 1.13.1
@@ -119,7 +119,7 @@ importers:
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.5.1)))(eslint@9.39.1(jiti@2.5.1))(prettier@3.6.2)
       eslint-plugin-vue:
         specifier: ^10.5.1
-        version: 10.5.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5))(eslint@9.39.1(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1)))
+        version: 10.5.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1)))
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -140,19 +140,19 @@ importers:
         version: 1.89.2
       stylelint:
         specifier: ^16.25.0
-        version: 16.25.0(typescript@4.9.5)
+        version: 16.25.0(typescript@5.9.3)
       stylelint-config-prettier-scss:
         specifier: ^1.0.0
-        version: 1.0.0(stylelint@16.25.0(typescript@4.9.5))
+        version: 1.0.0(stylelint@16.25.0(typescript@5.9.3))
       stylelint-config-recommended-scss:
         specifier: ^16.0.2
-        version: 16.0.2(postcss@8.5.6)(stylelint@16.25.0(typescript@4.9.5))
+        version: 16.0.2(postcss@8.5.6)(stylelint@16.25.0(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^39.0.1
-        version: 39.0.1(stylelint@16.25.0(typescript@4.9.5))
+        version: 39.0.1(stylelint@16.25.0(typescript@5.9.3))
       stylelint-config-standard-vue:
         specifier: ^1.0.0
-        version: 1.0.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5))
+        version: 1.0.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3))
       svgo:
         specifier: ^4.0.1
         version: 4.0.1
@@ -160,14 +160,14 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0(chokidar@3.6.0)
       typescript:
-        specifier: ^4.9.4
-        version: 4.9.5
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: 5.4.21
         version: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
       vitepress:
         specifier: ^1.5.0
-        version: 1.6.4(@algolia/client-search@5.42.0)(@types/node@24.2.0)(less@3.13.1)(postcss@8.5.6)(sass@1.89.2)(search-insights@2.17.3)(terser@5.43.1)(typescript@4.9.5)
+        version: 1.6.4(@algolia/client-search@5.42.0)(@types/node@24.2.0)(less@3.13.1)(postcss@8.5.6)(sass@1.89.2)(search-insights@2.17.3)(terser@5.43.1)(typescript@5.9.3)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@24.2.0)(jsdom@16.7.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
@@ -175,8 +175,8 @@ importers:
         specifier: ^10.2.0
         version: 10.2.0(eslint@9.39.1(jiti@2.5.1))
       vue-tsc:
-        specifier: ^1.0.24
-        version: 1.8.27(typescript@4.9.5)
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@5.9.3)
 
 packages:
 
@@ -2137,14 +2137,14 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
-  '@volar/language-core@1.11.1':
-    resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@1.11.1':
-    resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
-  '@volar/typescript@1.11.1':
-    resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue/babel-helper-vue-transform-on@1.4.0':
     resolution: {integrity: sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==}
@@ -2202,13 +2202,8 @@ packages:
   '@vue/devtools-shared@7.7.7':
     resolution: {integrity: sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==}
 
-  '@vue/language-core@1.8.27':
-    resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@vue/language-core@3.3.11':
+    resolution: {integrity: sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==}
 
   '@vue/reactivity@3.5.18':
     resolution: {integrity: sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==}
@@ -2235,12 +2230,15 @@ packages:
   '@vue/shared@3.5.18':
     resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
 
-  '@vue/tsconfig@0.1.3':
-    resolution: {integrity: sha512-kQVsh8yyWPvHpb8gIc9l/HIDiiVUy1amynLNpCy8p+FoCiZXCo6fQos5/097MmnNZc9AtseDsCrfkhqCrJ8Olg==}
+  '@vue/tsconfig@0.9.1':
+    resolution: {integrity: sha512-buvjm+9NzLCJL29KY1j1991YYJ5e6275OiK+G4jtmfIb+z4POywbdm0wXusT9adVWqe0xqg70TbI7+mRx4uU9w==}
     peerDependencies:
-      '@types/node': '*'
+      typescript: '>= 5.8'
+      vue: ^3.4.0
     peerDependenciesMeta:
-      '@types/node':
+      typescript:
+        optional: true
+      vue:
         optional: true
 
   '@vueuse/core@12.8.2':
@@ -2364,6 +2362,9 @@ packages:
   algoliasearch@5.42.0:
     resolution: {integrity: sha512-X5+PtWc9EJIPafT/cj8ZG+6IU3cjRRnlHGtqMHK/9gsiupQbAyYlH5y7qt/FtsAhfX5AICHffZy69ZAsVrxWkQ==}
     engines: {node: '>= 14.0.0'}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -2716,9 +2717,6 @@ packages:
   compare-versions@3.6.0:
     resolution: {integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==}
 
-  computeds@0.0.1:
-    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2861,9 +2859,6 @@ packages:
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
-
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3458,10 +3453,6 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -4224,8 +4215,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  muggle-string@0.3.1:
-    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -4470,6 +4461,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -5294,9 +5289,9 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.1:
@@ -5522,6 +5517,9 @@ packages:
       jsdom:
         optional: true
 
+  vscode-uri@3.2.0:
+    resolution: {integrity: sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -5551,14 +5549,11 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
-  vue-template-compiler@2.7.16:
-    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
-
-  vue-tsc@1.8.27:
-    resolution: {integrity: sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==}
+  vue-tsc@3.3.11:
+    resolution: {integrity: sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==}
     hasBin: true
     peerDependencies:
-      typescript: '*'
+      typescript: '>=5.0.0'
 
   vue@3.5.18:
     resolution: {integrity: sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==}
@@ -6672,9 +6667,9 @@ snapshots:
 
   '@dcloudio/types@3.4.19': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-app-harmony@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-app-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-app-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       debug: 4.4.1
       fs-extra: 10.1.0
       licia: 1.48.0
@@ -6689,10 +6684,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-app-plus@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-app-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-app-uts': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-app-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-app-vue': 3.0.0-4030620241128001
       debug: 4.4.1
       fs-extra: 10.1.0
@@ -6708,11 +6703,11 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-app-uts@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
       '@dcloudio/uni-nvue-styler': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
@@ -6741,14 +6736,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-app-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
       '@dcloudio/uni-nvue-styler': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       debug: 4.4.1
@@ -6766,15 +6761,15 @@ snapshots:
 
   '@dcloudio/uni-app-vue@3.0.0-4030620241128001': {}
 
-  '@dcloudio/uni-app@3.0.0-4030620241128001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-app@3.0.0-4030620241128001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@dcloudio/types': 3.4.19
-      '@dcloudio/uni-cloud': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-components': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cloud': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-components': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
-      '@dcloudio/uni-push': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-push': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
-      '@dcloudio/uni-stat': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-stat': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -6785,9 +6780,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-automator@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-automator@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       address: 1.2.2
       cross-env: 7.0.3
       debug: 4.4.1
@@ -6812,7 +6807,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-cli-shared@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
@@ -6829,7 +6824,7 @@ snapshots:
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/compiler-ssr': 3.4.21
-      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@4.9.5))
+      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.4.21
       adm-zip: 0.5.16
       autoprefixer: 10.4.21(postcss@8.5.6)
@@ -6859,7 +6854,7 @@ snapshots:
       resolve: 1.22.10
       source-map-js: 1.2.1
       tapable: 2.2.2
-      unplugin-auto-import: 0.18.6(@vueuse/core@12.8.2(typescript@4.9.5))(rollup@4.46.2)
+      unplugin-auto-import: 0.18.6(@vueuse/core@12.8.2(typescript@5.9.3))(rollup@4.46.2)
       xregexp: 3.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -6870,9 +6865,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-cloud@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -6886,10 +6881,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-components@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-h5': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cloud': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-h5': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -6900,14 +6895,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-h5-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
-      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@4.9.5))
+      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.4.21
       debug: 4.4.1
       fs-extra: 10.1.0
@@ -6922,26 +6917,26 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vue@3.0.0-4030620241128001(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-h5-vue@3.0.0-4030620241128001(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
-      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@4.9.5))
+      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@5.9.3))
     transitivePeerDependencies:
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-h5@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-h5-vue': 3.0.0-4030620241128001(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-h5-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-h5-vue': 3.0.0-4030620241128001(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
-      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@4.9.5))
+      '@vue/server-renderer': 3.4.21(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.4.21
       debug: 4.4.1
       localstorage-polyfill: 1.0.1
       postcss-selector-parser: 6.1.2
       safe-area-insets: 1.4.1
-      vue-router: 4.5.1(vue@3.5.18(typescript@4.9.5))
+      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.3))
       xmlhttprequest: 1.8.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -6954,10 +6949,10 @@ snapshots:
 
   '@dcloudio/uni-i18n@3.0.0-4030620241128001': {}
 
-  '@dcloudio/uni-mp-alipay@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-alipay@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
@@ -6971,13 +6966,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-baidu@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-baidu@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -6998,12 +6993,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-compiler@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -7018,11 +7013,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-jd@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-jd@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -7035,13 +7030,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-kuaishou@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-kuaishou@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -7057,12 +7052,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-lark@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-lark@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
@@ -7076,10 +7071,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-qq@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-qq@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -7093,11 +7088,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-core': 3.4.21
@@ -7111,11 +7106,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-vite@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-i18n': 3.0.0-4030620241128001
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/compiler-dom': 3.4.21
@@ -7136,10 +7131,10 @@ snapshots:
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
 
-  '@dcloudio/uni-mp-weixin@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-weixin@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -7160,11 +7155,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-xhs@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-mp-xhs@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -7182,9 +7177,9 @@ snapshots:
       parse-css-font: 4.0.0
       postcss: 8.5.6
 
-  '@dcloudio/uni-push@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-push@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -7194,10 +7189,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-quickapp-webview@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-quickapp-webview@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
-      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-mp-vue': 3.0.0-4030620241128001
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@vue/shared': 3.4.21
@@ -7216,9 +7211,9 @@ snapshots:
 
   '@dcloudio/uni-stacktracey@3.0.0-4030620241128001': {}
 
-  '@dcloudio/uni-stat@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/uni-stat@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       debug: 4.4.1
     transitivePeerDependencies:
@@ -7230,17 +7225,17 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@dcloudio/vite-plugin-uni@3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.0)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
-      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@4.9.5))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@4.9.5))
+      '@dcloudio/uni-cli-shared': 3.0.0-4030620241128001(@vueuse/core@12.8.2(typescript@5.9.3))(postcss@8.5.6)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       '@dcloudio/uni-shared': 3.0.0-4030620241128001
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       '@vitejs/plugin-legacy': 5.3.2(terser@5.43.1)(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -7256,7 +7251,7 @@ snapshots:
       magic-string: 0.30.17
       picocolors: 1.1.1
       terser: 5.43.1
-      unplugin-auto-import: 0.18.6(@vueuse/core@12.8.2(typescript@4.9.5))(rollup@4.46.2)
+      unplugin-auto-import: 0.18.6(@vueuse/core@12.8.2(typescript@5.9.3))(rollup@4.46.2)
       vite: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8325,41 +8320,41 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5))(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.3
-      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.3
       eslint: 9.39.1(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.3
       debug: 4.4.1
       eslint: 9.39.1(jiti@2.5.1)
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.3(typescript@4.9.5)':
+  '@typescript-eslint/project-service@8.46.3(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@4.9.5)
+      '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.3
       debug: 4.4.1
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8368,28 +8363,28 @@ snapshots:
       '@typescript-eslint/types': 8.46.3
       '@typescript-eslint/visitor-keys': 8.46.3
 
-  '@typescript-eslint/tsconfig-utils@8.46.3(typescript@4.9.5)':
+  '@typescript-eslint/tsconfig-utils@8.46.3(typescript@5.9.3)':
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
       debug: 4.4.1
       eslint: 9.39.1(jiti@2.5.1)
-      ts-api-utils: 2.1.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.46.3': {}
 
-  '@typescript-eslint/typescript-estree@8.46.3(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@8.46.3(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.3(typescript@4.9.5)
-      '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@4.9.5)
+      '@typescript-eslint/project-service': 8.46.3(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.3
       '@typescript-eslint/visitor-keys': 8.46.3
       debug: 4.4.1
@@ -8397,19 +8392,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/types': 8.46.3
-      '@typescript-eslint/typescript-estree': 8.46.3(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.5.1)
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8435,25 +8430,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
       vite: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.1.0(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       vite: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -8495,18 +8490,17 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@volar/language-core@1.11.1':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 1.11.1
+      '@volar/source-map': 2.4.28
 
-  '@volar/source-map@1.11.1':
-    dependencies:
-      muggle-string: 0.3.1
+  '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@1.11.1':
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/language-core': 1.11.1
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
+      vscode-uri: 3.2.0
 
   '@vue/babel-helper-vue-transform-on@1.4.0': {}
 
@@ -8619,19 +8613,15 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@1.8.27(typescript@4.9.5)':
+  '@vue/language-core@3.3.11':
     dependencies:
-      '@volar/language-core': 1.11.1
-      '@volar/source-map': 1.11.1
+      '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.18
       '@vue/shared': 3.5.18
-      computeds: 0.0.1
-      minimatch: 9.0.5
-      muggle-string: 0.3.1
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
       path-browserify: 1.0.1
-      vue-template-compiler: 2.7.16
-    optionalDependencies:
-      typescript: 4.9.5
+      picomatch: 4.0.7
 
   '@vue/reactivity@3.5.18':
     dependencies:
@@ -8649,40 +8639,41 @@ snapshots:
       '@vue/shared': 3.5.18
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.21(vue@3.5.18(typescript@4.9.5))':
+  '@vue/server-renderer@3.4.21(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@4.9.5))':
+  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.18
       '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
   '@vue/shared@3.4.21': {}
 
   '@vue/shared@3.5.18': {}
 
-  '@vue/tsconfig@0.1.3(@types/node@24.2.0)':
+  '@vue/tsconfig@0.9.1(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3))':
     optionalDependencies:
-      '@types/node': 24.2.0
+      typescript: 5.9.3
+      vue: 3.5.18(typescript@5.9.3)
 
-  '@vueuse/core@12.8.2(typescript@4.9.5)':
+  '@vueuse/core@12.8.2(typescript@5.9.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@4.9.5)
-      vue: 3.5.18(typescript@4.9.5)
+      '@vueuse/shared': 12.8.2(typescript@5.9.3)
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.6.6)(typescript@4.9.5)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.6.6)(typescript@5.9.3)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@4.9.5)
-      '@vueuse/shared': 12.8.2(typescript@4.9.5)
-      vue: 3.5.18(typescript@4.9.5)
+      '@vueuse/core': 12.8.2(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@5.9.3)
+      vue: 3.5.18(typescript@5.9.3)
     optionalDependencies:
       focus-trap: 7.6.6
     transitivePeerDependencies:
@@ -8690,9 +8681,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@4.9.5)':
+  '@vueuse/shared@12.8.2(typescript@5.9.3)':
     dependencies:
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -8771,6 +8762,8 @@ snapshots:
       '@algolia/requester-browser-xhr': 5.42.0
       '@algolia/requester-fetch': 5.42.0
       '@algolia/requester-node-http': 5.42.0
+
+  alien-signals@3.2.1: {}
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -9169,8 +9162,6 @@ snapshots:
 
   compare-versions@3.6.0: {}
 
-  computeds@0.0.1: {}
-
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
@@ -9205,14 +9196,14 @@ snapshots:
 
   core-js@3.44.0: {}
 
-  cosmiconfig@9.0.0(typescript@4.9.5):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
   cross-env@7.0.3:
     dependencies:
@@ -9297,8 +9288,6 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-
-  de-indent@1.0.2: {}
 
   debug@2.6.9:
     dependencies:
@@ -9524,7 +9513,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.5.1))
 
-  eslint-plugin-vue@10.5.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5))(eslint@9.39.1(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1))):
+  eslint-plugin-vue@10.5.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.5.1))
       eslint: 9.39.1(jiti@2.5.1)
@@ -9535,7 +9524,7 @@ snapshots:
       vue-eslint-parser: 10.2.0(eslint@9.39.1(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.5.1))(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -9961,8 +9950,6 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  he@1.2.0: {}
 
   hookable@5.5.3: {}
 
@@ -10952,7 +10939,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  muggle-string@0.3.1: {}
+  muggle-string@0.4.1: {}
 
   mz@2.7.0:
     dependencies:
@@ -11185,18 +11172,20 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.7: {}
+
   pify@2.3.0: {}
 
   pify@4.0.1:
     optional: true
 
-  pinia@2.3.1(typescript@4.9.5)(vue@3.5.18(typescript@4.9.5)):
+  pinia@2.3.1(typescript@5.9.3)(vue@3.5.18(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@4.9.5)
-      vue-demi: 0.14.10(vue@3.5.18(typescript@4.9.5))
+      vue: 3.5.18(typescript@5.9.3)
+      vue-demi: 0.14.10(vue@3.5.18(typescript@5.9.3))
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -11736,50 +11725,50 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-html@1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.0
-      stylelint: 16.25.0(typescript@4.9.5)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint-config-prettier-scss@1.0.0(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-prettier-scss@1.0.0(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@4.9.5)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint-config-recommended-scss@16.0.2(postcss@8.5.6)(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-recommended-scss@16.0.2(postcss@8.5.6)(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.6)
-      stylelint: 16.25.0(typescript@4.9.5)
-      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@4.9.5))
-      stylelint-scss: 6.12.1(stylelint@16.25.0(typescript@4.9.5))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@5.9.3))
+      stylelint-scss: 6.12.1(stylelint@16.25.0(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.6
 
-  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.0
       semver: 7.7.2
-      stylelint: 16.25.0(typescript@4.9.5)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5))
-      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@4.9.5))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3))
+      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@5.9.3))
 
-  stylelint-config-recommended@17.0.0(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-recommended@17.0.0(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@4.9.5)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint-config-standard-vue@1.0.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-standard-vue@1.0.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.0
-      stylelint: 16.25.0(typescript@4.9.5)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5))
-      stylelint-config-recommended-vue: 1.6.1(postcss-html@1.8.0)(stylelint@16.25.0(typescript@4.9.5))
-      stylelint-config-standard: 39.0.1(stylelint@16.25.0(typescript@4.9.5))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3))
+      stylelint-config-recommended-vue: 1.6.1(postcss-html@1.8.0)(stylelint@16.25.0(typescript@5.9.3))
+      stylelint-config-standard: 39.0.1(stylelint@16.25.0(typescript@5.9.3))
 
-  stylelint-config-standard@39.0.1(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-config-standard@39.0.1(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@4.9.5)
-      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@4.9.5))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.25.0(typescript@5.9.3))
 
-  stylelint-scss@6.12.1(stylelint@16.25.0(typescript@4.9.5)):
+  stylelint-scss@6.12.1(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       css-tree: 3.1.0
       is-plain-object: 5.0.0
@@ -11789,9 +11778,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
-      stylelint: 16.25.0(typescript@4.9.5)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint@16.25.0(typescript@4.9.5):
+  stylelint@16.25.0(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -11800,7 +11789,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.2.1
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0(typescript@4.9.5)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
       debug: 4.4.3
@@ -12034,9 +12023,9 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@2.1.0(typescript@4.9.5):
+  ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -12079,7 +12068,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript@4.9.5: {}
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -12158,7 +12147,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-auto-import@0.18.6(@vueuse/core@12.8.2(typescript@4.9.5))(rollup@4.46.2):
+  unplugin-auto-import@0.18.6(@vueuse/core@12.8.2(typescript@5.9.3))(rollup@4.46.2):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
@@ -12169,7 +12158,7 @@ snapshots:
       unimport: 3.14.6(rollup@4.46.2)
       unplugin: 1.16.1
     optionalDependencies:
-      '@vueuse/core': 12.8.2(typescript@4.9.5)
+      '@vueuse/core': 12.8.2(typescript@5.9.3)
     transitivePeerDependencies:
       - rollup
 
@@ -12262,7 +12251,7 @@ snapshots:
       sass: 1.89.2
       terser: 5.43.1
 
-  vitepress@1.6.4(@algolia/client-search@5.42.0)(@types/node@24.2.0)(less@3.13.1)(postcss@8.5.6)(sass@1.89.2)(search-insights@2.17.3)(terser@5.43.1)(typescript@4.9.5):
+  vitepress@1.6.4(@algolia/client-search@5.42.0)(@types/node@24.2.0)(less@3.13.1)(postcss@8.5.6)(sass@1.89.2)(search-insights@2.17.3)(terser@5.43.1)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.42.0)(search-insights@2.17.3)
@@ -12271,17 +12260,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@4.9.5))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.18
-      '@vueuse/core': 12.8.2(typescript@4.9.5)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.6.6)(typescript@4.9.5)
+      '@vueuse/core': 12.8.2(typescript@5.9.3)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.6.6)(typescript@5.9.3)
       focus-trap: 7.6.6
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.21(@types/node@24.2.0)(less@3.13.1)(sass@1.89.2)(terser@5.43.1)
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.5.6
     transitivePeerDependencies:
@@ -12346,9 +12335,11 @@ snapshots:
       - supports-color
       - terser
 
-  vue-demi@0.14.10(vue@3.5.18(typescript@4.9.5)):
+  vscode-uri@3.2.0: {}
+
+  vue-demi@0.14.10(vue@3.5.18(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
   vue-eslint-parser@10.2.0(eslint@9.39.1(jiti@2.5.1)):
     dependencies:
@@ -12362,44 +12353,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@9.14.5(vue@3.5.18(typescript@4.9.5)):
+  vue-i18n@9.14.5(vue@3.5.18(typescript@5.9.3)):
     dependencies:
       '@intlify/core-base': 9.14.5
       '@intlify/shared': 9.14.5
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
-  vue-router@4.5.1(vue@3.5.18(typescript@4.9.5)):
+  vue-router@4.5.1(vue@3.5.18(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
-  vue-template-compiler@2.7.16:
+  vue-tsc@3.3.11(typescript@5.9.3):
     dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.11
+      typescript: 5.9.3
 
-  vue-tsc@1.8.27(typescript@4.9.5):
-    dependencies:
-      '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@4.9.5)
-      semver: 7.7.2
-      typescript: 4.9.5
-
-  vue@3.5.18(typescript@4.9.5):
+  vue@3.5.18(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.18
       '@vue/compiler-sfc': 3.5.18
       '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@4.9.5))
+      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.5.18
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
-  vuex@4.1.0(vue@3.5.18(typescript@4.9.5)):
+  vuex@4.1.0(vue@3.5.18(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@4.9.5)
+      vue: 3.5.18(typescript@5.9.3)
 
   w3c-hr-time@1.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+overrides:
+  postcss: ^8.5.6
+
+allowBuilds:
+  vue-demi: true

--- a/src/uni_modules/lucky-ui/components/lk-dropdown/dropdown.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-dropdown/dropdown.utils.ts
@@ -81,8 +81,10 @@ export function shouldTeleportDropdown(teleport: unknown): boolean {
   return teleport !== false;
 }
 
-export function resolveDropdownTeleportTarget(teleport: unknown): unknown {
-  if (teleport === true || teleport === undefined || teleport === '') return 'body';
+export function resolveDropdownTeleportTarget(
+  teleport: string | HTMLElement | boolean | undefined
+): string | HTMLElement {
+  if (typeof teleport === 'boolean' || teleport === undefined || teleport === '') return 'body';
   return teleport;
 }
 

--- a/tests/unit/lk-dropdown.spec.ts
+++ b/tests/unit/lk-dropdown.spec.ts
@@ -222,6 +222,7 @@ describe('lk-dropdown open and item rules', () => {
     expect(shouldTeleportDropdown(true)).toBe(true);
     expect(shouldTeleportDropdown(false)).toBe(false);
     expect(resolveDropdownTeleportTarget(true)).toBe('body');
+    expect(resolveDropdownTeleportTarget(false)).toBe('body');
     expect(resolveDropdownTeleportTarget('body')).toBe('body');
 
     expect(resolveDropdownTeleportedMenuPosition({


### PR DESCRIPTION
## 📌 变更说明 (Summary)

- **变更背景/原因**：现有 `vue-tsc 1.8.27 + TypeScript 4.9.5` 全量类型检查约需 27.5 秒，本地反馈较慢。
- **核心改动内容**：
  - 升级到 `vue-tsc 3.3.11`、`TypeScript 5.9.3`、`@vue/tsconfig 0.9.1`。
  - 为全量类型检查增加增量缓存，并新增 `type-check:watch`。
  - 将 pnpm override 迁移到 `pnpm-workspace.yaml`，兼容 CI 的 pnpm 10 和本地 pnpm 11。
  - 收窄 Dropdown Teleport 目标类型，并补充 `false` 回退测试。
- **性能结果**：冷启动约 27.5s → 6.88s；热缓存约 2.88s（`pnpm run` 含启动开销约 3.45s）。
- **关联 Issue**：N/A

---

## 🏷️ 变更类型 (Change Type)

- [ ] `feat`: 新功能 / 新特性
- [ ] `fix`: 缺陷修复
- [ ] `style`: 代码格式化
- [ ] `refactor`: 代码重构
- [ ] `perf`: 性能优化
- [ ] `docs`: 文档/Demo 变更
- [x] `test`: 单元测试补充或修正
- [x] `chore` / `build` / `ci`: 构建、依赖或工程配置变更

---

## ✅ 提 PR 前自检清单 (Checklist)

### 1. 规范与提交 (Commit & Spec)
- [x] Commit 信息符合 Angular 规范（中文描述、小写 scope）。
- [x] 本提交不是 `style` 类型，未混入 CSS/SCSS/UI 样式修改。

### 2. 代码质量与验证 (Quality & Test)
- [x] `pnpm run type-check` 通过；watch 模式首次检查 0 errors。
- [x] `pnpm run test:unit` 通过：87 个测试文件、750 项测试。
- [x] `pnpm run lint:eslint` 通过。
- [x] `pnpm run lint:stylelint` 通过（13 条既有 warning，0 error）。
- [x] 改动源码符合现有格式；未执行全仓写入式 `pnpm run format`，避免重排既有测试文件产生无关 diff。
- [x] CI 同款 pnpm 10 frozen-lockfile 校验通过，pnpm 11 安装通过。

### 3. 多端兼容与文档 (Compatibility & Docs)
- [x] H5 构建通过。
- [x] 微信、支付宝、百度、QQ、抖音、飞书、快手、京东、小红书小程序构建全部通过。
- [x] `compat-check:strict` 通过：0 error，57 条既有 warning。
- [x] 小程序渲染测试通过。
- [x] 不涉及组件公开 API、Props 或 Events 变更，无需更新 Markdown 文档。

---

## 📸 视觉/效果演示 (Screenshots / Demos)

不涉及 UI 布局或交互效果变化。