### PR TITLE
feat(keyboard): 优化车牌布局与输入体验

### DIFF
--- a/src/pages_sub/components/demos/keyboard-demo.vue
+++ b/src/pages_sub/components/demos/keyboard-demo.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
 import LkKeyboard from '@/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue';
-import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
 import LkSpace from '@/uni_modules/lucky-ui/components/lk-space/lk-space.vue';
 import type {
   KeyboardKey,
@@ -155,11 +154,6 @@ function onClose() {
       </lk-space>
     </demo-block>
 
-    <view class="tips">
-      <lk-icon name="info-circle" size="28" color="var(--lk-color-primary)" />
-      <text>提示：键盘由 Popup 承载，采用纯色面板、反差文字和无卡片按键。</text>
-    </view>
-
     <!-- 键盘组件 -->
     <lk-keyboard
       v-model:visible="keyboardVisible"
@@ -220,19 +214,5 @@ function onClose() {
   font-size: 24rpx;
   color: var(--lk-text-secondary);
   margin-bottom: 16rpx;
-}
-
-.tips {
-  display: flex;
-  align-items: flex-start;
-  > :not(:first-child) {
-    margin-left: 12rpx;
-  }
-  padding: 24rpx;
-  background: var(--lk-fill-secondary);
-  border-radius: var(--lk-radius-lg);
-  font-size: 24rpx;
-  color: var(--lk-text-secondary);
-  line-height: 1.6;
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/keyboard.utils.ts
@@ -185,23 +185,37 @@ export function buildKeyboardRows(keys: string[], itemsPerRow: number): Keyboard
 }
 
 export function buildPlateProvinceKeyboardLayout(abcText: string): KeyboardKey[][] {
-  return [
-    ...buildKeyboardRows(keyboardPlateProvinces, 10),
-    [
-      { text: abcText, type: 'extra', value: '__switch__' },
-      { text: '', type: 'delete' },
-    ],
+  const row1 = keyboardPlateProvinces.slice(0, 9).map(k => ({ text: k, value: k }));
+  const row2 = keyboardPlateProvinces.slice(9, 18).map(k => ({ text: k, value: k }));
+  const row3 = keyboardPlateProvinces.slice(18, 27).map(k => ({ text: k, value: k }));
+  const remaining = keyboardPlateProvinces.slice(27).map(k => ({ text: k, value: k }));
+
+  const row4: KeyboardKey[] = [
+    { text: abcText, type: 'extra', value: '__switch__', flex: 1.5 },
+    ...remaining,
+    { text: '', type: 'delete', flex: 1.5 },
   ];
+
+  return [row1, row2, row3, row4];
 }
 
 export function buildPlateAlphaNumKeyboardLayout(provinceText: string): KeyboardKey[][] {
-  return [
-    ...buildKeyboardRows(keyboardPlateAlphaNum, 10),
-    [
-      { text: provinceText, type: 'extra', value: '__switch__' },
-      { text: '', type: 'delete' },
-    ],
+  // 数字 0~9：首行 10 个
+  const numbers = keyboardPlateAlphaNum.slice(24).map(k => ({ text: k, value: k }));
+  // 字母前9个 (A-J)
+  const lettersRow1 = keyboardPlateAlphaNum.slice(0, 9).map(k => ({ text: k, value: k }));
+  // 字母次9个 (K-T)
+  const lettersRow2 = keyboardPlateAlphaNum.slice(9, 18).map(k => ({ text: k, value: k }));
+  // 剩余字母 (U-Z 6个)
+  const remainingLetters = keyboardPlateAlphaNum.slice(18, 24).map(k => ({ text: k, value: k }));
+
+  const row4: KeyboardKey[] = [
+    { text: provinceText, type: 'extra', value: '__switch__', flex: 1.5 },
+    ...remainingLetters,
+    { text: '', type: 'delete', flex: 1.5 },
   ];
+
+  return [numbers, lettersRow1, lettersRow2, row4];
 }
 
 export function resolveKeyboardLayout(options: KeyboardLayoutOptions): KeyboardKey[][] {
@@ -252,8 +266,15 @@ export function resolveKeyboardPressAction(options: {
     return { kind: 'switch', nextPlateMode: getNextKeyboardPlateMode(plateMode) };
   }
 
-  if (key.value && canKeyboardInput(modelValue, maxLength)) {
-    return { kind: 'input', input: key.value, nextValue: modelValue + key.value };
+  const inputValue = key.value !== undefined ? key.value : key.text;
+
+  // 小数点重复输入防护
+  if (inputValue === '.' && modelValue.includes('.')) {
+    return { kind: 'ignore' };
+  }
+
+  if (inputValue && canKeyboardInput(modelValue, maxLength)) {
+    return { kind: 'input', input: inputValue, nextValue: modelValue + inputValue };
   }
 
   return { kind: 'ignore' };

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.scss
@@ -1,7 +1,7 @@
 @use '../../theme/src/mixins' as *;
 
 @include b(keyboard) {
-  --kb-key-height: var(--lk-rpx-104);
+  --kb-key-height: var(--lk-rpx-120);
 
   box-sizing: border-box;
   width: 100%;
@@ -19,7 +19,7 @@
   @include e(header) {
     display: flex;
     align-items: center;
-    min-height: var(--lk-rpx-88);
+    min-height: var(--lk-rpx-96);
     padding: var(--lk-spacing-xs) var(--lk-spacing-lg) 0;
   }
 
@@ -63,7 +63,7 @@
   @include e(body) {
     box-sizing: border-box;
     width: 100%;
-    padding: var(--lk-spacing-md) var(--lk-spacing-lg) var(--lk-spacing-lg);
+    padding: var(--lk-spacing-sm) var(--lk-spacing-lg) var(--lk-spacing-xl);
   }
 
   @include e(row) {
@@ -101,25 +101,26 @@
 
     @include m(extra) {
       .lk-keyboard__key-text {
-        font-size: var(--lk-font-size-base);
+        font-size: var(--lk-font-size-md);
+        font-weight: var(--lk-font-weight-regular);
       }
     }
   }
 
   @include e(key-text) {
     font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', sans-serif;
-    font-size: var(--lk-font-size-xl);
+    font-size: var(--lk-rpx-48);
     font-weight: var(--lk-font-weight-medium);
     line-height: 1;
     color: inherit;
   }
 
   @include m(plate) {
-    --kb-key-height: var(--lk-rpx-80);
+    --kb-key-height: var(--lk-rpx-92);
 
     .lk-keyboard__body {
-      padding-right: var(--lk-spacing-sm);
-      padding-left: var(--lk-spacing-sm);
+      padding-right: var(--lk-spacing-xs);
+      padding-left: var(--lk-spacing-xs);
     }
 
     .lk-keyboard__key-text {
@@ -127,14 +128,7 @@
     }
 
     .lk-keyboard__key {
-      flex: 0 0 10%;
-      width: 10%;
-    }
-
-    .lk-keyboard__key--extra,
-    .lk-keyboard__key--delete {
       flex: 1;
-      width: auto;
     }
   }
 }

--- a/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
+++ b/src/uni_modules/lucky-ui/components/lk-keyboard/lk-keyboard.vue
@@ -192,7 +192,7 @@ function getKeyStyle(key: KeyboardKey): Record<string, number> {
             :data-key="key.text"
             @tap="onKeyPress(key)"
           >
-            <lk-icon v-if="key.type === 'delete'" name="eraser" :size="40" />
+            <lk-icon v-if="key.type === 'delete'" name="eraser" :size="44" />
             <text v-else-if="key.type !== 'empty'" class="lk-keyboard__key-text">
               {{ key.text }}
             </text>

--- a/src/uni_modules/lucky-ui/theme/src/component-vars.scss
+++ b/src/uni_modules/lucky-ui/theme/src/component-vars.scss
@@ -69,11 +69,13 @@ page {
   --lk-rpx-80: 80rpx;
   --lk-rpx-84: 84rpx;
   --lk-rpx-88: 88rpx;
+  --lk-rpx-92: 92rpx;
   --lk-rpx-96: 96rpx;
   --lk-rpx-100: 100rpx;
   --lk-rpx-104: 104rpx;
   --lk-rpx-108: 108rpx;
   --lk-rpx-112: 112rpx;
+  --lk-rpx-120: 120rpx;
   --lk-rpx-128: 128rpx;
   --lk-rpx-140: 140rpx;
   --lk-rpx-144: 144rpx;

--- a/tests/unit/lk-keyboard.spec.ts
+++ b/tests/unit/lk-keyboard.spec.ts
@@ -61,18 +61,33 @@ describe('lk-keyboard input and layout rules', () => {
     ]);
 
     const provinceLayout = buildPlateProvinceKeyboardLayout('ABC');
+    expect(provinceLayout.length).toBe(4);
     expect(provinceLayout[0][0]).toEqual({ text: '京', value: '京' });
-    expect(provinceLayout.at(-1)).toEqual([
-      { text: 'ABC', type: 'extra', value: '__switch__' },
-      { text: '', type: 'delete' },
-    ]);
+    expect(provinceLayout[3][0]).toEqual({
+      text: 'ABC',
+      type: 'extra',
+      value: '__switch__',
+      flex: 1.5,
+    });
+    expect(provinceLayout[3].at(-1)).toEqual({
+      text: '',
+      type: 'delete',
+      flex: 1.5,
+    });
 
     const alphaNumLayout = buildPlateAlphaNumKeyboardLayout('省份');
-    expect(alphaNumLayout[0][0]).toEqual({ text: 'A', value: 'A' });
-    expect(alphaNumLayout.at(-1)?.[0]).toEqual({
+    expect(alphaNumLayout.length).toBe(4);
+    expect(alphaNumLayout[0][0]).toEqual({ text: '0', value: '0' });
+    expect(alphaNumLayout[3][0]).toEqual({
       text: '省份',
       type: 'extra',
       value: '__switch__',
+      flex: 1.5,
+    });
+    expect(alphaNumLayout[3].at(-1)).toEqual({
+      text: '',
+      type: 'delete',
+      flex: 1.5,
     });
   });
 
@@ -97,7 +112,7 @@ describe('lk-keyboard input and layout rules', () => {
         abcText: 'ABC',
         provinceText: '省份',
       })[0][0]
-    ).toEqual({ text: 'A', value: 'A' });
+    ).toEqual({ text: '0', value: '0' });
   });
 
   it('resolves key press actions without emitting disabled or overflowing input', () => {
@@ -131,6 +146,26 @@ describe('lk-keyboard input and layout rules', () => {
         plateMode: 'province',
       })
     ).toEqual({ kind: 'input', input: '1', nextValue: '121' });
+
+    // value 缺失时回退到 text
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: 'A' },
+        modelValue: '',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'input', input: 'A', nextValue: 'A' });
+
+    // 小数点防重复输入
+    expect(
+      resolveKeyboardPressAction({
+        key: { text: '.', value: '.' },
+        modelValue: '12.3',
+        maxLength: 0,
+        plateMode: 'province',
+      })
+    ).toEqual({ kind: 'ignore' });
 
     expect(
       resolveKeyboardPressAction({
@@ -184,7 +219,7 @@ describe('lk-keyboard input and layout rules', () => {
     expect(keyBlock).not.toContain('background:');
     expect(keyBlock).not.toContain('border:');
     expect(keyBlock).not.toContain('box-shadow:');
-    expect(styles).toContain('flex: 0 0 10%');
+    expect(styles).toContain('--kb-key-height: var(--lk-rpx-120)');
   });
 
   it('defaults to the minimal Popup presentation', () => {


### PR DESCRIPTION
## 背景

现有 Keyboard 的车牌键盘会生成不均衡的额外行，数字和车牌按键尺寸偏紧；自定义按键缺少 value 时也不会输入，同时数字键盘允许重复小数点。

## 变更内容

- 将省份和字母数字车牌键盘整理为四行均衡布局
- 字母数字车牌键盘首行改为 0~9，操作键使用弹性宽度
- 自定义按键未提供 value 时回退使用 text
- 阻止重复输入小数点
- 增大普通键盘和车牌键盘的按键高度、字号及底部留白
- 新增 92rpx、120rpx 主题尺寸变量
- 精简 Demo 中重复的提示卡片
- 更新 Keyboard 单测覆盖布局、回退输入与小数点规则

## 验证结果

- Keyboard 单测 7/7 通过
- vue-tsc 类型检查通过
- ESLint 与 Stylelint 通过
- H5 构建通过
- 微信小程序构建通过
- git diff --check 与 git show --check 通过

## 验收说明

本 PR 不改变 Keyboard 公共 Props 或事件签名，主要优化布局、视觉尺寸及输入边界行为。