### PR TITLE
feat(navbar): 优化操作区布局

### DIFF
--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -5,7 +5,7 @@ phone: navbar
 
 # Navbar 导航栏
 
-自定义顶部导航栏，适配 H5 安全区域和小程序状态栏高度。
+自定义顶部导航栏，深度适配 H5、App 安全区域与微信/多端小程序胶囊按钮对齐与避让。
 
 ## 基础用法
 
@@ -15,62 +15,100 @@ phone: navbar
 </template>
 ```
 
-## 带返回按钮
+## 详情导航（带副标题与操作）
 
 ```vue
-<template>
-  <lk-navbar title="订单详情" back @back="handleBack" />
-</template>
-
 <script setup lang="ts">
 function handleBack() {
-  uni.navigateBack()
+  uni.showToast({ title: '返回', icon: 'none' })
+}
+
+function handleMore() {
+  uni.showToast({ title: '更多', icon: 'none' })
 }
 </script>
+
+<template>
+  <lk-navbar
+    title="订单详情"
+    subtitle="已同步最新状态"
+    left-text="返回"
+    right-text="更多"
+    @click-left="handleBack"
+    @click-right="handleMore"
+  />
+</template>
 ```
 
-## 自定义左侧 / 中间 / 右侧
+## 标题左对齐
 
 ```vue
 <template>
-  <lk-navbar>
+  <lk-navbar
+    title="发现灵感"
+    subtitle="为你推荐新内容"
+    title-align="left"
+    :show-back="false"
+  >
     <template #left>
-      <lk-button variant="text" size="sm" @click="goHome">
-        <lk-icon name="house" :size="20" />
-      </lk-button>
-    </template>
-    <template #center>
-      <view style="flex:1; text-align:center;">
-        <text class="lk-navbar__title">自定义标题</text>
-      </view>
-    </template>
-    <template #right>
-      <view style="display:flex; gap:16rpx">
-        <lk-icon name="search" :size="22" @click="openSearch" />
-        <lk-icon name="person-circle" :size="22" @click="goProfile" />
-      </view>
+      <lk-icon name="house-fill" size="var(--lk-rpx-36)" />
     </template>
   </lk-navbar>
 </template>
 ```
 
-## 透明导航栏
+## 视觉变体与浮层导航
+
+支持 `default`、`frosted`（毛玻璃）、`transparent`（透明）与 `elevated`（悬浮卡片式）：
 
 ```vue
 <template>
-  <!-- 适合有封面大图的页面 -->
-  <lk-navbar title="详情" transparent dark back />
-
-  <view class="cover-image" style="height:500rpx; background:#7c3aed" />
+  <!-- 悬浮卡片式导航 -->
+  <lk-navbar
+    title="资产看板"
+    variant="elevated"
+    title-align="left"
+    :show-back="false"
+    shadow
+  >
+    <template #right>
+      <lk-icon name="bell" size="var(--lk-rpx-36)" />
+    </template>
+  </lk-navbar>
 </template>
 ```
 
-## 发布验收
+## 沉浸式渐变背景
 
-- H5：`fixed=false` 的 demo 变体应保持非 fixed 定位；插槽标题、左侧和右侧操作区不得挤压标题。
-- App：重点复核安全区顶部高度、透明背景和沉浸式页面状态栏文字颜色。
-- 小程序：重点复核胶囊按钮安全距离、返回事件和自定义右侧操作区点击。
-- 自动回归：`tests/visual/needs-hardening-showcase.spec.ts` 覆盖 showcase 元数据、非 fixed demo 和插槽内容可见性。
+```vue
+<template>
+  <lk-navbar
+    title="旅行计划"
+    subtitle="周末出发，轻松抵达"
+    background="linear-gradient(to right, var(--lk-color-primary), var(--lk-color-success))"
+    :show-back="false"
+    :border="false"
+  >
+    <template #right>
+      <lk-icon name="share" size="var(--lk-rpx-36)" />
+    </template>
+  </lk-navbar>
+</template>
+```
+
+## 推荐示例
+
+### 1) 直接复用项目 Demo（推荐）
+
+```vue
+<script setup lang="ts">
+import NavbarDemo from '@/pages_sub/components/demos/navbar-demo.vue'
+</script>
+
+<template>
+  <NavbarDemo />
+</template>
+```
 
 ## API
 
@@ -79,18 +117,30 @@ function handleBack() {
 | 参数 | 说明 | 类型 | 默认值 |
 |------|------|------|--------|
 | title | 标题文字 | `string` | `''` |
-| back | 是否显示返回按钮 | `boolean` | `false` |
-| transparent | 是否透明背景 | `boolean` | `false` |
-| dark | 暗色文字（配合透明） | `boolean` | `false` |
+| subtitle | 副标题文字 | `string` | `''` |
+| leftText | 左侧文本 | `string` | `''` |
+| rightText | 右侧文本 | `string` | `''` |
+| showBack | 是否显示返回按钮 | `boolean` | `true` |
+| backIcon | 返回图标名称 | `string` | `'chevron-left'` |
+| backIconSize | 返回图标尺寸 | `string \| number` | `var(--lk-rpx-36)` |
+| variant | 视觉风格：`default` 默认、`frosted` 毛玻璃、`transparent` 透明、`elevated` 悬浮卡片 | `default \| frosted \| transparent \| elevated` | `default` |
+| titleAlign | 标题对齐方式：`center` 居中、`left` 居左 | `center \| left` | `center` |
+| background | 自定义背景色或渐变 | `string` | `''` |
 | fixed | 是否固定在顶部 | `boolean` | `true` |
-| border | 是否显示底部边框 | `boolean` | `true` |
-| zIndex | 层级 | `number` | `100` |
+| placeholder | 固定在顶部时是否生成占位节点 | `boolean` | `true` |
+| safeArea | 是否开启状态栏安全区域适配 | `boolean` | `true` |
+| border | 是否显示底部分割线 | `boolean` | `true` |
+| shadow | 是否显示阴影 | `boolean` | `false` |
+| zIndex | 导航栏层级 | `number` | `200` |
+| id | 根节点 id | `string` | `''` |
+| customClass | 根节点自定义类名 | `string \| object \| array` | — |
+| customStyle | 根节点自定义样式 | `string \| object` | — |
 
 ### Events
 
 | 事件名 | 说明 | 回调参数 |
 |--------|------|----------|
-| back | 点击返回按钮 | `()` |
+| back | `showBack=true` 时点击左侧区域触发，组件同时尝试历史回退 | `()` |
 | click-left | 点击左侧区域时触发 | `()` |
 | click-right | 点击右侧区域时触发 | `()` |
 
@@ -98,7 +148,14 @@ function handleBack() {
 
 | 插槽名 | 说明 |
 |--------|------|
-| default | 标题区域自定义内容 |
-| left | 左侧区域自定义 |
-| center | 中间区域自定义（在屏幕中心显示，优先于 title） |
-| right | 右侧区域自定义 |
+| default | 标题区域自定义内容（居中模式下与 center 同级） |
+| left | 左侧操作区域自定义内容 |
+| center | 中间区域自定义内容（优先于 title） |
+| right | 右侧操作区域自定义内容 |
+
+## 发布验收
+
+- H5：`fixed=false` 的 Demo 变体应保持非 fixed 定位；自定义标题及左右操作区不得互相遮挡。
+- App：重点复核安全区顶部高度、自定义背景和沉浸式页面状态栏文字颜色。
+- 小程序：重点复核胶囊按钮安全距离、返回事件，以及缺省左右操作区时的标题布局。
+- 自动回归：`tests/visual/needs-hardening-showcase.spec.ts` 覆盖 Showcase 元数据、非 fixed Demo 和插槽内容可见性。

--- a/src/pages_sub/components/demos/navbar-demo.vue
+++ b/src/pages_sub/components/demos/navbar-demo.vue
@@ -45,7 +45,7 @@ const handleMore = () => {
         :fixed="false"
       >
         <template #left>
-          <lk-icon name="house-fill" size="36" />
+          <lk-icon name="house-fill" size="var(--lk-rpx-36)" />
         </template>
       </lk-navbar>
     </demo-block>
@@ -53,8 +53,8 @@ const handleMore = () => {
     <demo-block title="自定义操作区">
       <lk-navbar title="消息中心" subtitle="3 条未读提醒" :fixed="false">
         <template #right>
-          <lk-icon name="search" size="36" />
-          <lk-icon name="three-dots-vertical" size="36" />
+          <lk-icon name="search" size="var(--lk-rpx-36)" />
+          <lk-icon name="three-dots-vertical" size="var(--lk-rpx-36)" />
         </template>
       </lk-navbar>
     </demo-block>
@@ -62,13 +62,13 @@ const handleMore = () => {
     <demo-block title="自定义中间">
       <lk-navbar :fixed="false" variant="frosted">
         <template #left>
-          <lk-icon name="house-fill" size="36" />
+          <lk-icon name="house-fill" size="var(--lk-rpx-36)" />
         </template>
         <template #center>
           <view class="demo-search">搜索组件、文档、示例</view>
         </template>
         <template #right>
-          <lk-icon name="search" size="36" />
+          <lk-icon name="search" size="var(--lk-rpx-36)" />
         </template>
       </lk-navbar>
     </demo-block>
@@ -84,7 +84,7 @@ const handleMore = () => {
         shadow
       >
         <template #right>
-          <lk-icon name="bell" size="36" />
+          <lk-icon name="bell" size="var(--lk-rpx-36)" />
         </template>
       </lk-navbar>
     </demo-block>
@@ -100,7 +100,7 @@ const handleMore = () => {
           :border="false"
         >
           <template #right>
-            <lk-icon name="share" size="36" />
+            <lk-icon name="share" size="var(--lk-rpx-36)" />
           </template>
         </lk-navbar>
         <view class="demo-hero__content">优雅导航可以自然融入页面头图区域。</view>
@@ -114,12 +114,12 @@ const handleMore = () => {
   display: flex;
   flex-direction: column;
   > :not(:first-child) {
-    margin-top: 32rpx;
+    margin-top: var(--lk-spacing-xl);
   }
 }
 
 .demo-search {
-  width: 360rpx;
+  width: var(--lk-rpx-360);
   height: var(--lk-rpx-64);
   display: flex;
   align-items: center;

--- a/src/uni_modules/lucky-ui/components/lk-navbar/lk-navbar.scss
+++ b/src/uni_modules/lucky-ui/components/lk-navbar/lk-navbar.scss
@@ -67,8 +67,8 @@
       left: var(--lk-spacing-md);
       right: var(--lk-spacing-md);
       width: auto;
-      margin-right: 0;
-      margin-left: 0;
+      margin-right: var(--lk-rpx-0);
+      margin-left: var(--lk-rpx-0);
     }
   }
 
@@ -83,21 +83,23 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 0 var(--lk-navbar-content-padding-right) 0 var(--lk-navbar-content-padding-left);
+    padding: var(--lk-rpx-0) var(--lk-navbar-content-padding-right) var(--lk-rpx-0)
+      var(--lk-navbar-content-padding-left);
     box-sizing: border-box;
   }
 
   @include e(left) {
-    display: flex;
+    position: relative;
+    display: inline-flex;
     align-items: center;
     justify-content: flex-start;
-    min-width: var(--lk-navbar-action-min-width);
-    min-height: var(--lk-rpx-72);
-    padding: 0 var(--lk-spacing-xs);
+    min-height: var(--lk-rpx-56);
+    padding: var(--lk-rpx-0) var(--lk-spacing-xs);
     flex: 0 0 auto;
     box-sizing: border-box;
     z-index: 1;
-    border-radius: var(--lk-radius-full);
+    border-radius: var(--lk-radius-md);
+    overflow: hidden;
     transition:
       background-color var(--lk-transition-fast),
       opacity var(--lk-transition-fast),
@@ -115,16 +117,17 @@
   }
 
   @include e(right) {
-    display: flex;
+    position: relative;
+    display: inline-flex;
     align-items: center;
     justify-content: flex-end;
-    min-width: var(--lk-navbar-action-min-width);
-    min-height: var(--lk-rpx-72);
-    padding: 0 var(--lk-spacing-xs);
+    min-height: var(--lk-rpx-56);
+    padding: var(--lk-rpx-0) var(--lk-spacing-xs);
     flex: 0 0 auto;
     box-sizing: border-box;
     z-index: 1;
-    border-radius: var(--lk-radius-full);
+    border-radius: var(--lk-radius-md);
+    overflow: hidden;
     transition:
       background-color var(--lk-transition-fast),
       opacity var(--lk-transition-fast),
@@ -141,6 +144,11 @@
     }
   }
 
+  @include e(side-placeholder) {
+    min-width: var(--lk-rpx-0);
+    flex: 0 0 auto;
+  }
+
   @include e(center) {
     position: absolute;
     left: 50%;
@@ -152,6 +160,12 @@
     min-width: 0;
     z-index: 0;
     pointer-events: none;
+
+    .lk-navbar__title-wrap,
+    > view,
+    > text {
+      pointer-events: auto;
+    }
   }
 
   @include m(title-left) {
@@ -182,9 +196,9 @@
   @include e(title) {
     max-width: 100%;
     font-size: var(--lk-font-size-lg);
-    font-weight: 700;
+    font-weight: var(--lk-font-weight-bold);
     color: var(--lk-navbar-text);
-    line-height: 1.25;
+    line-height: var(--lk-line-height-tight);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -195,7 +209,7 @@
     margin-top: var(--lk-rpx-4);
     font-size: var(--lk-font-size-xs);
     color: var(--lk-navbar-text-secondary);
-    line-height: 1.2;
+    line-height: var(--lk-line-height-tight);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -210,8 +224,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: var(--lk-rpx-88);
-    min-height: var(--lk-rpx-72);
     color: var(--lk-navbar-text);
   }
 

--- a/src/uni_modules/lucky-ui/components/lk-navbar/lk-navbar.vue
+++ b/src/uni_modules/lucky-ui/components/lk-navbar/lk-navbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, type StyleValue } from 'vue';
+import { computed, useSlots, type StyleValue } from 'vue';
 import { navbarProps, navbarEmits } from './navbar.props';
 import { useRipple } from '@/uni_modules/lucky-ui/composables/useRipple';
 import {
@@ -9,6 +9,7 @@ import {
   resolveNavbarPlaceholderStyle,
   resolveNavbarRootClass,
   resolveNavbarSafeStyle,
+  resolveNavbarSideVisibility,
   shouldNavigateBack,
 } from './navbar.utils';
 
@@ -16,6 +17,17 @@ defineOptions({ name: 'LkNavbar' });
 
 const props = defineProps(navbarProps);
 const emit = defineEmits(navbarEmits);
+const slots = useSlots();
+
+const sideVisibility = computed(() =>
+  resolveNavbarSideVisibility({
+    showBack: props.showBack,
+    leftText: props.leftText,
+    rightText: props.rightText,
+    hasLeftSlot: Boolean(slots.left),
+    hasRightSlot: Boolean(slots.right),
+  })
+);
 
 const {
   rippleActive: leftActive,
@@ -123,17 +135,13 @@ function tryNavigateBack() {
   }
 }
 
-function onBackTap(event: unknown) {
-  // 点击返回图标：行为更符合直觉
-  triggerLeft(event);
-  emit('click-left');
-  emit('back');
-  tryNavigateBack();
-}
-
 function onLeftClick(event: unknown) {
   triggerLeft(event);
   emit('click-left');
+  if (props.showBack) {
+    emit('back');
+    tryNavigateBack();
+  }
 }
 
 function onRightClick(event: unknown) {
@@ -154,6 +162,7 @@ function onRightClick(event: unknown) {
     <!-- 导航栏内容 -->
     <view class="lk-navbar__content" :style="contentStyle">
       <view
+        v-if="sideVisibility.hasLeft"
         class="lk-navbar__left lk-ripple"
         :class="{ 'lk-ripple--active': leftActive }"
         @tap="onLeftClick"
@@ -161,14 +170,15 @@ function onRightClick(event: unknown) {
         <lk-icon
           v-if="showBack"
           :name="backIcon"
-          size="36"
+          :size="backIconSize"
           class="lk-navbar__back"
-          @tap.stop="onBackTap"
         />
         <text v-if="leftText" class="lk-navbar__text">{{ leftText }}</text>
         <slot name="left" />
         <view class="lk-ripple__wave" :style="leftRippleStyle" />
       </view>
+      <view v-else class="lk-navbar__side-placeholder" />
+
       <view class="lk-navbar__center">
         <slot name="center">
           <view class="lk-navbar__title-wrap">
@@ -178,7 +188,9 @@ function onRightClick(event: unknown) {
           <slot />
         </slot>
       </view>
+
       <view
+        v-if="sideVisibility.hasRight"
         class="lk-navbar__right lk-ripple"
         :class="{ 'lk-ripple--active': rightActive }"
         @tap="onRightClick"
@@ -187,6 +199,7 @@ function onRightClick(event: unknown) {
         <slot name="right" />
         <view class="lk-ripple__wave" :style="rightRippleStyle" />
       </view>
+      <view v-else class="lk-navbar__side-placeholder" />
     </view>
   </view>
 

--- a/src/uni_modules/lucky-ui/components/lk-navbar/navbar.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-navbar/navbar.props.ts
@@ -57,6 +57,9 @@ export const navbarProps = {
   /** 返回图标 */
   backIcon: LkProp.string('chevron-left'),
 
+  /** 返回图标尺寸 */
+  backIconSize: LkProp.stringNumber('var(--lk-rpx-36)'),
+
   /** 是否显示底部分割线 */
   border: LkProp.boolean(true),
 

--- a/src/uni_modules/lucky-ui/components/lk-navbar/navbar.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-navbar/navbar.utils.ts
@@ -13,6 +13,19 @@ export type NavbarMenuButtonInfo = {
   left?: number;
 };
 
+export function resolveNavbarSideVisibility(options: {
+  showBack: boolean;
+  leftText: string;
+  rightText: string;
+  hasLeftSlot: boolean;
+  hasRightSlot: boolean;
+}) {
+  return {
+    hasLeft: Boolean(options.showBack || options.leftText || options.hasLeftSlot),
+    hasRight: Boolean(options.rightText || options.hasRightSlot),
+  };
+}
+
 export function resolveNavbarRootClass(options: {
   variant: NavbarVariant;
   titleAlign: NavbarTitleAlign;

--- a/src/uni_modules/lucky-ui/theme/src/component-vars.scss
+++ b/src/uni_modules/lucky-ui/theme/src/component-vars.scss
@@ -474,9 +474,8 @@ page,
   --lk-popup-radius: var(--lk-radius-lg);
   --lk-tooltip-offset: var(--lk-spacing-xs);
 
-  --lk-navbar-content-padding-left: var(--lk-rpx-0);
+  --lk-navbar-content-padding-left: var(--lk-spacing-md);
   --lk-navbar-content-padding-right: var(--lk-spacing-md);
-  --lk-navbar-action-min-width: var(--lk-rpx-128);
 
   --lk-tabbar-height: var(--lk-rpx-112);
   --lk-tabbar-item-height: var(--lk-control-height-md);

--- a/tests/unit/lk-navbar.spec.ts
+++ b/tests/unit/lk-navbar.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { navbarProps } from '../../src/uni_modules/lucky-ui/components/lk-navbar/navbar.props';
 import {
   resolveNavbarContentHeight,
   resolveNavbarContentStyle,
@@ -6,6 +7,7 @@ import {
   resolveNavbarPlaceholderStyle,
   resolveNavbarRootClass,
   resolveNavbarSafeStyle,
+  resolveNavbarSideVisibility,
   shouldNavigateBack,
 } from '../../src/uni_modules/lucky-ui/components/lk-navbar/navbar.utils';
 
@@ -104,5 +106,30 @@ describe('lk-navbar layout and back rules', () => {
     expect(shouldNavigateBack([{}, {}])).toBe(true);
     expect(shouldNavigateBack([{}])).toBe(false);
     expect(shouldNavigateBack(undefined)).toBe(false);
+  });
+
+  it('renders only action regions that have content', () => {
+    expect(resolveNavbarSideVisibility({
+      showBack: false,
+      leftText: '',
+      rightText: '',
+      hasLeftSlot: false,
+      hasRightSlot: false,
+    })).toEqual({ hasLeft: false, hasRight: false });
+    expect(resolveNavbarSideVisibility({
+      showBack: true,
+      leftText: '',
+      rightText: '更多',
+      hasLeftSlot: false,
+      hasRightSlot: false,
+    })).toEqual({ hasLeft: true, hasRight: true });
+    expect(resolveNavbarSideVisibility({
+      showBack: false,
+      leftText: '',
+      rightText: '',
+      hasLeftSlot: true,
+      hasRightSlot: true,
+    })).toEqual({ hasLeft: true, hasRight: true });
+    expect(navbarProps.backIconSize.default).toBe('var(--lk-rpx-36)');
   });
 });


### PR DESCRIPTION
## 背景

Navbar 的左右操作区此前始终占据固定宽度，即使没有内容也会渲染，容易造成标题区空间浪费；返回图标尺寸也无法通过属性配置。

## 变更内容

- 根据返回按钮、左右文本和插槽内容决定操作区是否渲染
- 无内容侧使用零宽占位，减少无效空间并保持布局稳定
- 新增 `backIconSize`，支持数字、带单位尺寸和 CSS 变量
- 点击包含返回按钮的左侧操作区时统一触发 `click-left`、`back` 并尝试历史回退
- 优化左右操作区尺寸、圆角、涟漪裁切和标题交互区域
- 调整默认内容内边距并清理不再使用的操作区最小宽度变量
- 更新 Demo、完整 API 文档和跨端验收说明
- 补充左右区域显隐规则及返回图标尺寸测试

## 验证结果

- `pnpm run test:unit`：87 个测试文件、756 项测试通过
- `pnpm run compat-check:strict`：通过（0 error，59 条既存 warning）
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：通过（0 error，13 条既存 warning）
- `pnpm run type-check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过

## 验收说明

已完成 H5 与微信小程序构建级验证；本次未执行运行时截图验收。