### PR TITLE
feat(selection): 优化选择控件图标渲染

### DIFF
--- a/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.scss
+++ b/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.scss
@@ -12,6 +12,11 @@
 
   @include m(sm) {
     font-size: var(--lk-font-size-sm);
+    .lk-checkbox__icon,
+    .lk-checkbox__icon-wrap {
+      min-width: var(--lk-rpx-36);
+      min-height: var(--lk-rpx-36);
+    }
     .lk-checkbox__icon {
       width: var(--lk-rpx-36);
       height: var(--lk-rpx-36);
@@ -20,6 +25,11 @@
 
   @include m(md) {
     font-size: var(--lk-font-size-md);
+    .lk-checkbox__icon,
+    .lk-checkbox__icon-wrap {
+      min-width: var(--lk-rpx-44);
+      min-height: var(--lk-rpx-44);
+    }
     .lk-checkbox__icon {
       width: var(--lk-rpx-44);
       height: var(--lk-rpx-44);
@@ -28,6 +38,11 @@
 
   @include m(lg) {
     font-size: var(--lk-font-size-lg);
+    .lk-checkbox__icon,
+    .lk-checkbox__icon-wrap {
+      min-width: var(--lk-rpx-52);
+      min-height: var(--lk-rpx-52);
+    }
     .lk-checkbox__icon {
       width: var(--lk-rpx-52);
       height: var(--lk-rpx-52);
@@ -35,9 +50,11 @@
   }
 
   @include e(icon-wrap) {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
+    line-height: 1;
   }
 
   @include e(icon) {
@@ -71,11 +88,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
+    transform-origin: center center;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
     transition:
       opacity 0.18s ease,
-      transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 
     &::after {
       content: '';
@@ -96,11 +117,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
+    transform-origin: center center;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
     transition:
       opacity 0.18s ease,
-      transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @include e(dash) {
@@ -112,11 +137,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
+    transform-origin: center center;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
     transition:
       opacity 0.18s ease,
-      transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @include e(label) {
@@ -141,21 +170,21 @@
   &.lk-checkbox--checked.lk-checkbox--icon-check {
     .lk-checkbox__check {
       opacity: 1;
-      transform: scale(1);
+      transform: scale(1) translateZ(0);
     }
   }
 
   &.lk-checkbox--checked.lk-checkbox--icon-dot {
     .lk-checkbox__dot {
       opacity: 1;
-      transform: scale(1);
+      transform: scale(1) translateZ(0);
     }
   }
 
   &.lk-checkbox--indeterminate {
     .lk-checkbox__dash {
       opacity: 1;
-      transform: scale(1);
+      transform: scale(1) translateZ(0);
     }
   }
 

--- a/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue
+++ b/src/uni_modules/lucky-ui/components/lk-checkbox/lk-checkbox.vue
@@ -151,19 +151,23 @@ function handleLabelClick() {
           :class="[`lk-checkbox__icon--${mergedShape}`]"
           :style="iconStyle"
         >
-          <lk-icon
-            class="lk-checkbox__check"
-            name="check"
-            :size="mergedIconSize"
-            color="var(--lk-checkbox-check-color)"
-          />
-          <lk-icon
-            class="lk-checkbox__dash"
-            name="dash"
-            :size="mergedIconSize"
-            color="var(--lk-checkbox-check-color)"
-          />
-          <view class="lk-checkbox__dot" />
+          <view v-if="props.indeterminate" class="lk-checkbox__dash">
+            <lk-icon
+              name="dash"
+              :size="mergedIconSize"
+              color="var(--lk-checkbox-check-color)"
+            />
+          </view>
+          <template v-else>
+            <view v-if="mergedIconType === 'check'" class="lk-checkbox__check">
+              <lk-icon
+                name="check"
+                :size="mergedIconSize"
+                color="var(--lk-checkbox-check-color)"
+              />
+            </view>
+            <view v-else class="lk-checkbox__dot" />
+          </template>
         </view>
       </slot>
     </view>

--- a/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.scss
+++ b/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.scss
@@ -12,6 +12,11 @@
 
   @include m(sm) {
     font-size: var(--lk-font-size-sm);
+    .lk-radio__icon,
+    .lk-radio__icon-wrap {
+      min-width: var(--lk-rpx-36);
+      min-height: var(--lk-rpx-36);
+    }
     .lk-radio__icon {
       width: var(--lk-rpx-36);
       height: var(--lk-rpx-36);
@@ -20,6 +25,11 @@
 
   @include m(md) {
     font-size: var(--lk-font-size-md);
+    .lk-radio__icon,
+    .lk-radio__icon-wrap {
+      min-width: var(--lk-rpx-44);
+      min-height: var(--lk-rpx-44);
+    }
     .lk-radio__icon {
       width: var(--lk-rpx-44);
       height: var(--lk-rpx-44);
@@ -28,6 +38,11 @@
 
   @include m(lg) {
     font-size: var(--lk-font-size-lg);
+    .lk-radio__icon,
+    .lk-radio__icon-wrap {
+      min-width: var(--lk-rpx-52);
+      min-height: var(--lk-rpx-52);
+    }
     .lk-radio__icon {
       width: var(--lk-rpx-52);
       height: var(--lk-rpx-52);
@@ -35,9 +50,11 @@
   }
 
   @include e(icon-wrap) {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
+    line-height: 1;
   }
 
   @include e(icon) {
@@ -71,11 +88,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
+    transform-origin: center center;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
     transition:
       opacity 0.18s ease,
-      transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
 
     &::after {
       content: '';
@@ -96,11 +117,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     opacity: 0;
-    transform: scale(0.6);
+    transform: scale(0.6) translateZ(0);
+    transform-origin: center center;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
     transition:
       opacity 0.18s ease,
-      transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+      transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @include e(label) {
@@ -118,14 +143,14 @@
   &.lk-radio--checked.lk-radio--icon-dot {
     .lk-radio__dot {
       opacity: 1;
-      transform: scale(1);
+      transform: scale(1) translateZ(0);
     }
   }
 
   &.lk-radio--checked.lk-radio--icon-check {
     .lk-radio__check {
       opacity: 1;
-      transform: scale(1);
+      transform: scale(1) translateZ(0);
     }
   }
 

--- a/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue
+++ b/src/uni_modules/lucky-ui/components/lk-radio/lk-radio.vue
@@ -140,13 +140,14 @@ function handleLabelClick() {
     <view class="lk-radio__icon-wrap">
       <slot name="icon" :checked="isChecked" :disabled="isDisabled">
         <view class="lk-radio__icon" :class="[`lk-radio__icon--${mergedShape}`]" :style="iconStyle">
-          <lk-icon
-            class="lk-radio__check"
-            name="check"
-            :size="mergedIconSize"
-            color="var(--lk-radio-check-color)"
-          />
-          <view class="lk-radio__dot" />
+          <view v-if="mergedIconType === 'check'" class="lk-radio__check">
+            <lk-icon
+              name="check"
+              :size="mergedIconSize"
+              color="var(--lk-radio-check-color)"
+            />
+          </view>
+          <view v-else class="lk-radio__dot" />
         </view>
       </slot>
     </view>


### PR DESCRIPTION
## 背景

Checkbox 与 Radio 在不同尺寸及图标类型下存在占位宽度和动画中心不够稳定的问题，同时组件会同时渲染未使用的图标节点。

## 变更内容

- Checkbox 与 Radio 仅渲染当前 icon-type 对应的图标
- Checkbox 中间态仅渲染 dash 图标
- 为 sm、md、lg 图标容器补充稳定的最小尺寸
- 图标容器改为 inline-flex 并禁止压缩
- 统一勾选、圆点和中间态的缩放中心及过渡曲线
- 使用合成层变换减少缩放过程中的抖动

## 验证结果

- Checkbox、Radio 与表单禁用契约：3 个测试文件、139 项测试通过
- vue-tsc 类型检查通过
- ESLint 与 Stylelint 通过
- H5 构建通过
- 微信小程序构建通过
- git diff --check 与 git show --check 通过

## 验收说明

本 PR 不改变 Checkbox/Radio 的公共 Props、事件和选择逻辑，仅优化内部图标渲染与视觉稳定性。