### PR TITLE
fix(upload): 完善自定义触发器插槽

### DIFF
--- a/docs/components/upload.md
+++ b/docs/components/upload.md
@@ -155,13 +155,15 @@ const customRequest = ({ file, action, name, headers, data, onProgress, onSucces
 
 ## 自定义上传按钮
 
-通过 `trigger` 插槽自定义上传区域内容。
+通过 `trigger` 插槽自定义上传区域内容。插槽会完整替换默认图标、文案和数量提示；如需数量提示，请在插槽内自行渲染。
 
 ```vue
 <lk-upload v-model="fileList">
   <template #trigger>
-    <lk-icon name="camera" size="48" />
-    <text>拍照</text>
+    <view class="custom-trigger">
+      <lk-icon name="camera" size="48" />
+      <text class="custom-trigger-text">拍照上传</text>
+    </view>
   </template>
 </lk-upload>
 ```

--- a/src/pages_sub/components/demos/upload-demo.vue
+++ b/src/pages_sub/components/demos/upload-demo.vue
@@ -198,8 +198,10 @@ const mockCustomRequest: InstanceType<typeof LkUpload>['$props']['customRequest'
     <demo-block title="自定义上传按钮" desc="通过 trigger 插槽自定义">
       <lk-upload v-model="fileList7" upload-text="" :max-count="1">
         <template #trigger>
-          <lk-icon name="camera" size="48" />
-          <text class="upload-custom-text">拍照上传</text>
+          <view class="upload-custom-trigger">
+            <lk-icon name="camera" size="48" />
+            <text class="upload-custom-text">拍照上传</text>
+          </view>
         </template>
       </lk-upload>
     </demo-block>
@@ -243,6 +245,13 @@ const mockCustomRequest: InstanceType<typeof LkUpload>['$props']['customRequest'
   > :not(:first-child) {
     margin-top: 32rpx;
   }
+}
+
+.upload-custom-trigger {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .upload-custom-text {

--- a/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue
+++ b/src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue
@@ -788,10 +788,10 @@ defineExpose({
           <text v-if="resolvedUploadText" class="lk-upload__add-text">{{
             resolvedUploadText
           }}</text>
+          <text v-if="maxCount < 99" class="lk-upload__count">
+            {{ fileList.length }}/{{ maxCount }}
+          </text>
         </slot>
-        <text v-if="maxCount < 99" class="lk-upload__count">
-          {{ fileList.length }}/{{ maxCount }}
-        </text>
       </view>
 
       <!-- 内置删除确认弹窗 -->

--- a/tests/unit/lk-upload.spec.ts
+++ b/tests/unit/lk-upload.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   createH5UploadFiles,
@@ -109,5 +110,25 @@ describe('lk-upload file normalization', () => {
     expect(isImageUrl('wxfile://tmp-file')).toBe(true);
     expect(isImageUrl('https://cdn.example.com/a.pdf')).toBe(false);
     expect(getUploadFileName('', 'fallback')).toBe('fallback');
+  });
+});
+
+describe('lk-upload trigger slot contract', () => {
+  it('lets a custom trigger replace every piece of default trigger content', () => {
+    const source = readFileSync(
+      new URL(
+        '../../src/uni_modules/lucky-ui/components/lk-upload/lk-upload.vue',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    const slotStart = source.indexOf('<slot name="trigger">');
+    const slotEnd = source.indexOf('</slot>', slotStart);
+    const count = source.indexOf('class="lk-upload__count"');
+
+    expect(slotStart).toBeGreaterThanOrEqual(0);
+    expect(count).toBeGreaterThan(slotStart);
+    expect(count).toBeLessThan(slotEnd);
+    expect(source.indexOf('class="lk-upload__count"', count + 1)).toBe(-1);
   });
 });


### PR DESCRIPTION
## 背景

使用 `trigger` 插槽自定义 Upload 上传按钮时，组件仍会在插槽内容后强制渲染默认数量提示，导致自定义布局不完整。

## 变更内容

- 将默认数量提示移动到 `trigger` 插槽的 fallback 内容中
- 自定义 `trigger` 现在会完整替换默认图标、文案和数量提示
- 调整 Demo 的自定义触发器容器，明确纵向布局
- 更新组件文档并补充插槽契约回归测试

## 验证结果

- `pnpm run test:unit`：87 个测试文件、753 项测试通过
- `pnpm run compat-check:strict`：通过（0 error，57 条既存 warning）
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：通过（0 error，13 条既存 warning）
- `pnpm run type-check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过

## 验收说明

已完成 H5 与微信小程序构建级验证；本次未执行运行时截图验收。