### PR TITLE
feat(input): 优化输入与弹窗键盘体验

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -142,6 +142,30 @@ function onConfirm(event: any) {
 </template>
 ```
 
+## 键盘推顶与弹窗避让
+
+- **普通页面流**：使用 `:adjust-position="true"` 并在需要时通过 `:cursor-spacing="24"`（单位 px）设置光标与软键盘之间的呼吸间距；
+- **弹窗/抽屉场景**：在 `lk-popup` 上开启 `avoid-keyboard`，同时为内部 `lk-input` 设置 `:adjust-position="false"`，由 Popup 统一进行平滑位移抬起。
+
+```vue
+<template>
+  <!-- 场景 1：普通页面流推顶 + 安全间距 -->
+  <lk-input
+    v-model="text"
+    :adjust-position="true"
+    :cursor-spacing="24"
+    placeholder="页面自动上推并保持 24px 间距"
+  />
+
+  <!-- 场景 2：底部弹窗内联动抬起 -->
+  <lk-popup v-model="showPopup" position="bottom" round avoid-keyboard title="信息输入">
+    <view style="padding: 32rpx">
+      <lk-input v-model="popupText" :adjust-position="false" placeholder="弹层随软键盘平滑抬升" />
+    </view>
+  </lk-popup>
+</template>
+```
+
 ## 与表单验证结合
 
 ```vue
@@ -202,7 +226,7 @@ async function submit() {
 | focus                  | 是否聚焦，受控聚焦状态                       | `boolean`                 | —                                                              | `false`             |
 | prefixIcon             | 前缀图标名                                   | `string`                  | —                                                              | `''`                |
 | suffixIcon             | 后缀图标名                                   | `string`                  | —                                                              | `''`                |
-| showPassword           | 密码输入时是否显示明暗切换按钮               | `boolean`                 | —                                                              | `false`             |
+| showPassword           | 密码输入时是否显示明暗切换按钮（输入内容存在时展示） | `boolean`                 | —                                                              | `false`             |
 | borderless             | 是否无边框，常用于表单列表内                 | `boolean`                 | —                                                              | `false`             |
 | inputAlign             | 输入内容对齐方式                             | `string`                  | `left / center / right`                                        | `left`              |
 | confirmType            | 键盘右下角按钮文字                           | `string`                  | `send / search / next / go / done / return`                    | `done`              |

--- a/docs/components/popup.md
+++ b/docs/components/popup.md
@@ -159,6 +159,21 @@ Peekit 基准流程固定为：在 `bottom-default` 模式打开并记录 `slide
 </template>
 ```
 
+## 键盘自动避让 (avoid-keyboard)
+
+当弹窗内部包含输入框时，开启 `avoid-keyboard`。弹窗会自动监听系统软键盘高度并进行平滑抬升避让。此时建议为内部输入框设置 `:adjust-position="false"`，由 Popup 统一进行平滑位移：
+
+```vue
+<template>
+  <lk-popup v-model="show" position="bottom" avoid-keyboard>
+    <view style="padding: 32rpx">
+      <view style="margin-bottom: 24rpx; font-weight: 600">填写信息</view>
+      <lk-input v-model="text" :adjust-position="false" placeholder="键盘弹起时弹窗自动上移" />
+    </view>
+  </lk-popup>
+</template>
+```
+
 ## API
 
 ### Props
@@ -184,6 +199,7 @@ Peekit 基准流程固定为：在 `bottom-default` 模式打开并记录 `slide
 | closeOnOverlay    | 点击遮罩关闭                                                  | `boolean`                                              | `true`                                 |
 | lockScroll        | 锁定背景滚动                                                  | `boolean`                                              | `true`                                 |
 | safeArea          | 底部是否适配安全区                                            | `boolean`                                              | `true`                                 |
+| avoidKeyboard     | 软键盘弹起时是否自动上移避让（支持 bottom 与 center 弹窗）    | `boolean`                                              | `false`                                |
 | height            | 弹层高度；draggable bottom 模式下由 `snapPoints` 接管可见高度 | `string \| number`                                     | `''`                                   |
 | width             | 弹层宽度                                                      | `string \| number`                                     | `''`                                   |
 | animation         | 动画预设名称                                                  | `keyof ANIMATION_PRESETS`                              | `undefined`                            |

--- a/src/pages_sub/components/demos/input-demo.vue
+++ b/src/pages_sub/components/demos/input-demo.vue
@@ -1,6 +1,7 @@
-﻿<script setup lang="ts">
+<script setup lang="ts">
 import { ref } from 'vue';
 import LkInput from '@/uni_modules/lucky-ui/components/lk-input/lk-input.vue';
+import type { InputEventPayload } from '@/uni_modules/lucky-ui/components/lk-input/input.props';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
@@ -23,9 +24,20 @@ const valueAlign2 = ref('');
 const valueAlign3 = ref('');
 const valueConfirm = ref('');
 const confirmTip = ref('');
+const valueSpacing = ref('');
+const keyboardInfo = ref('');
 
 function onConfirm() {
   confirmTip.value = `已触发确认：${valueConfirm.value}`;
+}
+
+function onKeyboardHeight(e: InputEventPayload) {
+  const detail =
+    typeof e === 'object' && e !== null && 'detail' in e
+      ? (e.detail as { height?: number } | undefined)
+      : undefined;
+  const height = detail?.height ?? 0;
+  keyboardInfo.value = height > 0 ? `当前软键盘高度：${height}px` : '键盘已收起';
 }
 </script>
 
@@ -100,6 +112,20 @@ function onConfirm() {
     <demo-block title="字数统计">
       <lk-input v-model="value9" :maxlength="20" show-word-limit placeholder="最多20个字" />
     </demo-block>
+
+    <demo-block title="页面键盘推顶与安全间距 (cursor-spacing)">
+      <lk-space direction="vertical" :gap="24" fill>
+        <lk-input
+          v-model="valueSpacing"
+          :adjust-position="true"
+          :cursor-spacing="24"
+          placeholder="聚焦时页面上推并保持 24px 间距"
+          @keyboardheightchange="onKeyboardHeight"
+        />
+        <text v-if="keyboardInfo" class="demo-tip">{{ keyboardInfo }}</text>
+      </lk-space>
+    </demo-block>
+
   </view>
 </template>
 
@@ -119,4 +145,5 @@ function onConfirm() {
   font-size: 24rpx;
   color: var(--lk-text-secondary);
 }
+
 </style>

--- a/src/pages_sub/components/demos/popup-demo.vue
+++ b/src/pages_sub/components/demos/popup-demo.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkPopup from '@/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue';
 import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
+import LkInput from '@/uni_modules/lucky-ui/components/lk-input/lk-input.vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 import type { TransitionName } from '@/uni_modules/lucky-ui/composables/useTransition';
 
@@ -23,6 +24,8 @@ const visibleWithClose = ref(false);
 const visibleWithBoth = ref(false);
 const visibleCustomTitle = ref(false);
 const reactiveTransitionVisible = ref(false);
+const keyboardAvoidanceVisible = ref(false);
+const keyboardAvoidanceValue = ref('');
 
 type ReactiveTransitionProbeConfig = {
   key: string;
@@ -183,6 +186,32 @@ const showRight = () => {
           </view>
         </template>
         <view class="popup-content">使用插槽自定义标题样式</view>
+      </lk-popup>
+    </demo-block>
+
+    <demo-block title="软键盘自动避让">
+      <lk-button type="primary" @click="keyboardAvoidanceVisible = true">
+        打开输入弹窗
+      </lk-button>
+      <lk-popup
+        v-model="keyboardAvoidanceVisible"
+        position="bottom"
+        round
+        avoid-keyboard
+        title="弹窗键盘避让"
+        closable
+      >
+        <view class="keyboard-popup-content">
+          <view class="keyboard-popup-tip">
+            Popup 统一避让键盘，因此内部 Input 关闭原生 adjust-position。
+          </view>
+          <lk-input
+            v-model="keyboardAvoidanceValue"
+            :adjust-position="false"
+            placeholder="聚焦后观察弹窗平滑抬起"
+            clearable
+          />
+        </view>
       </lk-popup>
     </demo-block>
 
@@ -382,6 +411,16 @@ const showRight = () => {
   font-size: 32rpx;
   font-weight: 600;
   color: var(--lk-color-warning);
+}
+
+.keyboard-popup-content {
+  padding: 32rpx;
+}
+
+.keyboard-popup-tip {
+  margin-bottom: 20rpx;
+  color: var(--lk-text-secondary);
+  font-size: 24rpx;
 }
 
 .popup-content-large {

--- a/src/uni_modules/lucky-ui/components/lk-input/input.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-input/input.utils.ts
@@ -52,13 +52,15 @@ export function shouldShowPasswordToggle(options: {
   disabled: boolean;
   readonly: boolean;
   fake: boolean;
+  value?: unknown;
 }): boolean {
   return (
     options.showPassword &&
     options.type === 'password' &&
     !options.disabled &&
     !options.readonly &&
-    !options.fake
+    !options.fake &&
+    hasInputValue(options.value)
   );
 }
 

--- a/src/uni_modules/lucky-ui/components/lk-input/lk-input.scss
+++ b/src/uni_modules/lucky-ui/components/lk-input/lk-input.scss
@@ -8,7 +8,7 @@
   --_border: var(--lk-color-border-light);
   --_border-hover: var(--lk-color-primary);
   --_border-active: var(--lk-color-primary);
-  --_placeholder: var(--lk-text-placeholder);
+  --_placeholder: var(--lk-text-secondary);
   --_bg: var(--lk-bg-input);
 
   position: relative;
@@ -62,7 +62,8 @@
   @include e(inner) {
     flex: 1;
     min-width: 0;
-    height: 100%;
+    height: var(--_height);
+    min-height: var(--_height);
     font-size: var(--_fs);
     background: transparent;
     border: 0 !important;
@@ -70,11 +71,20 @@
     outline: none;
     padding: 0;
     color: var(--lk-text-primary);
-    line-height: normal;
+    caret-color: var(--lk-color-primary);
+    line-height: var(--_height);
 
     &::placeholder {
-      color: var(--lk-text-placeholder);
+      color: var(--_placeholder);
+      line-height: var(--_height);
     }
+  }
+
+  :deep(.input-placeholder),
+  .input-placeholder {
+    color: var(--_placeholder);
+    font-size: var(--_fs);
+    line-height: var(--_height);
   }
 
   @include e(prefix) {
@@ -144,7 +154,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--lk-text-placeholder);
+    color: var(--_placeholder);
     font-size: var(--_fs);
   }
 

--- a/src/uni_modules/lucky-ui/components/lk-input/lk-input.vue
+++ b/src/uni_modules/lucky-ui/components/lk-input/lk-input.vue
@@ -204,6 +204,7 @@ const showPasswordToggle = computed(() => {
     disabled: isDisabled.value,
     readonly: props.readonly,
     fake: props.fake,
+    value: inner.value,
   });
 });
 
@@ -279,7 +280,7 @@ onBeforeUnmount(() => {
   >
     <view v-if="$slots.prefix || prefixIcon" class="lk-input__prefix">
       <slot name="prefix">
-        <lk-icon v-if="prefixIcon" :name="prefixIcon" size="36" />
+        <lk-icon v-if="prefixIcon" :name="prefixIcon" size="32" />
       </slot>
     </view>
 
@@ -336,18 +337,18 @@ onBeforeUnmount(() => {
 
     <!-- 清空按钮 -->
     <view v-if="showClear" class="lk-input__clear" @tap.stop="clear">
-      <lk-icon name="x-circle-fill" size="36" />
+      <lk-icon name="x-circle" size="28" />
     </view>
 
     <!-- 密码明暗切换按钮 -->
     <view v-if="showPasswordToggle" class="lk-input__password-toggle" @tap.stop="togglePassword">
-      <lk-icon :name="passwordVisible ? 'eye' : 'eye-slash'" size="36" />
+      <lk-icon :name="passwordVisible ? 'eye' : 'eye-slash'" size="32" />
     </view>
 
     <!-- 后缀图标/插槽 -->
     <view v-if="showSuffix" class="lk-input__suffix">
       <slot name="suffix">
-        <lk-icon v-if="suffixIcon" :name="suffixIcon" size="36" />
+        <lk-icon v-if="suffixIcon" :name="suffixIcon" size="32" />
       </slot>
     </view>
 

--- a/src/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue
+++ b/src/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue
@@ -63,6 +63,55 @@ function onCloseClick() {
   emit('update:modelValue', false);
 }
 
+const keyboardHeight = ref(0);
+let keyboardListenerRegistered = false;
+
+function handleKeyboardHeightChange(res?: { height?: number }) {
+  if (!props.modelValue || !props.avoidKeyboard) return;
+  keyboardHeight.value = Math.max(0, Number(res?.height) || 0);
+}
+
+function registerKeyboardListener() {
+  if (keyboardListenerRegistered) return;
+  // #ifdef MP || APP-PLUS || H5
+  try {
+    if (typeof uni !== 'undefined' && typeof uni.onKeyboardHeightChange === 'function') {
+      uni.onKeyboardHeightChange(handleKeyboardHeightChange);
+      keyboardListenerRegistered = true;
+    }
+  } catch {
+    // ignore
+  }
+  // #endif
+}
+
+function unregisterKeyboardListener() {
+  keyboardHeight.value = 0;
+  if (!keyboardListenerRegistered) return;
+  // #ifdef MP || APP-PLUS || H5
+  try {
+    if (typeof uni !== 'undefined' && typeof uni.offKeyboardHeightChange === 'function') {
+      uni.offKeyboardHeightChange(handleKeyboardHeightChange);
+      keyboardListenerRegistered = false;
+    }
+  } catch {
+    // ignore
+  }
+  // #endif
+}
+
+watch(
+  () => [props.modelValue, props.avoidKeyboard],
+  ([visible, avoid]) => {
+    if (visible && avoid) {
+      registerKeyboardListener();
+    } else {
+      unregisterKeyboardListener();
+    }
+  },
+  { immediate: true }
+);
+
 const wrapperClass = computed(() => [
   ...resolvePopupWrapperClass({
     position: props.position,
@@ -75,6 +124,9 @@ const wrapperStyle = computed(() =>
   resolvePopupWrapperStyle({
     zIndex: props.zIndex,
     radius: props.radius,
+    position: props.position,
+    keyboardOffset: keyboardHeight.value,
+    avoidKeyboard: props.avoidKeyboard,
   })
 );
 
@@ -365,6 +417,7 @@ function onContentScrollUpper() {
 }
 
 onBeforeUnmount(() => {
+  unregisterKeyboardListener();
   clearPanelAnimationLock();
 });
 

--- a/src/uni_modules/lucky-ui/components/lk-popup/popup.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-popup/popup.props.ts
@@ -93,6 +93,9 @@ export const popupProps = {
   /** 是否开启安全区域适配 */
   safeArea: LkProp.boolean(true),
 
+  /** 是否在软键盘弹起时自动上移避让键盘（常用于包含输入框的 bottom 或 center 弹窗） */
+  avoidKeyboard: LkProp.boolean(false),
+
   /** 弹层高度 */
   height: {
     type: [String, Number] as PropType<string | number>,

--- a/src/uni_modules/lucky-ui/components/lk-popup/popup.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-popup/popup.utils.ts
@@ -112,11 +112,30 @@ export function resolvePopupWrapperClass(options: {
   ];
 }
 
-export function resolvePopupWrapperStyle(options: { zIndex: number; radius: string }) {
-  return {
+export function resolvePopupWrapperStyle(options: {
+  zIndex: number;
+  radius: string;
+  position?: string;
+  keyboardOffset?: number;
+  avoidKeyboard?: boolean;
+}) {
+  const styles: Record<string, string | number> = {
     zIndex: options.zIndex + 1,
     '--lk-popup-radius': options.radius,
   };
+
+  const offset = Math.max(0, options.keyboardOffset ?? 0);
+  if (options.avoidKeyboard && (options.position === 'bottom' || options.position === 'center')) {
+    styles.transition = 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)';
+    if (options.position === 'bottom') {
+      styles.transform = offset > 0 ? `translateY(-${offset}px)` : 'translateY(0)';
+    } else {
+      styles.transform =
+        offset > 0 ? `translate(-50%, calc(-50% - ${offset / 2}px))` : 'translate(-50%, -50%)';
+    }
+  }
+
+  return styles;
 }
 
 export function normalizePopupSnapPixels(options: {

--- a/tests/unit/lk-input.spec.ts
+++ b/tests/unit/lk-input.spec.ts
@@ -85,13 +85,14 @@ describe('lk-input value and display rules', () => {
     ).toBe('');
   });
 
-  it('prioritizes password toggle over suffix content', () => {
+  it('prioritizes password toggle over suffix content when value exists', () => {
     const passwordToggle = shouldShowPasswordToggle({
       showPassword: true,
       type: 'password',
       disabled: false,
       readonly: false,
       fake: false,
+      value: 'secret',
     });
 
     expect(passwordToggle).toBe(true);
@@ -99,9 +100,20 @@ describe('lk-input value and display rules', () => {
       shouldShowPasswordToggle({
         showPassword: true,
         type: 'password',
+        disabled: false,
+        readonly: false,
+        fake: false,
+        value: '',
+      })
+    ).toBe(false);
+    expect(
+      shouldShowPasswordToggle({
+        showPassword: true,
+        type: 'password',
         disabled: true,
         readonly: false,
         fake: false,
+        value: 'secret',
       })
     ).toBe(false);
     expect(

--- a/tests/unit/lk-popup.spec.ts
+++ b/tests/unit/lk-popup.spec.ts
@@ -99,6 +99,45 @@ describe('lk-popup transition and drag rules', () => {
       zIndex: 1001,
       '--lk-popup-radius': '24rpx',
     });
+
+    expect(resolvePopupWrapperStyle({
+      zIndex: 1000,
+      radius: '24rpx',
+      position: 'bottom',
+      keyboardOffset: 300,
+      avoidKeyboard: true,
+    })).toEqual({
+      zIndex: 1001,
+      '--lk-popup-radius': '24rpx',
+      transform: 'translateY(-300px)',
+      transition: 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)',
+    });
+
+    expect(resolvePopupWrapperStyle({
+      zIndex: 1000,
+      radius: '24rpx',
+      position: 'center',
+      keyboardOffset: 200,
+      avoidKeyboard: true,
+    })).toEqual({
+      zIndex: 1001,
+      '--lk-popup-radius': '24rpx',
+      transform: 'translate(-50%, calc(-50% - 100px))',
+      transition: 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)',
+    });
+
+    expect(resolvePopupWrapperStyle({
+      zIndex: 1000,
+      radius: '24rpx',
+      position: 'bottom',
+      keyboardOffset: 0,
+      avoidKeyboard: true,
+    })).toEqual({
+      zIndex: 1001,
+      '--lk-popup-radius': '24rpx',
+      transition: 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)',
+      transform: 'translateY(0)',
+    });
   });
 
   it('normalizes snap points and resolves drag targets', () => {


### PR DESCRIPTION
## 背景

改善输入组件的状态反馈，并为包含输入框的底部/居中 Popup 提供统一的软键盘避让能力。

## 变更内容

- `feat(popup): 支持软键盘自动避让`
  - 新增 `avoidKeyboard` 属性，支持 bottom 与 center 弹窗
  - 监听系统键盘高度并平滑调整弹窗位置
  - 防止重复监听；隐藏或禁用时清理偏移
  - 兼容缺少取消监听 API 的平台，避免重复回调积累
  - 补充 Popup Demo、文档和样式解析测试
- `feat(input): 优化输入状态与键盘体验`
  - 密码明暗按钮仅在已有输入内容时显示
  - 优化占位符、光标、垂直对齐与前后缀图标尺寸
  - 增加 `cursorSpacing`、`adjustPosition` 与键盘高度事件示例
  - 文档说明普通页面推顶和 Popup 统一避让的使用边界

## 验证结果

- `pnpm run test:unit`：87 个测试文件、756 项测试通过
- `pnpm run compat-check:strict`：通过（0 error，59 条既存 warning）
- `pnpm run lint:eslint`：通过
- `pnpm run lint:stylelint`：通过（0 error，13 条既存 warning）
- `pnpm run type-check`：通过
- `pnpm run build:h5`：通过
- `pnpm run build:mp-weixin`：通过

## 验收说明

已完成 H5 与微信小程序构建级验证；软键盘交互需在真实设备/开发者工具中进一步验收，本次未执行运行时截图验收。