### PR TITLE
feat(tag): 支持图标并统一组件对齐

### DIFF
--- a/docs/components/basic/tag.md
+++ b/docs/components/basic/tag.md
@@ -96,7 +96,9 @@ function remove(t: string) {
 |------|------|------|--------|
 | type | 样式变体 | `solid \| outline \| light` | `light` |
 | size | 尺寸 | `sm \| md \| lg` | `md` |
+| icon | 前置图标名称 | `string` | `''` |
 | closable | 是否可关闭 | `boolean` | `false` |
+| closeIcon | 关闭图标名称 | `string` | `'x'` |
 | disabled | 是否禁用 | `boolean` | `false` |
 | round | 是否胶囊圆角 | `boolean` | `true` |
 | textColor | 自定义文字颜色 | `string` | `''` |
@@ -119,3 +121,5 @@ function remove(t: string) {
 | 插槽名 | 说明 |
 |--------|------|
 | default | 标签内容 |
+| icon | 自定义前置图标插槽 |
+| close-icon | 自定义关闭图标插槽 |

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -50,7 +50,9 @@ phone: tag
 |------|------|------|--------|
 | type | 样式变体 | `solid / outline / light` | `light` |
 | size | 尺寸 | `sm / md / lg` | `md` |
+| icon | 前置图标名称 | `string` | `''` |
 | closable | 是否可关闭 | `boolean` | `false` |
+| closeIcon | 关闭图标名称 | `string` | `'x'` |
 | disabled | 是否禁用 | `boolean` | `false` |
 | round | 是否胶囊圆角 | `boolean` | `true` |
 | textColor | 自定义文字颜色 | `string` | `''` |
@@ -72,3 +74,5 @@ phone: tag
 | 插槽名 | 说明 |
 |--------|------|
 | default | 标签内容 |
+| icon | 自定义前置图标插槽 |
+| close-icon | 自定义关闭图标插槽 |

--- a/src/pages/app-main/tabs/components/home-content.vue
+++ b/src/pages/app-main/tabs/components/home-content.vue
@@ -426,10 +426,6 @@ const goToSearch = () => {
     min-width: 0;
     min-height: 0;
     box-sizing: border-box;
-
-    :deep(.lk-icon) {
-      vertical-align: 0;
-    }
   }
 
   .search-bar {

--- a/src/pages_sub/components/demos/tag-demo.vue
+++ b/src/pages_sub/components/demos/tag-demo.vue
@@ -2,7 +2,6 @@
 import { ref, computed } from 'vue';
 import LkTag from '@/uni_modules/lucky-ui/components/lk-tag/lk-tag.vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
-import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 
@@ -85,9 +84,9 @@ const toggleTag = (name: string) => {
           v-for="tag in selectableTags"
           :key="tag.name"
           class="selectable-tag"
+          :icon="tag.selected ? 'check-circle-fill' : ''"
           @click="toggleTag(tag.name)"
         >
-          <lk-icon v-if="tag.selected" name="check-circle-fill" class="selectable-tag__icon" />
           {{ tag.label }}
         </lk-tag>
       </lk-space>
@@ -113,15 +112,5 @@ const toggleTag = (name: string) => {
 
 .selectable-tag {
   cursor: pointer;
-}
-
-.selectable-tag__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1em;
-  height: 1em;
-  line-height: 1;
-  margin-right: 8rpx;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-button/lk-button.vue
+++ b/src/uni_modules/lucky-ui/components/lk-button/lk-button.vue
@@ -142,12 +142,7 @@ function emitNativeEvent(name: ButtonNativeEventName, e: unknown) {
     @im="emitNativeEvent('im', $event)"
   >
     <view v-if="loading" class="lk-button__loader" />
-    <lk-icon
-      v-if="icon && !loading"
-      class="lk-button__icon"
-      :name="icon"
-      custom-style="--lk-icon-vertical-align: -0.125em"
-    />
+    <lk-icon v-if="icon && !loading" class="lk-button__icon" :name="icon" />
     <slot />
     <view v-if="isRippleEnabled" class="lk-ripple__wave" :style="rippleWaveStyle" />
   </button>

--- a/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.scss
+++ b/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.scss
@@ -4,12 +4,14 @@
   font-family: 'lk-icons' !important;
   font-style: normal;
   font-weight: normal;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 1em;
   height: 1em;
   line-height: 1;
   text-align: center;
-  vertical-align: var(--lk-icon-vertical-align, -0.25em);
+  vertical-align: var(--lk-icon-vertical-align, middle);
   flex-shrink: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -31,6 +33,6 @@
   transition: var(--lk-transition-fast);
 
   .lk-icon {
-    vertical-align: 0;
+    vertical-align: middle;
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue
+++ b/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue
@@ -14,7 +14,13 @@ import './fonts/lk-icons.css';
 import './fonts/lk-icons-definitions.css';
 // #endif
 
-defineOptions({ name: 'LkIcon', inheritAttrs: false });
+defineOptions({
+  name: 'LkIcon',
+  options: {
+    virtualHost: true,
+  },
+  inheritAttrs: false,
+});
 
 const props = defineProps(iconProps);
 const emit = defineEmits(iconEmits);
@@ -87,9 +93,7 @@ function handleClick(e: Event) {
   >
     <text class="lk-icon">{{ iconChar }}</text>
   </view>
-  <text v-else :class="iconClass" :style="mergedIconStyle" aria-hidden="true" @tap="handleClick">
-    {{ iconChar }}
-  </text>
+  <text v-else :class="iconClass" :style="mergedIconStyle" aria-hidden="true" @tap="handleClick">{{ iconChar }}</text>
 </template>
 
 <style lang="scss">

--- a/src/uni_modules/lucky-ui/components/lk-tag/lk-tag.scss
+++ b/src/uni_modules/lucky-ui/components/lk-tag/lk-tag.scss
@@ -1,16 +1,17 @@
-﻿@use '../../theme/src/mixins/bem' as *;
+@use '../../theme/src/mixins/bem' as *;
 
 @include b(tag) {
   --_fs: var(--lk-rpx-24);
   --_px: var(--lk-rpx-20);
   --_py: var(--lk-rpx-8);
   --_radius: var(--lk-radius-full);
+  --_icon-gap: var(--lk-spacing-xs);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: var(--_fs);
   padding: var(--_py) var(--_px);
-  line-height: 1.4;
+  line-height: 1;
   border-radius: var(--_radius);
   user-select: none;
   box-sizing: border-box;
@@ -27,16 +28,19 @@
     --_fs: var(--lk-rpx-22);
     --_px: var(--lk-rpx-12);
     --_py: var(--lk-rpx-4);
+    --_icon-gap: var(--lk-spacing-xxs);
   }
   @include m(md) {
     --_fs: var(--lk-rpx-26);
     --_px: var(--lk-rpx-20);
     --_py: var(--lk-rpx-12);
+    --_icon-gap: var(--lk-spacing-xs);
   }
   @include m(lg) {
     --_fs: var(--lk-rpx-28);
     --_px: var(--lk-rpx-36);
     --_py: var(--lk-rpx-20);
+    --_icon-gap: var(--lk-spacing-sm);
   }
 
   @include m(light) {
@@ -65,22 +69,37 @@
   }
 
   @include e(content) {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     color: inherit;
-    line-height: inherit;
+    line-height: 1;
+  }
+
+  @include e(icon) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: var(--_icon-gap, var(--lk-spacing-xs));
+    font-size: inherit;
+    line-height: 1;
+    flex-shrink: 0;
   }
 
   @include e(close) {
-    font-size: var(--lk-rpx-28);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: var(--_icon-gap, var(--lk-spacing-xs));
+    font-size: inherit;
     line-height: 1;
     color: inherit;
-    padding: var(--lk-rpx-4);
-    margin-left: var(--lk-spacing-xs);
     border-radius: var(--lk-radius-sm);
+    cursor: pointer;
+    flex-shrink: 0;
+
     &:active {
-      background: var(--lk-fill-2);
+      opacity: 0.7;
     }
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-tag/lk-tag.vue
+++ b/src/uni_modules/lucky-ui/components/lk-tag/lk-tag.vue
@@ -3,6 +3,7 @@ import type { StyleValue } from 'vue';
 import { tagEmits, tagProps } from './tag.props';
 import { computed } from 'vue';
 import { resolveTagClass, resolveTagEventName, resolveTagStyle } from './tag.utils';
+import LkIcon from '../lk-icon/lk-icon.vue';
 
 defineOptions({ name: 'LkTag' });
 
@@ -57,9 +58,18 @@ const customStyle = computed(() =>
     @tap="onClick"
   >
     <view class="lk-tag__content">
+      <view v-if="props.icon || $slots.icon" class="lk-tag__icon">
+        <slot name="icon">
+          <lk-icon :name="props.icon" />
+        </slot>
+      </view>
       <slot />
     </view>
-    <view v-if="props.closable" class="lk-tag__close" @tap.stop="onClose">×</view>
+    <view v-if="props.closable" class="lk-tag__close" @tap.stop="onClose">
+      <slot name="close-icon">
+        <lk-icon :name="props.closeIcon" />
+      </slot>
+    </view>
   </view>
 </template>
 

--- a/src/uni_modules/lucky-ui/components/lk-tag/tag.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-tag/tag.props.ts
@@ -51,6 +51,12 @@ export const tagProps = {
   /** 是否圆角 */
   round: LkProp.boolean(true),
 
+  /** 图标名称 */
+  icon: LkProp.string(''),
+
+  /** 关闭图标名称 */
+  closeIcon: LkProp.string('x'),
+
   /** 主颜色：文字使用该颜色，背景自动生成浅色系，无边框 */
   color: LkProp.string(''),
 

--- a/tests/unit/lk-tag.spec.ts
+++ b/tests/unit/lk-tag.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { tagProps } from '../../src/uni_modules/lucky-ui/components/lk-tag/tag.props';
 import {
   expandShortHex,
   resolveTagClass,
@@ -9,6 +10,11 @@ import {
 } from '../../src/uni_modules/lucky-ui/components/lk-tag/tag.utils';
 
 describe('lk-tag style and event rules', () => {
+  it('defines stable defaults for leading and close icons', () => {
+    expect(tagProps.icon.default).toBe('');
+    expect(tagProps.closeIcon.default).toBe('x');
+  });
+
   it('expands short hex and converts hex colors to soft rgba backgrounds', () => {
     expect(expandShortHex('0af')).toBe('00aaff');
     expect(toSoftColor('#0af')).toBe('rgba(0, 170, 255, 0.12)');


### PR DESCRIPTION
## 📌 变更说明 (Summary)

- **变更背景/原因**：Tag 需要组件级前置/关闭图标能力；Icon 默认垂直偏移导致 Button 与首页分别维护局部对齐补丁。
- **核心改动内容**：
  - 统一 `lk-icon` 的 inline-flex 布局与默认垂直对齐，并启用 uni-app virtual host。
  - 删除 `lk-button` 和首页搜索入口的局部图标对齐 workaround。
  - 为 `lk-tag` 增加 `icon`、`closeIcon` props，以及 `icon`、`close-icon` 插槽。
  - 为不同 Tag 尺寸补充图标间距与关闭图标布局。
  - 更新 Tag demo、两份 API 文档和图标默认值单测。
- **提交拆分**：
  1. `fix(icon): 统一图标垂直对齐`
  2. `feat(tag): 支持前置与关闭图标`
- **关联 Issue**：N/A

---

## 🏷️ 变更类型 (Change Type)

- [x] `feat`: 新功能 / 新特性
- [x] `fix`: 缺陷修复
- [ ] `style`: 代码格式化
- [ ] `refactor`: 代码重构
- [ ] `perf`: 性能优化
- [x] `docs`: 文档/Demo 变更
- [x] `test`: 单元测试补充或修正
- [ ] `chore` / `build` / `ci`: 构建、依赖或工程配置变更

---

## ✅ 提 PR 前自检清单 (Checklist)

### 1. 规范与提交 (Commit & Spec)
- [x] 两个 Commit 均符合 Angular 规范，按 Icon 修复与 Tag 功能拆分。
- [x] 未使用 `style` 类型，未混入无关格式化。

### 2. 代码质量与验证 (Quality & Test)
- [x] `pnpm run type-check` 通过。
- [x] `pnpm run test:unit` 通过：87 个测试文件、751 项测试。
- [x] `pnpm run lint:eslint` 通过。
- [x] `pnpm run lint:stylelint` 通过：0 error，13 条既有 warning。
- [x] `pnpm run compat-check:strict` 通过：0 error，57 条既有 warning。
- [x] 保持改动文件现有格式，未执行会重排既有文件的全仓写入式格式化。

### 3. 多端兼容与文档 (Compatibility & Docs)
- [x] H5 构建通过。
- [x] 微信小程序构建通过。
- [x] 新增 Props 与 Slots 已同步更新两份 Tag Markdown 文档。
- [x] 不改变既有事件名称和交互契约。

---

## 📸 视觉/效果演示 (Screenshots / Demos)

Tag demo 已改为通过 `icon` prop 展示选中图标。本次完成 H5 与微信小程序构建级验证，未附运行态截图。