### PR TITLE
feat(grid): 支持自定义图标样式

### DIFF
--- a/docs/components/grid.md
+++ b/docs/components/grid.md
@@ -92,6 +92,8 @@ import GridDemo from '@/pages_sub/components/demos/grid-demo.vue'
 | columns | 列数；不传时自动填充 | `number` | `undefined` |
 | gap | 栅格整体间距 | `number` | `undefined` |
 | itemGap | 单个栅格项内部图标与文本的间距 | `number` | `undefined` |
+| iconColor | 所有宫格项的默认图标颜色 | `string` | `''` |
+| iconSize | 所有宫格项的默认图标尺寸 | `string \| number` | `36` |
 | carousel | 是否启用轮播分页模式 | `boolean` | `false` |
 | rows | 轮播模式下每页行数 | `number` | `undefined` |
 | items | 宫格数据源 | `GridItem[]` | `[]` |
@@ -105,6 +107,8 @@ import GridDemo from '@/pages_sub/components/demos/grid-demo.vue'
 |------|------|------|
 | text | 文本内容 | `string` |
 | icon | 图标名称 | `string` |
+| iconColor | 图标颜色（支持语义色和任意颜色值） | `string` |
+| iconSize | 图标尺寸（默认 36rpx） | `string \| number` |
 | disabled | 是否禁用点击 | `boolean` |
 | ...rest | 其他业务字段，便于外部自行扩展 | `unknown` |
 

--- a/src/uni_modules/lucky-ui/components/lk-button/lk-button.scss
+++ b/src/uni_modules/lucky-ui/components/lk-button/lk-button.scss
@@ -26,6 +26,7 @@
   border-radius: var(--_radius);
   background: var(--_bg);
   color: var(--_color);
+  --lk-icon-color: var(--_color);
   border: var(--_border);
 
   font-weight: 500;

--- a/src/uni_modules/lucky-ui/components/lk-grid/grid.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-grid/grid.props.ts
@@ -3,6 +3,8 @@ import { baseProps, LkProp } from '../common/props';
 
 export interface GridItem {
   icon?: string;
+  iconColor?: string;
+  iconSize?: string | number;
   text: string;
   disabled?: boolean;
   [key: string]: unknown;
@@ -40,6 +42,12 @@ export const gridProps = {
     type: Number,
     default: undefined,
   },
+
+  /** 图标尺寸 */
+  iconSize: LkProp.stringNumber(36),
+
+  /** 图标颜色 */
+  iconColor: LkProp.string(''),
 
   /** 宫格数据 */
   items: {

--- a/src/uni_modules/lucky-ui/components/lk-grid/grid.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-grid/grid.utils.ts
@@ -64,6 +64,21 @@ export function resolveGridItemClass(options: {
   };
 }
 
+export function resolveGridItemIconColor(itemColor?: string, defaultColor?: string): string {
+  if (itemColor) return itemColor;
+  if (defaultColor) return defaultColor;
+  return '';
+}
+
+export function resolveGridItemIconSize(
+  itemSize?: string | number,
+  defaultSize?: string | number
+): string | number {
+  if (itemSize !== undefined && itemSize !== '') return itemSize;
+  if (defaultSize !== undefined && defaultSize !== '') return defaultSize;
+  return 36;
+}
+
 export function resolveGridClickResult(options: {
   item: GridItem;
   index: number;

--- a/src/uni_modules/lucky-ui/components/lk-grid/lk-grid.scss
+++ b/src/uni_modules/lucky-ui/components/lk-grid/lk-grid.scss
@@ -4,6 +4,7 @@
   display: grid;
   width: auto; // 重要：让负 margin 正常工作
   grid-auto-rows: 1fr;
+  color: var(--lk-text-primary);
 
   &-container {
     width: 100%;
@@ -21,6 +22,7 @@
     align-items: center;
     justify-content: center;
     padding: var(--lk-spacing-sm);
+    color: var(--lk-text-primary);
     transition: background var(--lk-transition-fast);
     overflow: visible;
   }

--- a/src/uni_modules/lucky-ui/components/lk-grid/lk-grid.vue
+++ b/src/uni_modules/lucky-ui/components/lk-grid/lk-grid.vue
@@ -12,6 +12,8 @@ import {
   resolveGridGap,
   resolveGridInnerGapStyle,
   resolveGridItemClass,
+  resolveGridItemIconColor,
+  resolveGridItemIconSize,
   resolveGridItemStyle,
   resolveGridStyle,
 } from './grid.utils';
@@ -45,6 +47,14 @@ const pages = computed(() => paginateGridItems(props.items || [], props.columns,
 
 function resolveGridPage(page: unknown): GridItem[] {
   return Array.isArray(page) ? (page as GridItem[]) : [];
+}
+
+function itemIconColor(item: GridItem): string {
+  return resolveGridItemIconColor(item.iconColor, props.iconColor);
+}
+
+function itemIconSize(item: GridItem): string | number {
+  return resolveGridItemIconSize(item.iconSize, props.iconSize);
 }
 
 function onItemClick(item: GridItem, index: number, pageIndex: number = 0, event?: unknown) {
@@ -93,7 +103,12 @@ function onPageChange(index: number, oldIndex?: number) {
           :style="itemStyle"
           @tap="onItemClick(it, Number(idx), Number(pageIndex), $event)"
         >
-          <lk-icon v-if="it.icon" :name="it.icon" size="36" />
+          <lk-icon
+            v-if="it.icon"
+            :name="it.icon"
+            :color="itemIconColor(it)"
+            :size="itemIconSize(it)"
+          />
           <text class="lk-grid__item-text" :style="innerGapStyle">{{ it.text }}</text>
           <view class="lk-ripple__wave" :style="rippleWaveStyle" />
         </view>
@@ -120,7 +135,12 @@ function onPageChange(index: number, oldIndex?: number) {
           :style="itemStyle"
           @tap="onItemClick(item, index, 0, $event)"
         >
-          <lk-icon v-if="item.icon" :name="item.icon" size="36" />
+          <lk-icon
+            v-if="item.icon"
+            :name="item.icon"
+            :color="itemIconColor(item)"
+            :size="itemIconSize(item)"
+          />
           <text class="lk-grid__item-text" :style="innerGapStyle">{{ item.text }}</text>
           <view class="lk-ripple__wave" :style="rippleWaveStyle" />
         </view>

--- a/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.scss
+++ b/src/uni_modules/lucky-ui/components/lk-icon/lk-icon.scss
@@ -15,9 +15,7 @@
   flex-shrink: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  /* 继承父容器颜色（如按钮、列表等），保证在有背景色的容器内自动匹配 */
-  /* 如果用户传了 color prop，会通过内联样式覆盖 */
-  color: inherit;
+  color: var(--lk-icon-color, var(--lk-text-primary, inherit));
 }
 
 @include b(icon-bg-box) {
@@ -27,7 +25,7 @@
   box-sizing: border-box;
   flex-shrink: 0;
   overflow: hidden;
-  color: inherit;
+  color: var(--lk-icon-color, var(--lk-text-primary, inherit));
   line-height: 1;
   vertical-align: middle;
   transition: var(--lk-transition-fast);

--- a/tests/unit/lk-grid.spec.ts
+++ b/tests/unit/lk-grid.spec.ts
@@ -6,6 +6,8 @@ import {
   resolveGridGap,
   resolveGridInnerGapStyle,
   resolveGridItemClass,
+  resolveGridItemIconColor,
+  resolveGridItemIconSize,
   resolveGridItemKey,
   resolveGridItemStyle,
   resolveGridStyle,
@@ -34,6 +36,16 @@ describe('lk-grid layout and click rules', () => {
 
   it('builds container class from clipping state', () => {
     expect(resolveGridContainerClass(true)).toEqual(['lk-grid-container', { 'is-clipped': true }]);
+  });
+
+  it('resolves per-item icon options before grid defaults', () => {
+    expect(resolveGridItemIconColor('warning', 'primary')).toBe('warning');
+    expect(resolveGridItemIconColor('', 'primary')).toBe('primary');
+    expect(resolveGridItemIconColor()).toBe('');
+
+    expect(resolveGridItemIconSize(48, 36)).toBe(48);
+    expect(resolveGridItemIconSize('', '40rpx')).toBe('40rpx');
+    expect(resolveGridItemIconSize()).toBe(36);
   });
 
   it('paginates items by columns multiplied by rows', () => {


### PR DESCRIPTION
## 背景

统一图标在主题组件中的颜色继承行为，并为 Grid 增加更灵活的图标颜色与尺寸配置。

## 变更内容

- `fix(icon): 统一主题颜色继承`
  - 图标使用 `--lk-icon-color` 变量，并保留文本主色与继承回退
  - Button 将当前按钮文字颜色传递给内部图标
- `feat(grid): 支持自定义图标样式`
  - Grid 增加全局 `iconColor`、`iconSize` 属性
  - GridItem 支持逐项覆盖图标颜色和尺寸
  - 补充解析工具、单元测试与组件文档

## 验证结果

- `pnpm run test:unit`：87 个测试文件、752 项测试通过
- `pnpm run compat-check:strict`：通过（0 error，57 条既存 warning）
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：通过（0 error，13 条既存 warning）
- `pnpm run type-check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过

## 验收说明

已完成 H5 与微信小程序构建级验证；本次未执行运行时截图验收。