### PR TITLE
feat(collapse): 增强样式与异步切换

### DIFF
--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -19,10 +19,10 @@ const activeNames = ref(['1'])
 <template>
   <lk-collapse v-model="activeNames">
     <lk-collapse-item name="1" title="标题 1">
-      <view style="padding: 24rpx">折叠内容 1</view>
+      <view>折叠内容 1</view>
     </lk-collapse-item>
     <lk-collapse-item name="2" title="标题 2">
-      <view style="padding: 24rpx">折叠内容 2</view>
+      <view>折叠内容 2</view>
     </lk-collapse-item>
   </lk-collapse>
 </template>
@@ -42,10 +42,10 @@ const activeName = ref('1')
 <template>
   <lk-collapse v-model="activeName" accordion>
     <lk-collapse-item name="1" title="配送说明">
-      <view style="padding: 24rpx">仅展开当前项</view>
+      <view>仅展开当前项</view>
     </lk-collapse-item>
     <lk-collapse-item name="2" title="售后说明">
-      <view style="padding: 24rpx">打开后会自动关闭其他项</view>
+      <view>打开后会自动关闭其他项</view>
     </lk-collapse-item>
   </lk-collapse>
 </template>
@@ -56,31 +56,69 @@ const activeName = ref('1')
 ```vue
 <lk-collapse v-model="activeNames" @click-disabled="handleDisabled">
   <lk-collapse-item name="1" title="可用项">
-    <view style="padding: 24rpx">正常展开</view>
+    <view>正常展开</view>
   </lk-collapse-item>
   <lk-collapse-item name="2" title="禁用项" disabled>
-    <view style="padding: 24rpx">点击不会展开</view>
+    <view>点击不会展开</view>
   </lk-collapse-item>
 </lk-collapse>
 ```
 
-## 自定义标题内容
+## 异步展开切换
 
-`lk-collapse-item` 提供 `title` 插槽，可以放入图标、状态标签等内容。
+通过 `before-toggle` 属性传入拦截函数或异步 `Promise`，可用于在展开前进行权限校验或数据异步加载，执行过程中右侧会自动展示 Loading 加载状态：
 
 ```vue
-<lk-collapse v-model="activeNames">
-  <lk-collapse-item name="1">
-    <template #title>
-      <view style="display:flex;align-items:center;gap:12rpx">
-        <lk-icon name="info-circle" size="28" color="primary" />
-        <text>带图标标题</text>
-      </view>
-    </template>
+<script setup lang="ts">
+import { ref } from 'vue'
 
-    <view style="padding:24rpx">自定义标题插槽</view>
-  </lk-collapse-item>
-</lk-collapse>
+const activeNames = ref(['1'])
+
+function handleBeforeToggle(name: string | number, expanded: boolean) {
+  if (!expanded) return true // 收起无需等待
+  return new Promise<boolean>((resolve) => {
+    setTimeout(() => {
+      resolve(true) // 返回 true 允许展开，返回 false 阻止展开
+    }, 600)
+  })
+}
+</script>
+
+<template>
+  <lk-collapse v-model="activeNames">
+    <lk-collapse-item
+      name="1"
+      title="异步加载内容"
+      :before-toggle="handleBeforeToggle"
+    >
+      <view>异步获取的内容已加载完毕</view>
+    </lk-collapse-item>
+  </lk-collapse>
+</template>
+```
+
+## 自定义标题与操作图标
+
+`lk-collapse-item` 支持通过属性直接切换加减号图标（推荐使用粗体饱满的 `plus-lg` / `dash-lg`）、展开收起文字，或使用 `title` 与 `arrow` 插槽自定义：
+
+```vue
+<!-- 1. 加减号图标切换 -->
+<lk-collapse-item name="1" title="加减号模式" arrow-icon="plus-lg" open-icon="dash-lg">
+  <view>折叠内容</view>
+</lk-collapse-item>
+
+<!-- 2. 展开/收起文字 -->
+<lk-collapse-item name="2" title="文字操作" arrow-text="展开" open-text="收起">
+  <view>折叠内容</view>
+</lk-collapse-item>
+
+<!-- 3. 自定义箭头插槽 -->
+<lk-collapse-item name="3" title="自定义插槽">
+  <template #arrow="{ open, loading }">
+    <text>{{ loading ? '加载中...' : (open ? '已展开' : '点击查看') }}</text>
+  </template>
+  <view>折叠内容</view>
+</lk-collapse-item>
 ```
 
 ## 推荐示例
@@ -117,9 +155,15 @@ import CollapseDemo from '@/pages_sub/components/demos/collapse-demo.vue'
 |------|------|------|--------|
 | modelValue | 当前展开面板；普通模式为数组，手风琴模式为字符串或数字 | `any[] \| string \| number` | `[]` |
 | accordion | 是否开启手风琴模式 | `boolean` | `false` |
-| variant | 折叠面板风格 | `group \| card \| ghost` | `group` |
-| gap | 卡片模式下项目间距 | `string \| number` | `var(--lk-spacing-sm)` |
-| bordered | 是否显示边框 | `boolean` | `true` |
+| variant | 折叠面板风格：`default` 线条列表、`group` 整块分组、`card` 分离卡片、`ghost` 轻量无框 | `default \| group \| card \| ghost` | `default` |
+| gap | `card`、`ghost` 模式下的项目间距 | `string \| number` | `var(--lk-spacing-sm)` |
+| bordered | 是否显示边框/分割线 | `boolean` | `true` |
+| arrow | 全局是否显示右侧箭头 | `boolean` | `true` |
+| arrowIcon | 全局收起时图标名 | `string` | `''` |
+| openIcon | 全局展开时图标名 | `string` | `''` |
+| animationDuration | 展开动画时长；为空时继承主题变量 | `string` | `''` |
+| animationTiming | 展开动画缓动函数；为空时继承主题变量 | `string` | `''` |
+| beforeToggle | 切换面板前的全局拦截钩子，支持异步 Promise | `(name, expanded) => boolean \| Promise<boolean>` | — |
 | id | 根节点 id | `string` | `''` |
 | customClass | 根节点自定义类名 | `string \| object \| array` | — |
 | customStyle | 根节点自定义样式 | `string \| object` | — |
@@ -131,6 +175,13 @@ import CollapseDemo from '@/pages_sub/components/demos/collapse-demo.vue'
 | name | 面板唯一标识 | `string \| number` | — |
 | title | 标题文本 | `string` | `''` |
 | disabled | 是否禁用当前面板 | `boolean` | `false` |
+| arrow | 是否显示右侧箭头/操作区（未设置时继承父级） | `boolean` | `undefined` |
+| arrowIcon | 自定义收起时的图标名（如 `'plus-lg'`） | `string` | `''` |
+| openIcon | 自定义展开时的图标名（如 `'dash-lg'`） | `string` | `''` |
+| arrowText | 自定义收起时的文本（如 `'展开'`） | `string` | `''` |
+| openText | 自定义展开时的文本（如 `'收起'`） | `string` | `''` |
+| iconSize | 右侧图标尺寸 | `string \| number` | `var(--lk-rpx-28)` |
+| beforeToggle | 切换当前面板前的拦截钩子，支持异步 Promise | `(name, expanded) => boolean \| Promise<boolean>` | — |
 
 ### Events
 
@@ -160,13 +211,14 @@ import CollapseDemo from '@/pages_sub/components/demos/collapse-demo.vue'
 
 #### LkCollapseItem
 
-| 插槽名 | 说明 |
-|--------|------|
-| title | 自定义标题区域 |
-| default | 折叠内容 |
+| 插槽名 | 说明 | 作用域参数 |
+|--------|------|------------|
+| title | 自定义标题区域 | `{ open, disabled }` |
+| arrow | 自定义右侧箭头/操作区域 | `{ open, disabled, loading }` |
+| default | 折叠内容 | — |
 
 ## 使用建议
 
 ::: tip
-如果你需要“左侧导航 + 右侧内容联动”的结构，请使用 `lk-anchor`，不要用折叠面板替代锚点导航。
+如果你的页面是以线条排布为主的常规信息，使用默认 `variant="default"`；如果需要整块卡片包裹，显式指定 `variant="group"` 或 `variant="card"`。
 :::

--- a/src/pages_sub/components/demos/collapse-demo.vue
+++ b/src/pages_sub/components/demos/collapse-demo.vue
@@ -4,125 +4,170 @@ import LkCollapse from '@/uni_modules/lucky-ui/components/lk-collapse/lk-collaps
 import LkCollapseItem from '@/uni_modules/lucky-ui/components/lk-collapse/lk-collapse-item.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 
-const activeNames1 = ref(['1']);
-const activeNames2 = ref(['1']);
-const activeNames3 = ref(['1']);
-const activeNames4 = ref('1');
-const activeNames5 = ref(['1']);
+const defaultActive = ref(['1']);
+const accordionActive = ref('1');
+const iconAccordionActive = ref('1');
+const asyncActive = ref(['1']);
+const groupActive = ref(['1']);
+const cardActive = ref(['1']);
+const ghostActive = ref(['1']);
+const disabledActive = ref(['1']);
+
+function handleBeforeToggle(_name: string | number, expanded: boolean) {
+  if (!expanded) return true; // 收起直接允许
+  return new Promise<boolean>(resolve => {
+    setTimeout(() => {
+      resolve(true);
+    }, 600);
+  });
+}
 </script>
 
 <template>
   <view class="component-demo">
-    <demo-block title="动画速率调节" desc="通过 duration 和 timing 自定义动画曲线">
-      <view class="demo-item">
-        <text class="label">慢速展开 (0.8s, linear)</text>
-        <lk-collapse v-model="activeNames1" animation-duration="0.8s" animation-timing="linear">
-          <lk-collapse-item name="1" title="平滑慢速">
-            <view class="collapse-content"> duration=0.8s, timing=linear </view>
-          </lk-collapse-item>
-        </lk-collapse>
-      </view>
-      <view class="demo-item">
-        <text class="label">快速反馈 (0.1s, ease-in-out)</text>
-        <lk-collapse
-          v-model="activeNames2"
-          animation-duration="0.1s"
-          animation-timing="ease-in-out"
-        >
-          <lk-collapse-item name="1" title="灵敏快速">
-            <view class="collapse-content"> duration=0.1s, timing=ease-in-out </view>
-          </lk-collapse-item>
-        </lk-collapse>
-      </view>
-    </demo-block>
-
-    <demo-block title="整体分组" desc="默认 group 布局，多个面板连成一整块">
-      <lk-collapse v-model="activeNames1">
-        <lk-collapse-item name="1" title="基础信息">
+    <demo-block title="基础用法">
+      <lk-collapse v-model="defaultActive">
+        <lk-collapse-item name="1" title="平滑折叠体验">
           <view class="collapse-content">
-            将多个折叠项组织在同一个容器里，适合设置页和详情页的信息分组。
+            提供跨端一致的平滑折叠展开动效，折叠时彻底收起内边距与高度。
           </view>
         </lk-collapse-item>
-        <lk-collapse-item name="2" title="配送信息">
+        <lk-collapse-item name="2" title="多项同时展开">
           <view class="collapse-content">
-            分组模式下不会出现割裂的卡片间隙，视觉上是一整块内容。
-          </view>
-        </lk-collapse-item>
-        <lk-collapse-item name="3" title="售后说明">
-          <view class="collapse-content">
-            边框、背景和圆角会由父级统一控制，亮暗主题下保持一致层级。
-          </view>
-        </lk-collapse-item>
-      </lk-collapse>
-    </demo-block>
-
-    <demo-block title="卡片布局" desc="variant=card，保留单项卡片并通过 gap 控制间距">
-      <lk-collapse v-model="activeNames2" variant="card" gap="20">
-        <lk-collapse-item name="1" title="订单进度">
-          <view class="collapse-content"> 卡片布局适合强调每个独立模块，间距由父级统一控制。 </view>
-        </lk-collapse-item>
-        <lk-collapse-item name="2" title="费用明细">
-          <view class="collapse-content">
-            不再通过 item 间的固定 margin 控制间隔，避免不同布局下间隙不可控。
-          </view>
-        </lk-collapse-item>
-      </lk-collapse>
-    </demo-block>
-
-    <demo-block title="轻量布局" desc="variant=ghost，用于页面背景上的弱容器展示">
-      <lk-collapse v-model="activeNames3" variant="ghost" :bordered="false">
-        <lk-collapse-item name="1" title="为什么选择轻量布局">
-          <view class="collapse-content">
-            轻量布局减少边框和容器存在感，适合 FAQ、帮助说明等场景。
-          </view>
-        </lk-collapse-item>
-        <lk-collapse-item name="2" title="是否支持暗黑模式">
-          <view class="collapse-content">
-            所有背景、边框和文本颜色都来自主题 token，亮暗主题会自动适配。
+            支持同时展开多个面板，默认风格轻量简洁，与页面自然融合。
           </view>
         </lk-collapse-item>
       </lk-collapse>
     </demo-block>
 
     <demo-block title="手风琴模式">
-      <lk-collapse v-model="activeNames4" accordion>
-        <lk-collapse-item name="1" title="标题1">
-          <view class="collapse-content"> 手风琴模式，同时只能展开一个面板。 </view>
+      <lk-collapse v-model="accordionActive" accordion>
+        <lk-collapse-item name="1" title="什么是手风琴模式">
+          <view class="collapse-content">
+            手风琴模式下，展开任意一项将自动收起其他已展开项。
+          </view>
         </lk-collapse-item>
-        <lk-collapse-item name="2" title="标题2">
-          <view class="collapse-content"> 点击其他面板会自动关闭当前面板。 </view>
+        <lk-collapse-item name="2" title="适用场景">
+          <view class="collapse-content">
+            适合帮助中心、常见问题（FAQ）等需要单项聚焦的场景。
+          </view>
         </lk-collapse-item>
-        <lk-collapse-item name="3" title="标题3">
-          <view class="collapse-content"> 适合 FAQ 等场景。 </view>
+        <lk-collapse-item name="3" title="平滑切换">
+          <view class="collapse-content">
+            切换过程高度动态抵消，页面无上下漂移。
+          </view>
+        </lk-collapse-item>
+      </lk-collapse>
+    </demo-block>
+
+    <demo-block title="加减号图标（手风琴）">
+      <lk-collapse
+        v-model="iconAccordionActive"
+        accordion
+        arrow-icon="plus-lg"
+        open-icon="dash-lg"
+      >
+        <lk-collapse-item name="1" title="如何办理退换货">
+          <view class="collapse-content">
+            在订单详情中提交售后申请，审核通过后寄回商品。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="2" title="配送服务范围">
+          <view class="collapse-content">
+            支持全国主要城市及部分偏远地区配送服务。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="3" title="发票开具说明">
+          <view class="collapse-content">
+            确认收货后可在订单页面自助申请开具电子普通发票。
+          </view>
+        </lk-collapse-item>
+      </lk-collapse>
+    </demo-block>
+
+    <demo-block title="异步展开">
+      <lk-collapse v-model="asyncActive">
+        <lk-collapse-item
+          name="1"
+          title="异步加载内容 (600ms)"
+          :before-toggle="handleBeforeToggle"
+        >
+          <view class="collapse-content">
+            点击展开时触发异步校验或数据请求，加载完成后平滑展开。
+          </view>
+        </lk-collapse-item>
+      </lk-collapse>
+    </demo-block>
+
+    <demo-block title="整体分组">
+      <lk-collapse v-model="groupActive" variant="group">
+        <lk-collapse-item name="1" title="账号与安全">
+          <view class="collapse-content">
+            管理个人基本信息、登录密码与绑定手机号。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="2" title="消息与通知">
+          <view class="collapse-content">
+            设置系统通知、活动推送与免打扰时段。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="3" title="通用设置">
+          <view class="collapse-content">
+            多语言、亮暗主题模式与缓存清理。
+          </view>
+        </lk-collapse-item>
+      </lk-collapse>
+    </demo-block>
+
+    <demo-block title="卡片布局">
+      <lk-collapse v-model="cardActive" variant="card">
+        <lk-collapse-item name="1" title="订单进度">
+          <view class="collapse-content">
+            包裹已由配送员揽收，正在发往目的地。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="2" title="费用明细">
+          <view class="collapse-content">
+            商品总价 ¥128.00，优惠减免 ¥20.00，实付 ¥108.00。
+          </view>
+        </lk-collapse-item>
+      </lk-collapse>
+    </demo-block>
+
+    <demo-block title="轻量布局">
+      <lk-collapse v-model="ghostActive" variant="ghost" :bordered="false">
+        <lk-collapse-item name="1" title="什么是轻量布局">
+          <view class="collapse-content">
+            去除边框与外层背景，以更轻量的方式组织内容。
+          </view>
+        </lk-collapse-item>
+        <lk-collapse-item name="2" title="适用场景">
+          <view class="collapse-content">
+            适合嵌在卡片内部、弹窗中或纯文本展示页面。
+          </view>
         </lk-collapse-item>
       </lk-collapse>
     </demo-block>
 
     <demo-block title="禁用状态">
-      <lk-collapse v-model="activeNames5" variant="card">
-        <lk-collapse-item name="1" title="正常">
-          <view class="collapse-content"> 可以正常展开 </view>
+      <lk-collapse v-model="disabledActive">
+        <lk-collapse-item name="1" title="正常面板">
+          <view class="collapse-content"> 可以正常展开收起 </view>
         </lk-collapse-item>
-        <lk-collapse-item name="2" title="禁用" disabled>
+        <lk-collapse-item name="2" title="禁用面板" disabled>
           <view class="collapse-content"> 此面板已禁用 </view>
         </lk-collapse-item>
       </lk-collapse>
     </demo-block>
   </view>
 </template>
+
 <style scoped lang="scss">
 .component-demo {
   display: flex;
   flex-direction: column;
   > :not(:first-child) {
-    margin-top: 32rpx;
+    margin-top: var(--lk-spacing-xl);
   }
-}
-
-.collapse-content {
-  padding: var(--lk-spacing-md);
-  color: var(--lk-text-secondary);
-  font-size: var(--lk-font-size-sm);
-  line-height: 1.6;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-collapse/collapse.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-collapse/collapse.props.ts
@@ -4,6 +4,7 @@ import { baseProps, LkProp } from '../common/props';
 export type CollapseName = string | number;
 
 export const CollapseVariant = {
+  Default: 'default',
   Group: 'group',
   Card: 'card',
   Ghost: 'ghost',
@@ -22,23 +23,80 @@ export const collapseProps = {
   /** 是否手风琴模式 */
   accordion: LkProp.boolean(false),
 
-  /** 折叠面板布局风格 */
-  variant: LkProp.enum(Object.values(CollapseVariant), CollapseVariant.Group, 'Collapse.variant'),
+  /** 折叠面板布局风格：默认线条列表(default)、整块分组(group)、分离卡片(card)、轻量无框(ghost) */
+  variant: LkProp.enum(Object.values(CollapseVariant), CollapseVariant.Default, 'Collapse.variant'),
 
-  /** 分离卡片模式下的项目间距 */
+  /** 卡片与轻量模式下的项目间距 */
   gap: LkProp.stringNumber('var(--lk-spacing-sm)'),
 
-  /** 是否显示边框 */
+  /** 是否显示边框/分割线 */
   bordered: LkProp.boolean(true),
 
-  /** 动画持续时间 */
-  animationDuration: LkProp.string('0.3s'),
+  /** 是否显示右侧箭头/操作区 */
+  arrow: LkProp.boolean(true),
 
-  /** 动画缓动函数 */
-  animationTiming: LkProp.string('cubic-bezier(0.4, 0, 0.2, 1)'),
+  /** 全局收起时的图标名 */
+  arrowIcon: LkProp.string(''),
+
+  /** 全局展开时的图标名 */
+  openIcon: LkProp.string(''),
+
+  /** 动画持续时间（为空时自动继承全局 Token） */
+  animationDuration: LkProp.string(''),
+
+  /** 动画缓动函数（为空时自动继承全局 Token） */
+  animationTiming: LkProp.string(''),
+
+  /** 切换面板前的拦截钩子，支持异步 Promise */
+  beforeToggle: {
+    type: Function as PropType<(name: CollapseName, expanded: boolean) => boolean | Promise<boolean>>,
+    default: undefined,
+  },
 } as const;
 
 export type CollapseProps = ExtractPropTypes<typeof collapseProps>;
+
+export const collapseItemProps = {
+  ...baseProps,
+
+  /** 面板唯一标识 */
+  name: { type: [String, Number] as PropType<CollapseName>, required: true as const },
+
+  /** 标题文本 */
+  title: LkProp.string(''),
+
+  /** 是否禁用当前面板 */
+  disabled: LkProp.boolean(false),
+
+  /** 是否显示右侧箭头（未设置时继承父级 arrow） */
+  arrow: {
+    type: Boolean,
+    default: undefined,
+  },
+
+  /** 自定义收起时的图标名（如 'chevron-down', 'plus-lg'） */
+  arrowIcon: LkProp.string(''),
+
+  /** 自定义展开时的图标名（如 'chevron-up', 'dash-lg'） */
+  openIcon: LkProp.string(''),
+
+  /** 自定义收起时的文本（如 '展开'） */
+  arrowText: LkProp.string(''),
+
+  /** 自定义展开时的文本（如 '收起'） */
+  openText: LkProp.string(''),
+
+  /** 图标尺寸 */
+  iconSize: LkProp.stringNumber('var(--lk-rpx-28)'),
+
+  /** 切换当前面板前的拦截钩子，支持异步 Promise */
+  beforeToggle: {
+    type: Function as PropType<(name: CollapseName, expanded: boolean) => boolean | Promise<boolean>>,
+    default: undefined,
+  },
+} as const;
+
+export type CollapseItemProps = ExtractPropTypes<typeof collapseItemProps>;
 
 export const collapseEmits = {
   'update:modelValue': (_value: CollapseName[] | CollapseName) => true,
@@ -57,8 +115,12 @@ export const collapseItemEmits = {
 export interface CollapseContext {
   active: Ref<CollapseName[]>;
   accordion: boolean;
+  arrow: boolean;
+  arrowIcon: string;
+  openIcon: string;
   animationDuration: string;
   animationTiming: string;
+  beforeToggle?: (name: CollapseName, expanded: boolean) => boolean | Promise<boolean>;
   toggle: (name: CollapseName, event?: unknown) => void;
   clickDisabled: (name: CollapseName, event?: unknown) => void;
 }

--- a/src/uni_modules/lucky-ui/components/lk-collapse/collapse.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-collapse/collapse.utils.ts
@@ -100,9 +100,39 @@ export function resolveCollapseHeaderClass(rippleActive: boolean) {
 export function resolveCollapseBodyStyle(options: {
   animationDuration?: string;
   animationTiming?: string;
-}) {
-  return {
-    '--lk-collapse-anim-duration': options.animationDuration,
-    '--lk-collapse-anim-timing': options.animationTiming,
-  };
+}): Record<string, string> {
+  const style: Record<string, string> = {};
+  if (options.animationDuration) {
+    style['--lk-collapse-anim-duration'] = options.animationDuration;
+  }
+  if (options.animationTiming) {
+    style['--lk-collapse-anim-timing'] = options.animationTiming;
+  }
+  return style;
+}
+
+export function resolveCollapseArrowIcon(options: {
+  open: boolean;
+  itemArrowIcon?: string;
+  itemOpenIcon?: string;
+  parentArrowIcon?: string;
+  parentOpenIcon?: string;
+}): string {
+  if (options.open) {
+    if (options.itemOpenIcon) return options.itemOpenIcon;
+    if (options.parentOpenIcon) return options.parentOpenIcon;
+  }
+  if (options.itemArrowIcon) return options.itemArrowIcon;
+  if (options.parentArrowIcon) return options.parentArrowIcon;
+  return 'chevron-down';
+}
+
+export function resolveCollapseArrowText(options: {
+  open: boolean;
+  arrowText?: string;
+  openText?: string;
+}): string {
+  if (options.open && options.openText) return options.openText;
+  if (!options.open && options.arrowText) return options.arrowText;
+  return '';
 }

--- a/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse-item.vue
+++ b/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse-item.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed, inject } from 'vue';
-import type { PropType, StyleValue } from 'vue';
+import { computed, inject, ref } from 'vue';
+import type { StyleValue } from 'vue';
 import { useRipple } from '@/uni_modules/lucky-ui/composables/useRipple';
-import { baseProps } from '../common/props';
-import { collapseInjectionKey, collapseItemEmits, type CollapseName } from './collapse.props';
+import LkLoading from '../lk-loading/lk-loading.vue';
+import { collapseInjectionKey, collapseItemEmits, collapseItemProps } from './collapse.props';
 import {
+  resolveCollapseArrowIcon,
+  resolveCollapseArrowText,
   resolveCollapseBodyStyle,
   resolveCollapseHeaderClass,
   resolveCollapseItemClass,
@@ -12,15 +14,41 @@ import {
 
 defineOptions({ name: 'LkCollapseItem' });
 
-const props = defineProps({
-  ...baseProps,
-  name: { type: [String, Number] as PropType<CollapseName>, required: true },
-  title: { type: String, default: '' },
-  disabled: { type: Boolean, default: false },
-});
+const props = defineProps(collapseItemProps);
 const emit = defineEmits(collapseItemEmits);
 const collapse = inject(collapseInjectionKey);
+
 const open = computed(() => collapse?.active.value.includes(props.name) ?? false);
+const loading = ref(false);
+
+const showArrow = computed(() => {
+  if (props.arrow !== undefined) return props.arrow;
+  return collapse?.arrow ?? true;
+});
+
+const currentArrowIcon = computed(() => {
+  return resolveCollapseArrowIcon({
+    open: open.value,
+    itemArrowIcon: props.arrowIcon,
+    itemOpenIcon: props.openIcon,
+    parentArrowIcon: collapse?.arrowIcon,
+    parentOpenIcon: collapse?.openIcon,
+  });
+});
+
+const currentArrowText = computed(() => {
+  return resolveCollapseArrowText({
+    open: open.value,
+    arrowText: props.arrowText,
+    openText: props.openText,
+  });
+});
+
+const shouldRotateArrow = computed(() => {
+  const hasDistinctOpenIcon = Boolean(props.openIcon || collapse?.openIcon);
+  return !hasDistinctOpenIcon;
+});
+
 const itemClass = computed(() =>
   resolveCollapseItemClass({
     open: open.value,
@@ -39,24 +67,40 @@ const bodyStyle = computed(() =>
   })
 );
 
-function toggle(event?: unknown) {
-  if (props.disabled) {
-    const payload = { name: props.name, event };
-    emit('click-disabled', payload);
-    collapse?.clickDisabled(props.name, event);
+async function onHeaderTap(e: unknown) {
+  if (props.disabled || loading.value) {
+    if (props.disabled) {
+      const payload = { name: props.name, event: e };
+      emit('click-disabled', payload);
+      collapse?.clickDisabled(props.name, e);
+    }
     return;
   }
-  collapse?.toggle(props.name, event);
-}
 
-function onHeaderTap(e: unknown) {
   emit('click', { name: props.name, expanded: open.value, event: e });
-  if (props.disabled) {
-    toggle(e);
-    return;
+
+  const hook = props.beforeToggle ?? collapse?.beforeToggle;
+  if (typeof hook === 'function') {
+    const willOpen = !open.value;
+    let allow = false;
+    try {
+      const result = hook(props.name, willOpen);
+      if (typeof result === 'boolean') {
+        allow = result;
+      } else {
+        loading.value = true;
+        allow = await result;
+      }
+    } catch {
+      return;
+    } finally {
+      loading.value = false;
+    }
+    if (!allow || open.value === willOpen) return;
   }
+
   triggerRipple(e);
-  toggle(e);
+  collapse?.toggle(props.name, e);
 }
 </script>
 
@@ -64,20 +108,40 @@ function onHeaderTap(e: unknown) {
   <view class="lk-collapse-item" :class="itemClass" :style="itemStyle">
     <view class="lk-collapse-item__header lk-ripple" :class="headerClass" @tap="onHeaderTap">
       <view class="lk-ripple__content">
-        <text class="lk-collapse-item__title">
-          <slot name="title">{{ title }}</slot>
-        </text>
-        <lk-icon
-          name="chevron-down"
-          size="28"
-          class="lk-collapse-item__arrow"
-          :class="{ 'is-open': open }"
-        />
+        <view class="lk-collapse-item__title">
+          <slot name="title" :open="open" :disabled="disabled">{{ title }}</slot>
+        </view>
+        <view v-if="showArrow" class="lk-collapse-item__action">
+          <slot name="arrow" :open="open" :disabled="disabled" :loading="loading">
+            <lk-loading
+              v-if="loading"
+              :size="iconSize"
+              class="lk-collapse-item__loading"
+            />
+            <text v-else-if="currentArrowText" class="lk-collapse-item__action-text">
+              {{ currentArrowText }}
+            </text>
+            <view
+              v-else
+              class="lk-collapse-item__arrow"
+              :class="{
+                'is-open': open,
+                'is-rotate': shouldRotateArrow,
+              }"
+            >
+              <lk-icon :name="currentArrowIcon" :size="iconSize" />
+            </view>
+          </slot>
+        </view>
       </view>
       <view class="lk-ripple__wave" :style="rippleWaveStyle" />
     </view>
-    <view v-show="open" class="lk-collapse-item__body" :style="bodyStyle">
-      <slot />
+    <view class="lk-collapse-item__wrapper" :class="{ 'is-open': open }" :style="bodyStyle">
+      <view class="lk-collapse-item__body">
+        <view class="lk-collapse-item__content">
+          <slot />
+        </view>
+      </view>
     </view>
   </view>
 </template>

--- a/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse.scss
+++ b/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse.scss
@@ -9,12 +9,17 @@
   --lk-collapse-header-py: var(--lk-spacing-lg);
   --lk-collapse-header-px: var(--lk-spacing-xl);
   --lk-collapse-title-size: var(--lk-font-size-lg);
-  --lk-collapse-body-px: var(--lk-spacing-xl);
-  --lk-collapse-body-pb: var(--lk-spacing-xl);
-  --lk-collapse-body-size: var(--lk-font-size-sm);
+  --lk-collapse-body-pb: var(--lk-spacing-lg);
+  --lk-collapse-body-size: var(--lk-font-size-base);
 
   display: flex;
   flex-direction: column;
+  color: var(--lk-text-primary);
+  width: 100%;
+
+  @include m(default) {
+    background: transparent;
+  }
 
   @include m(group) {
     overflow: hidden;
@@ -27,35 +32,66 @@
   }
 
   @include m(card) {
-    row-gap: var(--lk-collapse-gap);
+    > :not(:first-child) {
+      margin-top: var(--lk-collapse-gap);
+    }
   }
 
   @include m(ghost) {
-    row-gap: var(--lk-collapse-gap);
+    > :not(:first-child) {
+      margin-top: var(--lk-collapse-gap);
+    }
   }
 }
 
 @include b(collapse-item) {
-  background: var(--lk-collapse-bg);
-  border-radius: var(--lk-collapse-radius);
+  position: relative;
   overflow: hidden;
+  color: var(--lk-text-primary);
+  transition: background var(--lk-transition-fast);
 
-  .lk-collapse--card.is-bordered & {
-    border: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+  /* 默认风格：线条分割列表，默认不使用卡片 */
+  .lk-collapse--default & {
+    background: transparent;
+    border-radius: var(--lk-rpx-0);
+
+    .lk-collapse.is-bordered & {
+      border-bottom: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
   }
 
+  /* 整块分组风格 */
   .lk-collapse--group & {
-    border-radius: 0;
-    box-shadow: 0 var(--lk-rpx-1) 0 var(--lk-collapse-border-color);
+    background: var(--lk-collapse-bg);
+    border-radius: var(--lk-rpx-0);
+
+    &:not(:last-child) {
+      border-bottom: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+    }
   }
 
+  /* 分离卡片风格 */
+  .lk-collapse--card & {
+    background: var(--lk-collapse-bg);
+    border-radius: var(--lk-collapse-radius);
+
+    .lk-collapse.is-bordered & {
+      border: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+    }
+  }
+
+  /* 轻量无框风格 */
   .lk-collapse--ghost & {
     background: transparent;
     border-radius: var(--lk-collapse-radius);
-  }
 
-  .lk-collapse--ghost.is-bordered & {
-    border: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+    .lk-collapse.is-bordered & {
+      border: var(--lk-rpx-1) solid var(--lk-collapse-border-color);
+    }
   }
 
   @include e(header) {
@@ -65,22 +101,24 @@
     justify-content: space-between;
     padding: var(--lk-collapse-header-py) var(--lk-collapse-header-px);
     font-size: var(--lk-collapse-title-size);
-    font-weight: 500;
+    font-weight: var(--lk-font-weight-medium);
     transition: background var(--lk-transition-fast);
+
+    .lk-collapse--default & {
+      padding: var(--lk-collapse-header-py) var(--lk-rpx-0);
+    }
+
+    .lk-collapse--ghost & {
+      background: var(--lk-collapse-bg-soft);
+      border-radius: var(--lk-collapse-radius);
+    }
 
     .lk-ripple__content {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       width: 100%;
     }
-
-    .lk-collapse-item__arrow {
-      margin-left: var(--lk-spacing-sm);
-    }
-  }
-
-  .lk-collapse--ghost &__header {
-    background: var(--lk-collapse-bg-soft);
   }
 
   @include e(title) {
@@ -88,38 +126,92 @@
     color: var(--lk-text-primary);
   }
 
+  @include e(action) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: var(--lk-spacing-sm);
+    color: var(--lk-text-secondary);
+    font-size: var(--lk-font-size-sm);
+    flex: none;
+    line-height: 1;
+  }
+
+  @include e(action-text) {
+    color: var(--lk-text-secondary);
+    font-size: var(--lk-font-size-sm);
+    line-height: 1;
+    transition: color var(--lk-transition-fast);
+  }
+
+  @include e(loading) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    line-height: 1;
+  }
+
   @include e(arrow) {
-    transition: transform var(--lk-transition-fast);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     color: var(--lk-text-secondary);
     flex: none;
+    line-height: 1;
+    -webkit-text-stroke: calc(var(--lk-rpx-1) * 0.5) currentColor;
+    transform: rotate(0deg);
+    transform-origin: center;
+    transition: transform var(--lk-collapse-anim-duration) var(--lk-collapse-anim-timing);
+
+    .lk-icon {
+      -webkit-text-stroke: calc(var(--lk-rpx-1) * 0.5) currentColor;
+    }
+
+    &.is-rotate.is-open {
+      transform: rotate(-180deg);
+    }
+  }
+
+  @include e(wrapper) {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    transition: grid-template-rows var(--lk-collapse-anim-duration) var(--lk-collapse-anim-timing);
 
     @include when(open) {
-      transform: rotate(180deg);
+      grid-template-rows: 1fr;
     }
   }
 
   @include e(body) {
-    padding: 0 var(--lk-collapse-body-px) var(--lk-collapse-body-pb);
+    min-height: var(--lk-rpx-0);
+    overflow: hidden;
+  }
+
+  @include e(content) {
+    padding: var(--lk-rpx-0) var(--lk-collapse-header-px) var(--lk-collapse-body-pb);
     font-size: var(--lk-collapse-body-size);
-    line-height: 1.6;
-    color: var(--lk-text-secondary);
-    animation: lk-collapse-expand var(--lk-collapse-anim-duration) var(--lk-collapse-anim-timing);
+    line-height: var(--lk-line-height-loose);
+    opacity: 0;
+    transform: translateY(calc(var(--lk-rpx-8) * -1));
+    transition:
+      opacity var(--lk-collapse-anim-duration) var(--lk-collapse-anim-timing),
+      transform var(--lk-collapse-anim-duration) var(--lk-collapse-anim-timing);
+    will-change: opacity, transform;
+
+    .lk-collapse--default & {
+      padding: var(--lk-rpx-0) var(--lk-rpx-0) var(--lk-collapse-body-pb) var(--lk-rpx-0);
+    }
+
+    .lk-collapse-item__wrapper.is-open & {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   @include when(disabled) {
     opacity: 0.5;
-  }
-}
-
-@keyframes lk-collapse-expand {
-  from {
-    opacity: 0;
-    transform: translateY(calc(var(--lk-rpx-12) * -1));
-    max-height: 0;
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-    max-height: var(--lk-rpx-2000);
+    cursor: not-allowed;
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse.vue
+++ b/src/uni_modules/lucky-ui/components/lk-collapse/lk-collapse.vue
@@ -68,9 +68,27 @@ function clickDisabled(name: CollapseName, event?: unknown) {
 
 provide(collapseInjectionKey, {
   active,
-  accordion: props.accordion,
-  animationDuration: props.animationDuration,
-  animationTiming: props.animationTiming,
+  get accordion() {
+    return props.accordion;
+  },
+  get arrow() {
+    return props.arrow;
+  },
+  get arrowIcon() {
+    return props.arrowIcon;
+  },
+  get openIcon() {
+    return props.openIcon;
+  },
+  get animationDuration() {
+    return props.animationDuration;
+  },
+  get animationTiming() {
+    return props.animationTiming;
+  },
+  get beforeToggle() {
+    return props.beforeToggle;
+  },
   toggle,
   clickDisabled,
 });

--- a/src/uni_modules/lucky-ui/components/lk-loading/loading.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-loading/loading.utils.ts
@@ -1,8 +1,15 @@
 import type { StyleValue } from 'vue';
 
+export function resolveLoadingSize(size: string | number): string {
+  if (size === '' || size === undefined || size === null) return '';
+  const value = String(size).trim();
+  return /^\d+(\.\d+)?$/.test(value) ? `${value}rpx` : value;
+}
+
 export function normalizeLoadingSize(size: string | number): number {
   if (typeof size === 'number') return size;
-  return parseInt(size, 10);
+  const num = parseInt(size, 10);
+  return Number.isNaN(num) ? 40 : num;
 }
 
 export function resolveLoadingRootClass(options: {
@@ -33,22 +40,34 @@ export function resolveLoadingRootStyle(options: {
 }
 
 export function resolveLoadingSquareStyle(size: string | number) {
-  const value = normalizeLoadingSize(size);
+  const value = resolveLoadingSize(size);
   return {
-    width: `${value}rpx`,
-    height: `${value}rpx`,
+    width: value,
+    height: value,
   };
 }
 
 export function resolveLoadingHeightStyle(size: string | number) {
   return {
-    height: `${normalizeLoadingSize(size)}rpx`,
+    height: resolveLoadingSize(size),
   };
 }
 
 export function resolveLoadingBarStyle(size: string | number) {
+  const rawValue = String(size).trim();
+  if (/^\d+(\.\d+)?$/.test(rawValue)) {
+    return {
+      width: `${Number(rawValue) * 2}rpx`,
+    };
+  }
+  const value = resolveLoadingSize(size);
+  if (!value) {
+    return {
+      width: '',
+    };
+  }
   return {
-    width: `${Number(size) * 2}rpx`,
+    width: `calc(${value} + ${value})`,
   };
 }
 

--- a/src/uni_modules/lucky-ui/theme/src/component-vars.scss
+++ b/src/uni_modules/lucky-ui/theme/src/component-vars.scss
@@ -493,7 +493,7 @@ page,
   --lk-anchor-active-color: var(--lk-color-primary);
 
   --lk-collapse-anim-duration: 0.3s;
-  --lk-collapse-anim-timing: cubic-bezier(0.4, 0, 0.2, 1);
+  --lk-collapse-anim-timing: cubic-bezier(0.25, 1, 0.5, 1);
   --lk-choice-gap: var(--lk-spacing-sm);
   --lk-hs-gap: var(--lk-spacing-md);
   --lk-space-row-gap: var(--lk-spacing-md);

--- a/tests/unit/lk-collapse.spec.ts
+++ b/tests/unit/lk-collapse.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  collapseItemProps,
+  collapseProps,
+} from '../../src/uni_modules/lucky-ui/components/lk-collapse/collapse.props';
+import {
   getCollapseEmitValue,
+  resolveCollapseArrowIcon,
+  resolveCollapseArrowText,
   resolveCollapseBodyStyle,
   resolveCollapseHeaderClass,
   resolveCollapseItemClass,
@@ -101,5 +107,36 @@ describe('lk-collapse state and style rules', () => {
       '--lk-collapse-anim-duration': '0.2s',
       '--lk-collapse-anim-timing': 'ease-out',
     });
+    expect(resolveCollapseBodyStyle({})).toEqual({});
+  });
+
+  it('exposes the lightweight default variant and item icon defaults', () => {
+    expect(collapseProps.variant.default).toBe('default');
+    expect(collapseProps.arrow.default).toBe(true);
+    expect(collapseItemProps.iconSize.default).toBe('var(--lk-rpx-28)');
+  });
+
+  it('resolves item arrow options before collapse defaults', () => {
+    expect(resolveCollapseArrowIcon({
+      open: false,
+      itemArrowIcon: 'plus-lg',
+      parentArrowIcon: 'chevron-down',
+    })).toBe('plus-lg');
+    expect(resolveCollapseArrowIcon({
+      open: true,
+      itemOpenIcon: 'dash-lg',
+      parentOpenIcon: 'chevron-up',
+    })).toBe('dash-lg');
+    expect(resolveCollapseArrowIcon({ open: true })).toBe('chevron-down');
+    expect(resolveCollapseArrowText({
+      open: false,
+      arrowText: '展开',
+      openText: '收起',
+    })).toBe('展开');
+    expect(resolveCollapseArrowText({
+      open: true,
+      arrowText: '展开',
+      openText: '收起',
+    })).toBe('收起');
   });
 });

--- a/tests/unit/lk-loading.spec.ts
+++ b/tests/unit/lk-loading.spec.ts
@@ -6,6 +6,7 @@ import {
   resolveLoadingHeightStyle,
   resolveLoadingRootClass,
   resolveLoadingRootStyle,
+  resolveLoadingSize,
   resolveLoadingSquareStyle,
   resolveLoadingText,
   shouldRenderLoadingText,
@@ -34,7 +35,13 @@ describe('lk-loading display rules', () => {
       height: '48rpx',
     });
     expect(resolveLoadingHeightStyle(32)).toEqual({ height: '32rpx' });
+    expect(resolveLoadingSize(' var(--lk-rpx-28) ')).toBe('var(--lk-rpx-28)');
+    expect(resolveLoadingSquareStyle('var(--lk-rpx-28)')).toEqual({
+      width: 'var(--lk-rpx-28)',
+      height: 'var(--lk-rpx-28)',
+    });
     expect(resolveLoadingBarStyle('30')).toEqual({ width: '60rpx' });
+    expect(resolveLoadingBarStyle('2rem')).toEqual({ width: 'calc(2rem + 2rem)' });
   });
 
   it('builds root class and color style', () => {


### PR DESCRIPTION
## 背景

完善 Collapse 的常规列表样式、展开动画和操作区定制能力，并支持展开前的同步/异步校验。

## 变更内容

- `fix(loading): 支持带单位的尺寸值`
  - Loading 支持 `rpx`、`rem`、CSS 变量等尺寸值
  - Bar 类型对非纯数字尺寸使用兼容的 `calc(a + a)` 计算宽度
- `feat(collapse): 增强样式与异步切换`
  - 新增轻量线条列表 `default`，并设为默认 variant
  - 保留 `group`、`card`、`ghost` 三种显式布局
  - 支持全局及单项箭头开关、收起/展开图标、文字和图标尺寸
  - 新增 `arrow` 作用域插槽
  - 新增同步/异步 `beforeToggle`，异步等待时展示 Loading
  - 改进展开动画、响应式父级配置和异步状态变化保护
  - 更新 Demo、文档、主题缓动变量及单元测试

## 兼容性说明

默认 variant 由 `group` 调整为 `default`；需要原整块分组外观时请显式设置 `variant="group"`。

## 验证结果

- `pnpm run test:unit`：87 个测试文件、755 项测试通过
- `pnpm run compat-check:strict`：通过（0 error，59 warning；其中 2 条为本次图标 WebKit 描边渐进增强）
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：通过（0 error，13 条既存 warning）
- `pnpm run type-check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过

## 验收说明

已完成 H5 与微信小程序构建级验证；本次未执行运行时截图验收。