### PR TITLE
feat(page): 完善全屏布局与演示场景

### DIFF
--- a/docs/components/page.md
+++ b/docs/components/page.md
@@ -85,8 +85,17 @@ phone: page
 | capsule-align | 是否开启左侧插槽与小程序胶囊按钮物理居中对齐 | `boolean` | `false` |
 | safe-area-bottom | 是否开启底部安全区适配 | `boolean` | `true` |
 | scrollable | 默认插槽内容是否包裹在滚动区域中 | `boolean` | `true` |
-| scroll-class | 滚动区域的自定义类名 | `string` | `''` |
+| scroll-class | 滚动区域的自定义类名 | `string \| object \| Array<string \| object>` | `''` |
 | scroll-style | 滚动区域的自定义样式 | `string \| object` | `''` |
+
+### CSS Variables
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `--lk-page-bg` | 页面容器背景色 | `var(--lk-bg-page)` |
+| `--lk-page-left-slot-left` | 左侧操作区的水平偏移 | `var(--lk-spacing-lg)` |
+| `--lk-page-left-slot-z-index` | 左侧操作区层级 | `100` |
+| `--lk-page-bottom-slot-z-index` | 底部操作区层级 | `90` |
 
 ### Slots
 

--- a/src/pages_sub/component-detail/index.vue
+++ b/src/pages_sub/component-detail/index.vue
@@ -14,6 +14,8 @@ const componentMark = computed(
 );
 const isFormPreview = computed(() => componentName.value === 'form');
 const isRootPreview = computed(() => componentName.value === 'root');
+const isPagePreview = computed(() => componentName.value === 'page');
+const isStandalonePreview = computed(() => isRootPreview.value || isPagePreview.value);
 
 const { theme, toggleTheme, themeClass } = useTheme();
 
@@ -23,9 +25,12 @@ usePreviewQuery(['component', 'name'], value => {
 </script>
 
 <template>
-  <view class="detail-page" :class="[themeClass, { 'is-native-scroll': isFormPreview }]">
-    <!-- 导航栏 -->
-    <lk-navbar :title="componentTitle">
+  <view
+    class="detail-page"
+    :class="[themeClass, { 'is-native-scroll': isFormPreview, 'is-standalone-page': isPagePreview }]"
+  >
+    <!-- 导航栏 (非独立全屏页面模式展示) -->
+    <lk-navbar v-if="!isPagePreview" :title="componentTitle">
       <template #right>
         <view class="theme-toggle" @click="toggleTheme">
           <lk-icon :name="theme === 'dark' ? 'sun' : 'moon'" size="28" />
@@ -33,8 +38,12 @@ usePreviewQuery(['component', 'name'], value => {
       </template>
     </lk-navbar>
 
+    <!-- 独立页面直接呈现 (如 root, page) -->
+    <preview-demo-renderer v-if="isStandalonePreview" :slug="componentName" />
+
     <!-- 内容区域 -->
     <scroll-view
+      v-else
       class="page-content"
       :class="{ 'is-native-scroll': isFormPreview }"
       :scroll-y="!isFormPreview"
@@ -61,8 +70,7 @@ usePreviewQuery(['component', 'name'], value => {
         </view>
 
         <!-- 演示区域 -->
-        <preview-demo-renderer v-if="isRootPreview" :slug="componentName" />
-        <view v-else class="demo-area" :class="{ 'is-full-screen': isFormPreview }">
+        <view class="demo-area" :class="{ 'is-full-screen': isFormPreview }">
           <preview-demo-renderer :slug="componentName">
             <view class="developing-tip">
               <lk-icon name="code-square" size="100" color="textTertiary" />
@@ -90,6 +98,13 @@ usePreviewQuery(['component', 'name'], value => {
     height: auto;
     min-height: 100vh;
     display: block;
+  }
+
+  &.is-standalone-page {
+    height: 100vh;
+    display: block;
+    overflow: hidden;
+    background: transparent;
   }
 }
 

--- a/src/pages_sub/components/demos/page-demo.vue
+++ b/src/pages_sub/components/demos/page-demo.vue
@@ -1,426 +1,756 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import LkPage from '@/uni_modules/lucky-ui/components/lk-page/lk-page.vue';
-import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
-import LkSwitch from '@/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue';
 import LkButton from '@/uni_modules/lucky-ui/components/lk-button/lk-button.vue';
-import DemoBlock from '@/uni_modules/lucky-ui/components/demo-block/demo-block.vue';
+import LkIcon from '@/uni_modules/lucky-ui/components/lk-icon/lk-icon.vue';
+import LkTag from '@/uni_modules/lucky-ui/components/lk-tag/lk-tag.vue';
+import LkCard from '@/uni_modules/lucky-ui/components/lk-card/lk-card.vue';
+import LkCellGroup from '@/uni_modules/lucky-ui/components/lk-cell/lk-cell-group.vue';
+import LkCell from '@/uni_modules/lucky-ui/components/lk-cell/lk-cell.vue';
+import LkPopup from '@/uni_modules/lucky-ui/components/lk-popup/lk-popup.vue';
+import LkSwitch from '@/uni_modules/lucky-ui/components/lk-switch/lk-switch.vue';
+import { useTheme } from '@/uni_modules/lucky-ui/theme';
 
-// 交互控制
-const reserveTop = ref(true);
-const capsuleAlign = ref(true);
-const safeAreaBottom = ref(true);
-const showBottomSlot = ref(true);
-const scrollable = ref(true);
+type SceneMode = 'order' | 'immersive' | 'result';
 
-type SysInfoLike = {
-  statusBarHeight?: number;
-  windowWidth?: number;
-};
+const currentScene = ref<SceneMode>('order');
+const showConfigDrawer = ref(false);
 
-// 提取系统指标
-const sys: SysInfoLike = typeof uni !== 'undefined' ? (uni.getSystemInfoSync() as SysInfoLike) : {};
-const statusBarHeight = sys.statusBarHeight ?? 0;
-
-// 获取胶囊位置参数
-let menuButtonInfo = { height: 32, top: statusBarHeight + 6, left: 280 };
-// #ifdef MP
-try {
-  if (typeof uni !== 'undefined' && uni.getMenuButtonBoundingClientRect) {
-    const rect = uni.getMenuButtonBoundingClientRect();
-    if (rect && rect.height) {
-      menuButtonInfo = {
-        height: rect.height,
-        top: rect.top,
-        left: rect.left,
-      };
-    }
-  }
-} catch {
-  // ignore
-}
-// #endif
-
-// 计算模拟导航栏的高度
-const navbarHeight = computed(() => {
-  const capsuleHeight = menuButtonInfo.height;
-  const capsuleTop = menuButtonInfo.top;
-  if (capsuleHeight > 0) {
-    return capsuleHeight + (capsuleTop - statusBarHeight) * 2;
-  }
-  return 44;
+const customConfig = ref({
+  reserveTop: true,
+  capsuleAlign: true,
+  safeAreaBottom: true,
+  scrollable: true,
+  showLeftSlot: true,
+  showBottomSlot: true,
 });
 
-const totalNavHeight = computed(() => statusBarHeight + navbarHeight.value);
+const { theme, toggleTheme, themeClass } = useTheme();
+
+const activeProps = computed(() => {
+  if (currentScene.value === 'immersive') {
+    return {
+      reserveTop: false,
+      capsuleAlign: true,
+      safeAreaBottom: true,
+      scrollable: true,
+      showLeftSlot: true,
+      showBottomSlot: true,
+    };
+  }
+  if (currentScene.value === 'result') {
+    return {
+      reserveTop: true,
+      capsuleAlign: true,
+      safeAreaBottom: true,
+      scrollable: false,
+      showLeftSlot: true,
+      showBottomSlot: true,
+    };
+  }
+  return {
+    reserveTop: customConfig.value.reserveTop,
+    capsuleAlign: customConfig.value.capsuleAlign,
+    safeAreaBottom: customConfig.value.safeAreaBottom,
+    scrollable: customConfig.value.scrollable,
+    showLeftSlot: customConfig.value.showLeftSlot,
+    showBottomSlot: customConfig.value.showBottomSlot,
+  };
+});
+
+function switchScene(scene: SceneMode) {
+  currentScene.value = scene;
+  if (scene === 'order') {
+    customConfig.value = {
+      reserveTop: true,
+      capsuleAlign: true,
+      safeAreaBottom: true,
+      scrollable: true,
+      showLeftSlot: true,
+      showBottomSlot: true,
+    };
+  }
+  uni.showToast({
+    title: `已切换：${scene === 'order' ? '标准订单页' : scene === 'immersive' ? '沉浸大图页' : '全屏结果页'}`,
+    icon: 'none',
+  });
+}
+
+function handleBack() {
+  uni.showToast({ title: '返回上一页 (Back)', icon: 'none' });
+}
+
+function handleHome() {
+  uni.showToast({ title: '返回主页 (Home)', icon: 'none' });
+}
+
+function handlePay() {
+  uni.showToast({ title: '正在拉起支付...', icon: 'none' });
+}
+
+function handleCancel() {
+  uni.showToast({ title: '订单已取消', icon: 'none' });
+}
 </script>
 
 <template>
-  <view class="component-demo">
-    <demo-block title="布局参数配置">
-      <view class="demo-controls">
-        <view class="control-item">
-          <view class="control-text">
-            <text class="control-title">顶部导航高度留白 (reserveTop)</text>
-            <text class="control-desc">开启后自动为自定义导航栏预留高度</text>
-          </view>
-          <lk-switch v-model="reserveTop" />
+  <view class="page-component-preview" :class="themeClass">
+    <!-- 核心 Page 容器 -->
+    <lk-page
+      :reserve-top="activeProps.reserveTop"
+      :capsule-align="activeProps.capsuleAlign"
+      :safe-area-bottom="activeProps.safeAreaBottom"
+      :scrollable="activeProps.scrollable"
+      :custom-class="['business-page-root', themeClass]"
+    >
+      <!-- 左侧插槽：胶囊垂直居中 -->
+      <template v-if="activeProps.showLeftSlot" #left>
+        <view
+          v-if="currentScene === 'immersive'"
+          class="immersive-back-btn"
+          @click="handleBack"
+        >
+          <lk-icon name="arrow-left" size="36" color="#ffffff" />
         </view>
-        <view class="control-item">
-          <view class="control-text">
-            <text class="control-title">左侧插槽胶囊对齐 (capsuleAlign)</text>
-            <text class="control-desc">使左侧返回按钮与右侧胶囊按钮垂直物理居中</text>
-          </view>
-          <lk-switch v-model="capsuleAlign" />
-        </view>
-        <view class="control-item">
-          <view class="control-text">
-            <text class="control-title">底部安全区适配 (safeAreaBottom)</text>
-            <text class="control-desc">开启时自动在底部空出系统操作条距离</text>
-          </view>
-          <lk-switch v-model="safeAreaBottom" />
-        </view>
-        <view class="control-item">
-          <view class="control-text">
-            <text class="control-title">使用底部插槽 (showBottomSlot)</text>
-            <text class="control-desc">显示底部的提交/操作固定操作栏</text>
-          </view>
-          <lk-switch v-model="showBottomSlot" />
-        </view>
-        <view class="control-item">
-          <view class="control-text">
-            <text class="control-title">启用默认滚动区域 (scrollable)</text>
-            <text class="control-desc">关闭则为普通容器，方便自定义更复杂的滚动</text>
-          </view>
-          <lk-switch v-model="scrollable" />
-        </view>
-      </view>
-    </demo-block>
 
-    <demo-block title="物理布局模拟器">
-      <view class="simulator-container">
-        <!-- 模拟手机外壳 -->
-        <view class="phone-simulator">
-          <!-- 模拟的小程序右上角胶囊按钮 -->
-          <view
-            class="mock-capsule"
-            :style="{
-              top: menuButtonInfo.top + 'px',
-              height: menuButtonInfo.height + 'px',
-            }"
-          >
-            <view class="capsule-dot" />
-            <view class="capsule-line" />
-            <view class="capsule-circle" />
+        <view v-else class="capsule-nav-actions">
+          <view class="nav-action-btn" @click="handleBack">
+            <lk-icon name="arrow-left" size="34" color="var(--lk-text-primary)" />
+          </view>
+          <view class="nav-action-divider" />
+          <view class="nav-action-btn" @click="handleHome">
+            <lk-icon name="house" size="32" color="var(--lk-text-primary)" />
+          </view>
+        </view>
+      </template>
+
+      <!-- 默认插槽：主体内容 -->
+      <!-- 场景一：标准二级订单详情页 -->
+      <view v-if="currentScene === 'order'" class="business-body">
+        <!-- 顶部效果切换卡片 -->
+        <view class="scene-switcher-card">
+          <view class="switcher-header">
+            <view class="switcher-title-wrap">
+              <lk-icon name="sliders" size="30" color="var(--lk-color-primary)" />
+              <text class="switcher-title">LkPage 效果切换</text>
+            </view>
+            <view class="theme-pill" @click="toggleTheme">
+              <lk-icon :name="theme === 'dark' ? 'sun' : 'moon'" size="24" />
+              <text class="theme-text">{{ theme === 'dark' ? '暗色' : '亮色' }}</text>
+            </view>
           </view>
 
-          <!-- 模拟的顶部自定义导航栏 (当 reserveTop 时配合展示，辅助看清位置关系) -->
-          <view
-            class="mock-navbar"
-            :style="{
-              height: totalNavHeight + 'px',
-              paddingTop: statusBarHeight + 'px',
-            }"
-            :class="{ 'is-transparent': !reserveTop }"
-          >
-            <text class="mock-navbar__title">自定义导航栏</text>
+          <view class="scene-grid">
+            <view class="scene-btn is-active" @click="switchScene('order')">
+              <lk-icon name="receipt" size="34" />
+              <text class="scene-label">标准订单</text>
+            </view>
+            <view class="scene-btn" @click="switchScene('immersive')">
+              <lk-icon name="image" size="34" />
+              <text class="scene-label">沉浸大图</text>
+            </view>
+            <view class="scene-btn" @click="switchScene('result')">
+              <lk-icon name="check-circle" size="34" />
+              <text class="scene-label">全屏结果</text>
+            </view>
+            <view class="scene-btn" @click="showConfigDrawer = true">
+              <lk-icon name="gear" size="34" />
+              <text class="scene-label">参数调试</text>
+            </view>
           </view>
+        </view>
 
-          <!-- 测试的目标组件: LkPage -->
-          <lk-page
-            :reserve-top="reserveTop"
-            :capsule-align="capsuleAlign"
-            :safe-area-bottom="safeAreaBottom"
-            :scrollable="scrollable"
-            custom-class="simulator-page"
-          >
-            <!-- 左侧插槽 -->
-            <template #left>
-              <view class="mock-left-slot">
-                <lk-icon name="arrow-left" size="36" color="var(--lk-text-primary)" />
-                <lk-icon
-                  name="house"
-                  size="34"
-                  color="var(--lk-text-primary)"
-                  style="margin-left: 16rpx"
-                />
+        <!-- 订单状态横幅 -->
+        <view class="order-status-banner">
+          <view class="status-left">
+            <text class="status-main">等待买家付款</text>
+            <text class="status-sub">剩 14:59 自动取消 · 订单 #LK-9824</text>
+          </view>
+          <lk-icon name="clock" size="40" color="var(--lk-color-primary)" />
+        </view>
+
+        <!-- 服务商品卡片 -->
+        <lk-card>
+          <view class="product-item">
+            <view class="product-thumb">
+              <lk-icon name="tools" size="56" color="var(--lk-color-primary)" />
+            </view>
+            <view class="product-info">
+              <text class="product-title">全屋智能家电深度清洗保养</text>
+              <view class="product-tags">
+                <lk-tag size="sm" color="primary">专业认证</lk-tag>
+                <lk-tag size="sm" color="success">极速上门</lk-tag>
               </view>
-            </template>
-
-            <!-- 默认插槽 (滚动内容) -->
-            <view class="simulator-body">
-              <view class="content-info-card">
-                <text class="info-card-title">配置状态监控</text>
-                <view class="info-card-row">
-                  <text class="info-card-label">顶部高度预留:</text>
-                  <text class="info-card-val" :class="{ 'is-active': reserveTop }">{{
-                    reserveTop ? '已开启' : '直接贴顶'
-                  }}</text>
-                </view>
-                <view class="info-card-row">
-                  <text class="info-card-label">左侧返回键对齐:</text>
-                  <text class="info-card-val" :class="{ 'is-active': capsuleAlign }">{{
-                    capsuleAlign ? '胶囊按钮居中' : '标准导航居中'
-                  }}</text>
-                </view>
-                <view class="info-card-row">
-                  <text class="info-card-label">底部安全适配:</text>
-                  <text class="info-card-val" :class="{ 'is-active': safeAreaBottom }">{{
-                    safeAreaBottom ? '自动留空适配' : '无安全留白'
-                  }}</text>
-                </view>
-              </view>
-
-              <view v-for="item in 12" :key="item" class="mock-content-card">
-                <text class="mock-card-title">段落内容示例 #{{ item }}</text>
-                <text class="mock-card-desc"
-                  >此处为页面主体滚动内容。通过滑动可以测试顶部和底部在滚动时的穿透与对齐效果。支持在小程序或全面屏手机上直观查看底部安全区是否被操作条遮挡。</text
-                >
+              <view class="product-price-row">
+                <text class="price-symbol">¥<text class="price-val">249.00</text></text>
+                <text class="price-qty">× 1</text>
               </view>
             </view>
+          </view>
+        </lk-card>
 
-            <!-- 底部插槽 -->
-            <template v-if="showBottomSlot" #bottom>
-              <view class="mock-bottom-bar">
-                <lk-button type="primary" block>保存并提交配置</lk-button>
-              </view>
-            </template>
-          </lk-page>
+        <!-- 费用与地址明细 -->
+        <lk-card>
+          <lk-cell-group>
+            <lk-cell title="服务地址" label="北京市海淀区中关村南大街 1 号 801 室" />
+            <lk-cell title="新客礼券" value="-¥50.00" />
+            <lk-cell title="实付金额" value="¥249.00" />
+          </lk-cell-group>
+        </lk-card>
+      </view>
 
-          <!-- 模拟物理 Home Indicator 安全区操作条 -->
-          <view class="mock-home-indicator" />
+      <!-- 场景二：沉浸大图详情页 -->
+      <view v-else-if="currentScene === 'immersive'" class="business-body is-immersive">
+        <view class="immersive-hero">
+          <view class="hero-content">
+            <lk-tag color="primary" size="sm">探索自然</lk-tag>
+            <text class="hero-heading">山林秘境·高空探索</text>
+            <text class="hero-sub">沉浸大图贴顶穿透 (reserveTop=false)</text>
+          </view>
+        </view>
+
+        <view class="immersive-inner">
+          <view class="scene-strip">
+            <text class="strip-text">当前处于沉浸式模式</text>
+            <lk-button size="sm" type="primary" @click="switchScene('order')">返回标准页</lk-button>
+          </view>
+
+          <lk-card title="亮点特色">
+            <text class="info-desc">全景高空步道，专业领队带队保障，支持提前24小时退订。</text>
+          </lk-card>
         </view>
       </view>
-    </demo-block>
+
+      <!-- 场景三：全屏不可滚动结果页 -->
+      <view v-else-if="currentScene === 'result'" class="business-body is-result">
+        <view class="result-card">
+          <lk-icon name="check-circle-fill" size="108" color="var(--lk-color-success)" />
+          <text class="result-title">预约办理成功</text>
+          <text class="result-desc">服务工单 #YZ-8899201 已派发给工程师</text>
+
+          <view class="result-info-box">
+            <view class="info-line">
+              <text class="info-label">服务人员</text>
+              <text class="info-val">张师傅 (认证工程师)</text>
+            </view>
+            <view class="info-line">
+              <text class="info-label">上门时间</text>
+              <text class="info-val">明日 09:30 - 11:30</text>
+            </view>
+          </view>
+
+          <lk-button block type="primary" @click="switchScene('order')">返回标准订单页</lk-button>
+        </view>
+      </view>
+
+      <!-- 底部吸底操作栏 -->
+      <template v-if="activeProps.showBottomSlot" #bottom>
+        <view v-if="currentScene === 'order'" class="order-bottom-bar">
+          <view class="bottom-price-info">
+            <text class="price-label">实付：</text>
+            <text class="price-symbol">¥<text class="price-num">249.00</text></text>
+          </view>
+          <view class="bottom-actions">
+            <lk-button size="md" @click="handleCancel">取消</lk-button>
+            <lk-button size="md" type="primary" @click="handlePay">立即支付</lk-button>
+          </view>
+        </view>
+
+        <view v-else-if="currentScene === 'immersive'" class="order-bottom-bar">
+          <text class="price-symbol">¥198.00<text class="price-label"> 起</text></text>
+          <lk-button size="md" type="primary" @click="handlePay">立即预订</lk-button>
+        </view>
+
+        <view v-else-if="currentScene === 'result'" class="order-bottom-bar is-center">
+          <text class="footer-tip">Lucky UI · 基础布局容器</text>
+        </view>
+      </template>
+    </lk-page>
+
+    <!-- 自由微调参数抽屉 -->
+    <lk-popup v-model="showConfigDrawer" position="bottom" round title="LkPage 属性微调">
+      <view class="drawer-content">
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">预留顶部导航高度 (reserveTop)</text>
+            <text class="item-desc">状态栏 + 胶囊导航区自适应避让</text>
+          </view>
+          <lk-switch v-model="customConfig.reserveTop" />
+        </view>
+
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">左侧胶囊物理居中 (capsuleAlign)</text>
+            <text class="item-desc">与小程序右上角胶囊按钮垂直居中</text>
+          </view>
+          <lk-switch v-model="customConfig.capsuleAlign" />
+        </view>
+
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">底部安全区留白 (safeAreaBottom)</text>
+            <text class="item-desc">全面屏底条 Home Indicator 避让</text>
+          </view>
+          <lk-switch v-model="customConfig.safeAreaBottom" />
+        </view>
+
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">启用滚动容器 (scrollable)</text>
+            <text class="item-desc">关闭则为普通非滚动容器</text>
+          </view>
+          <lk-switch v-model="customConfig.scrollable" />
+        </view>
+
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">渲染左侧插槽 (#left)</text>
+            <text class="item-desc">返回与首页操作区</text>
+          </view>
+          <lk-switch v-model="customConfig.showLeftSlot" />
+        </view>
+
+        <view class="drawer-item">
+          <view class="item-text">
+            <text class="item-title">渲染底部插槽 (#bottom)</text>
+            <text class="item-desc">吸底操作结算栏</text>
+          </view>
+          <lk-switch v-model="customConfig.showBottomSlot" />
+        </view>
+
+        <view class="drawer-actions">
+          <lk-button block type="primary" @click="showConfigDrawer = false">完成配置</lk-button>
+        </view>
+      </view>
+    </lk-popup>
   </view>
 </template>
 
 <style scoped lang="scss">
-.component-demo {
-  display: flex;
-  flex-direction: column;
-  gap: 32rpx;
-}
-
-.demo-controls {
-  display: flex;
-  flex-direction: column;
-  background-color: var(--lk-bg-container);
-  border-radius: var(--lk-radius-lg);
-  padding: 12rpx 24rpx;
-  border: 1rpx solid var(--lk-border-color);
-
-  .control-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 24rpx 0;
-
-    &:not(:last-child) {
-      border-bottom: 1rpx solid var(--lk-border-color-light);
-    }
-  }
-
-  .control-text {
-    display: flex;
-    flex-direction: column;
-    gap: 4rpx;
-  }
-
-  .control-title {
-    font-size: 28rpx;
-    font-weight: 600;
-    color: var(--lk-text-primary);
-  }
-
-  .control-desc {
-    font-size: 22rpx;
-    color: var(--lk-text-tertiary);
-  }
-}
-
-.simulator-container {
-  display: flex;
-  justify-content: center;
-  padding: 24rpx 0;
-}
-
-.phone-simulator {
+.page-component-preview {
   position: relative;
   width: 100%;
-  max-width: 700rpx;
-  height: 960rpx;
-  border-radius: 48rpx;
-  border: 12rpx solid #1a1a1a;
-  background-color: var(--lk-bg-page);
+  height: 100vh;
   overflow: hidden;
-  box-shadow: 0 24rpx 48rpx rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
 }
 
-.mock-capsule {
-  position: absolute;
-  right: 20rpx;
-  width: 160rpx;
-  border-radius: 32rpx;
-  background-color: rgba(255, 255, 255, 0.7);
-  border: 1rpx solid rgba(0, 0, 0, 0.08);
-  backdrop-filter: blur(10px);
-  z-index: 210;
+:deep(.business-page-root) {
+  background-color: var(--lk-bg-page);
+}
+
+// 胶囊双按钮
+.capsule-nav-actions {
   display: flex;
   align-items: center;
-  justify-content: space-evenly;
-  padding: 0 10rpx;
-  box-sizing: border-box;
+  background-color: var(--lk-bg-container);
+  backdrop-filter: blur(16px);
+  border: 1rpx solid var(--lk-color-border-light);
+  border-radius: 36rpx;
+  padding: 6rpx 14rpx;
+  box-shadow: var(--lk-shadow-sm);
 
-  .capsule-dot {
-    width: 16rpx;
-    height: 16rpx;
-    border-radius: 50%;
-    background-color: #000;
+  .nav-action-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rpx 6rpx;
+    cursor: pointer;
   }
 
-  .capsule-line {
+  .nav-action-divider {
     width: 2rpx;
-    height: 24rpx;
-    background-color: rgba(0, 0, 0, 0.15);
-  }
-
-  .capsule-circle {
-    width: 24rpx;
-    height: 24rpx;
-    border-radius: 50%;
-    border: 4rpx solid #000;
-    box-sizing: border-box;
+    height: 22rpx;
+    background-color: var(--lk-color-border-light);
+    margin: 0 6rpx;
   }
 }
 
-.mock-navbar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+.immersive-back-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--lk-bg-container);
-  border-bottom: 1rpx solid var(--lk-border-color);
-  z-index: 180;
-  box-sizing: border-box;
-  transition: all 0.3s;
-
-  &.is-transparent {
-    background-color: transparent;
-    border-color: transparent;
-    pointer-events: none;
-    .mock-navbar__title {
-      opacity: 0;
-    }
-  }
-
-  &__title {
-    font-size: 28rpx;
-    font-weight: 600;
-    color: var(--lk-text-primary);
-  }
+  width: 64rpx;
+  height: 64rpx;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+  cursor: pointer;
 }
 
-:deep(.simulator-page) {
-  background-color: var(--lk-bg-page);
-}
-
-.mock-left-slot {
-  display: flex;
-  align-items: center;
-  background-color: rgba(255, 255, 255, 0.75);
-  border: 1rpx solid var(--lk-border-color);
-  padding: 8rpx 16rpx;
-  border-radius: 32rpx;
-  backdrop-filter: blur(10px);
-}
-
-.simulator-body {
-  padding: 24rpx;
+// 业务容器
+.business-body {
   display: flex;
   flex-direction: column;
-  gap: 24rpx;
+  gap: 20rpx;
+  padding: 20rpx;
+  box-sizing: border-box;
+
+  &.is-immersive {
+    padding: 0;
+    gap: 0;
+  }
+
+  &.is-result {
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    padding: 32rpx;
+  }
 }
 
-.content-info-card {
+// 场景切换卡片
+.scene-switcher-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  padding: 20rpx;
+  border-radius: var(--lk-radius-lg);
   background: linear-gradient(
     135deg,
     var(--lk-color-primary-soft),
-    rgba(var(--lk-color-primary-rgb), 0.05)
+    rgba(var(--lk-color-primary-rgb), 0.04)
   );
   border: 1rpx solid var(--lk-color-primary-soft);
-  border-radius: 20rpx;
-  padding: 24rpx;
-  display: flex;
-  flex-direction: column;
-  gap: 12rpx;
 
-  .info-card-title {
+  .switcher-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .switcher-title-wrap {
+    display: flex;
+    align-items: center;
+    gap: 10rpx;
+  }
+
+  .switcher-title {
     font-size: 26rpx;
     font-weight: 700;
     color: var(--lk-color-primary);
   }
 
-  .info-card-row {
+  .theme-pill {
     display: flex;
-    justify-content: space-between;
-    font-size: 22rpx;
+    align-items: center;
+    gap: 6rpx;
+    padding: 4rpx 14rpx;
+    border-radius: 20rpx;
+    background-color: var(--lk-bg-container);
+    border: 1rpx solid var(--lk-border-color-light);
+    cursor: pointer;
+
+    .theme-text {
+      font-size: 20rpx;
+      color: var(--lk-text-secondary);
+    }
   }
 
-  .info-card-label {
-    color: var(--lk-text-secondary);
+  .scene-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10rpx;
   }
 
-  .info-card-val {
-    color: var(--lk-text-tertiary);
-    font-weight: 600;
+  .scene-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6rpx;
+    padding: 14rpx 4rpx;
+    border-radius: var(--lk-radius-md);
+    background-color: var(--lk-bg-container);
+    border: 1rpx solid var(--lk-border-color-light);
+    cursor: pointer;
+    transition: all 0.2s;
 
     &.is-active {
-      color: var(--lk-color-success);
+      border-color: var(--lk-color-primary);
+      background-color: var(--lk-color-primary-soft);
+      color: var(--lk-color-primary);
+    }
+
+    .scene-label {
+      font-size: 20rpx;
+      font-weight: 600;
+      color: var(--lk-text-primary);
     }
   }
 }
 
-.mock-content-card {
-  background-color: var(--lk-bg-container);
-  border: 1rpx solid var(--lk-border-color);
-  border-radius: 16rpx;
-  padding: 20rpx;
+// 订单状态横幅
+.order-status-banner {
   display: flex;
-  flex-direction: column;
-  gap: 8rpx;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24rpx;
+  border-radius: var(--lk-radius-lg);
+  background: linear-gradient(135deg, var(--lk-color-primary-soft), var(--lk-bg-container));
+  border: 1rpx solid var(--lk-color-primary-soft);
 
-  .mock-card-title {
+  .status-left {
+    display: flex;
+    flex-direction: column;
+    gap: 4rpx;
+  }
+
+  .status-main {
+    font-size: 30rpx;
+    font-weight: 700;
+    color: var(--lk-color-primary);
+  }
+
+  .status-sub {
+    font-size: 20rpx;
+    color: var(--lk-text-secondary);
+  }
+}
+
+// 商品卡片
+.product-item {
+  display: flex;
+  gap: 16rpx;
+
+  .product-thumb {
+    width: 110rpx;
+    height: 110rpx;
+    border-radius: var(--lk-radius-md);
+    background-color: var(--lk-color-primary-soft);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .product-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    flex: 1;
+  }
+
+  .product-title {
     font-size: 26rpx;
     font-weight: 600;
     color: var(--lk-text-primary);
   }
 
-  .mock-card-desc {
+  .product-tags {
+    display: flex;
+    gap: 8rpx;
+    margin: 4rpx 0;
+  }
+
+  .product-price-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .price-symbol {
     font-size: 22rpx;
-    color: var(--lk-text-secondary);
-    line-height: 1.4;
+    font-weight: 700;
+    color: var(--lk-color-danger, #ff4d4f);
+
+    .price-val {
+      font-size: 30rpx;
+    }
+  }
+
+  .price-qty {
+    font-size: 22rpx;
+    color: var(--lk-text-tertiary);
   }
 }
 
-.mock-bottom-bar {
-  background-color: var(--lk-bg-container);
-  border-top: 1rpx solid var(--lk-border-color);
-  padding: 20rpx 24rpx;
+// 沉浸页
+.immersive-hero {
+  width: 100%;
+  height: 380rpx;
+  background: linear-gradient(135deg, #1890ff, #722ed1);
+  display: flex;
+  align-items: flex-end;
+  padding: 28rpx;
+  box-sizing: border-box;
+
+  .hero-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8rpx;
+  }
+
+  .hero-heading {
+    font-size: 36rpx;
+    font-weight: 800;
+    color: #ffffff;
+  }
+
+  .hero-sub {
+    font-size: 20rpx;
+    color: rgba(255, 255, 255, 0.85);
+  }
 }
 
-.mock-home-indicator {
-  position: absolute;
-  bottom: 8rpx;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 240rpx;
-  height: 8rpx;
-  border-radius: 4rpx;
-  background-color: #000000;
-  z-index: 220;
-  pointer-events: none;
+.immersive-inner {
+  padding: 20rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+}
+
+.scene-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12rpx 20rpx;
+  border-radius: var(--lk-radius-md);
+  background-color: var(--lk-bg-container);
+  border: 1rpx solid var(--lk-border-color-light);
+
+  .strip-text {
+    font-size: 22rpx;
+    color: var(--lk-text-secondary);
+  }
+}
+
+.info-desc {
+  font-size: 22rpx;
+  color: var(--lk-text-secondary);
+  line-height: 1.5;
+}
+
+// 结果页
+.result-card {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40rpx 28rpx;
+  border-radius: var(--lk-radius-xl);
+  background-color: var(--lk-bg-container);
+  border: 1rpx solid var(--lk-border-color-light);
+  box-shadow: var(--lk-shadow-sm);
+
+  .result-title {
+    font-size: 34rpx;
+    font-weight: 800;
+    color: var(--lk-text-primary);
+    margin-top: 16rpx;
+  }
+
+  .result-desc {
+    font-size: 22rpx;
+    color: var(--lk-text-secondary);
+    margin: 6rpx 0 28rpx;
+  }
+
+  .result-info-box {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10rpx;
+    padding: 18rpx;
+    border-radius: var(--lk-radius-md);
+    background-color: var(--lk-bg-page);
+    margin-bottom: 32rpx;
+
+    .info-line {
+      display: flex;
+      justify-content: space-between;
+      font-size: 22rpx;
+
+      .info-label {
+        color: var(--lk-text-tertiary);
+      }
+      .info-val {
+        color: var(--lk-text-primary);
+        font-weight: 600;
+      }
+    }
+  }
+}
+
+// 底部栏
+.order-bottom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16rpx 24rpx;
+  background-color: var(--lk-bg-container);
+  border-top: 1rpx solid var(--lk-border-color-light);
+
+  &.is-center {
+    justify-content: center;
+    padding: 18rpx;
+  }
+
+  .bottom-price-info {
+    display: flex;
+    align-items: baseline;
+
+    .price-label {
+      font-size: 22rpx;
+      color: var(--lk-text-secondary);
+    }
+
+    .price-symbol {
+      font-size: 22rpx;
+      font-weight: 700;
+      color: var(--lk-color-danger, #ff4d4f);
+    }
+
+    .price-num {
+      font-size: 32rpx;
+    }
+  }
+
+  .bottom-actions {
+    display: flex;
+    gap: 12rpx;
+  }
+
+  .footer-tip {
+    font-size: 20rpx;
+    color: var(--lk-text-tertiary);
+  }
+}
+
+// 抽屉
+.drawer-content {
+  padding: 20rpx 28rpx 40rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 18rpx;
+
+  .drawer-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 14rpx;
+    border-bottom: 1rpx solid var(--lk-border-color-light);
+
+    .item-text {
+      display: flex;
+      flex-direction: column;
+      gap: 2rpx;
+    }
+
+    .item-title {
+      font-size: 26rpx;
+      font-weight: 600;
+      color: var(--lk-text-primary);
+    }
+
+    .item-desc {
+      font-size: 20rpx;
+      color: var(--lk-text-tertiary);
+    }
+  }
+
+  .drawer-actions {
+    margin-top: 10rpx;
+  }
 }
 </style>

--- a/src/uni_modules/lucky-ui/components/lk-page/lk-page.scss
+++ b/src/uni_modules/lucky-ui/components/lk-page/lk-page.scss
@@ -1,4 +1,6 @@
-.lk-page {
+@use '../../theme/src/mixins/bem' as *;
+
+@include b(page) {
   position: absolute;
   top: 0;
   left: 0;
@@ -8,60 +10,71 @@
   flex-direction: column;
   overflow: hidden;
   box-sizing: border-box;
-  background-color: var(--lk-bg-page);
+  background-color: var(--lk-page-bg, var(--lk-bg-page));
   color: var(--lk-text-primary);
   font-family: var(--lk-font-family);
 
-  &__left-slot {
+  @include m(non-scrollable) {
+    position: relative;
+    height: auto;
+    min-height: 100%;
+    overflow: visible;
+  }
+
+  @include e(left-slot) {
     position: absolute;
-    left: 16px;
+    left: var(--lk-page-left-slot-left, var(--lk-spacing-lg, 16px));
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    z-index: 100;
+    z-index: var(--lk-page-left-slot-z-index, 100);
     box-sizing: border-box;
   }
 
-  &__top-placeholder {
+  @include e(top-placeholder) {
     width: 100%;
     flex-shrink: 0;
     box-sizing: border-box;
     background-color: transparent;
   }
 
-  &__scroll-view {
+  @include e(scroll-view) {
     flex: 1;
     height: 0;
     width: 100%;
     box-sizing: border-box;
   }
 
-  &__normal-view {
+  @include e(normal-view) {
     flex: 1;
     width: 100%;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+
+    > .lk-page__content {
+      flex: 1;
+    }
   }
 
-  &__content {
+  @include e(content) {
     width: 100%;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
 
-    &--safe-area {
+    @include m(safe-area) {
       padding-bottom: env(safe-area-inset-bottom);
     }
   }
 
-  &__bottom-slot {
+  @include e(bottom-slot) {
     width: 100%;
     flex-shrink: 0;
     box-sizing: border-box;
-    z-index: 90;
+    z-index: var(--lk-page-bottom-slot-z-index, 90);
 
-    &--safe-area {
+    @include m(safe-area) {
       padding-bottom: env(safe-area-inset-bottom);
     }
   }

--- a/src/uni_modules/lucky-ui/components/lk-page/lk-page.vue
+++ b/src/uni_modules/lucky-ui/components/lk-page/lk-page.vue
@@ -2,6 +2,13 @@
 import type { StyleValue } from 'vue';
 import { computed } from 'vue';
 import { pageProps } from './page.props';
+import {
+  resolvePageLeftSlotStyle,
+  resolvePageNavbarContentHeight,
+  resolvePageReservedTopHeight,
+  resolvePageRootClass,
+  type PageMenuButtonInfo,
+} from './page.utils';
 
 defineOptions({ name: 'LkPage' });
 
@@ -17,7 +24,7 @@ const sys: SysInfoLike = typeof uni !== 'undefined' ? (uni.getSystemInfoSync() a
 const statusBarHeight = sys.statusBarHeight ?? 0;
 
 // 获取胶囊按钮信息（仅小程序）
-let menuButtonInfo = { height: 0, top: 0, left: 0 };
+let menuButtonInfo: PageMenuButtonInfo = { height: 0, top: 0, left: 0 };
 // #ifdef MP
 try {
   if (typeof uni !== 'undefined' && uni.getMenuButtonBoundingClientRect) {
@@ -37,46 +44,41 @@ try {
 
 // 计算导航栏内容高度
 // 在小程序中，导航栏高度应该与胶囊按钮对齐
-const navbarContentHeight = computed(() => {
-  const capsuleHeight = menuButtonInfo.height ?? 0;
-  const capsuleTop = menuButtonInfo.top ?? 0;
-  if (capsuleHeight > 0) {
-    return capsuleHeight + (capsuleTop - statusBarHeight) * 2;
-  }
-  return 44; // 默认标准高度为 44px
-});
+const navbarContentHeight = computed(() =>
+  resolvePageNavbarContentHeight({
+    statusBarHeight,
+    menuButtonInfo,
+  })
+);
 
 // 计算预留的顶部总高度
-const reservedTopHeight = computed(() => {
-  return statusBarHeight + navbarContentHeight.value;
-});
+const reservedTopHeight = computed(() =>
+  resolvePageReservedTopHeight({
+    statusBarHeight,
+    navbarContentHeight: navbarContentHeight.value,
+  })
+);
 
 // 计算左侧插槽的定位与高度样式，实现精准物理居中对齐
-const leftSlotStyle = computed(() => {
-  const style: Record<string, string> = {
-    zIndex: String(props.zIndex),
-  };
+const leftSlotStyle = computed(() =>
+  resolvePageLeftSlotStyle({
+    capsuleAlign: props.capsuleAlign,
+    statusBarHeight,
+    navbarContentHeight: navbarContentHeight.value,
+    menuButtonInfo,
+    zIndex: props.zIndex,
+  })
+);
 
-  if (props.capsuleAlign) {
-    // 胶囊对齐逻辑：居中对齐小程序右上角的胶囊按钮
-    const top = menuButtonInfo.top || statusBarHeight + 6;
-    const height = menuButtonInfo.height || 32;
-    style.top = `${top}px`;
-    style.height = `${height}px`;
-  } else {
-    // 默认对齐逻辑：居中对齐标准导航栏内容区
-    style.top = `${statusBarHeight}px`;
-    style.height = `${navbarContentHeight.value}px`;
-  }
-
-  return style;
-});
-
-const rootClass = computed(() => {
-  return ['lk-page', props.customClass];
-});
+const rootClass = computed(() =>
+  resolvePageRootClass({
+    customClass: props.customClass,
+    scrollable: props.scrollable,
+  })
+);
 
 const rootStyle = computed(() => props.customStyle as StyleValue);
+const resolvedScrollStyle = computed(() => props.scrollStyle as StyleValue);
 </script>
 
 <template>
@@ -98,7 +100,7 @@ const rootStyle = computed(() => props.customStyle as StyleValue);
       v-if="scrollable"
       class="lk-page__scroll-view"
       :class="scrollClass"
-      :style="scrollStyle"
+      :style="resolvedScrollStyle"
       scroll-y
     >
       <view
@@ -109,11 +111,10 @@ const rootStyle = computed(() => props.customStyle as StyleValue);
       </view>
     </scroll-view>
 
-    <view v-else class="lk-page__normal-view" :class="scrollClass" :style="scrollStyle">
+    <view v-else class="lk-page__normal-view" :class="scrollClass" :style="resolvedScrollStyle">
       <view
         class="lk-page__content"
         :class="{ 'lk-page__content--safe-area': safeAreaBottom && !$slots.bottom }"
-        style="flex: 1"
       >
         <slot />
       </view>

--- a/src/uni_modules/lucky-ui/components/lk-page/page.props.ts
+++ b/src/uni_modules/lucky-ui/components/lk-page/page.props.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes } from 'vue';
+import type { ExtractPropTypes, PropType } from 'vue';
 import { baseProps, LkProp } from '../common/props';
 
 export const pageProps = {
@@ -27,12 +27,18 @@ export const pageProps = {
   /**
    * 滚动区域的自定义类名
    */
-  scrollClass: LkProp.string(''),
+  scrollClass: {
+    type: [String, Object, Array] as PropType<string | object | Array<string | object>>,
+    default: '',
+  },
 
   /**
    * 滚动区域的自定义样式
    */
-  scrollStyle: LkProp.string(''),
+  scrollStyle: {
+    type: [String, Object] as PropType<string | Record<string, unknown>>,
+    default: '',
+  },
 } as const;
 
 export type PageProps = ExtractPropTypes<typeof pageProps>;

--- a/src/uni_modules/lucky-ui/components/lk-page/page.utils.ts
+++ b/src/uni_modules/lucky-ui/components/lk-page/page.utils.ts
@@ -1,0 +1,86 @@
+export type PageMenuButtonInfo = {
+  height?: number;
+  top?: number;
+  left?: number;
+};
+
+export type ResolvePageNavbarHeightOptions = {
+  statusBarHeight: number;
+  menuButtonInfo?: PageMenuButtonInfo;
+  defaultHeight?: number;
+};
+
+export type ResolvePageLeftSlotStyleOptions = {
+  capsuleAlign: boolean;
+  statusBarHeight: number;
+  navbarContentHeight: number;
+  menuButtonInfo?: PageMenuButtonInfo;
+  zIndex?: number | string;
+};
+
+export type ResolvePageRootClassOptions = {
+  customClass?: unknown;
+  scrollable: boolean;
+};
+
+/**
+ * 计算导航栏内容区域高度（小程序中根据胶囊按钮自适应，默认 44px）
+ */
+export function resolvePageNavbarContentHeight(options: ResolvePageNavbarHeightOptions): number {
+  const capsuleHeight = options.menuButtonInfo?.height ?? 0;
+  const capsuleTop = options.menuButtonInfo?.top ?? 0;
+  if (capsuleHeight > 0) {
+    return capsuleHeight + (capsuleTop - options.statusBarHeight) * 2;
+  }
+  return options.defaultHeight ?? 44;
+}
+
+/**
+ * 计算预留的顶部总高度（状态栏高度 + 导航栏内容区高度）
+ */
+export function resolvePageReservedTopHeight(options: {
+  statusBarHeight: number;
+  navbarContentHeight: number;
+}): number {
+  return options.statusBarHeight + options.navbarContentHeight;
+}
+
+/**
+ * 计算左侧插槽的定位与高度样式，实现精准物理居中对齐
+ */
+export function resolvePageLeftSlotStyle(
+  options: ResolvePageLeftSlotStyleOptions
+): Record<string, string> {
+  const style: Record<string, string> = {};
+
+  if (options.zIndex !== undefined && options.zIndex !== '') {
+    style.zIndex = String(options.zIndex);
+  }
+
+  if (options.capsuleAlign) {
+    // 胶囊对齐逻辑：居中对齐小程序右上角的胶囊按钮（若无胶囊信息则使用 6px 偏移与 32px 标准高度回退）
+    const top = options.menuButtonInfo?.top || options.statusBarHeight + 6;
+    const height = options.menuButtonInfo?.height || 32;
+    style.top = `${top}px`;
+    style.height = `${height}px`;
+  } else {
+    // 默认对齐逻辑：居中对齐标准导航栏内容区
+    style.top = `${options.statusBarHeight}px`;
+    style.height = `${options.navbarContentHeight}px`;
+  }
+
+  return style;
+}
+
+/**
+ * 构建根容器类名
+ */
+export function resolvePageRootClass(options: ResolvePageRootClassOptions): unknown[] {
+  return [
+    'lk-page',
+    options.customClass,
+    {
+      'lk-page--non-scrollable': !options.scrollable,
+    },
+  ];
+}

--- a/src/uni_modules/lucky-ui/theme/src/component-vars.scss
+++ b/src/uni_modules/lucky-ui/theme/src/component-vars.scss
@@ -479,6 +479,11 @@ page,
   --lk-navbar-content-padding-left: var(--lk-spacing-md);
   --lk-navbar-content-padding-right: var(--lk-spacing-md);
 
+  --lk-page-bg: var(--lk-bg-page);
+  --lk-page-left-slot-left: var(--lk-spacing-lg);
+  --lk-page-left-slot-z-index: 100;
+  --lk-page-bottom-slot-z-index: 90;
+
   --lk-tabbar-height: var(--lk-rpx-112);
   --lk-tabbar-item-height: var(--lk-control-height-md);
   --lk-tabbar-safe-area-bottom: env(safe-area-inset-bottom);

--- a/tests/unit/lk-page.spec.ts
+++ b/tests/unit/lk-page.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { pageProps } from '../../src/uni_modules/lucky-ui/components/lk-page/page.props';
+import {
+  resolvePageLeftSlotStyle,
+  resolvePageNavbarContentHeight,
+  resolvePageReservedTopHeight,
+  resolvePageRootClass,
+} from '../../src/uni_modules/lucky-ui/components/lk-page/page.utils';
+
+describe('lk-page layout and calculations', () => {
+  it('has standard default props', () => {
+    expect(pageProps.reserveTop.default).toBe(false);
+    expect(pageProps.capsuleAlign.default).toBe(false);
+    expect(pageProps.safeAreaBottom.default).toBe(true);
+    expect(pageProps.scrollable.default).toBe(true);
+    expect(pageProps.scrollClass.default).toBe('');
+    expect(pageProps.scrollStyle.default).toBe('');
+  });
+
+  it('calculates navbar content height and reserved top spacing', () => {
+    // 小程序胶囊存在时的计算
+    const navHeightWithCapsule = resolvePageNavbarContentHeight({
+      statusBarHeight: 20,
+      menuButtonInfo: {
+        height: 32,
+        top: 26,
+        left: 280,
+      },
+    });
+    // 32 + (26 - 20) * 2 = 32 + 12 = 44
+    expect(navHeightWithCapsule).toBe(44);
+
+    const totalReservedTop = resolvePageReservedTopHeight({
+      statusBarHeight: 20,
+      navbarContentHeight: navHeightWithCapsule,
+    });
+    expect(totalReservedTop).toBe(64);
+
+    // 无胶囊（如 H5/App）时的回退计算
+    const navHeightFallback = resolvePageNavbarContentHeight({
+      statusBarHeight: 0,
+      menuButtonInfo: {},
+    });
+    expect(navHeightFallback).toBe(44);
+
+    const customDefaultHeight = resolvePageNavbarContentHeight({
+      statusBarHeight: 0,
+      menuButtonInfo: {},
+      defaultHeight: 48,
+    });
+    expect(customDefaultHeight).toBe(48);
+  });
+
+  it('resolves left slot style for standard and capsule alignments', () => {
+    // 1. 标准居中对齐 (capsuleAlign: false)
+    const standardStyle = resolvePageLeftSlotStyle({
+      capsuleAlign: false,
+      statusBarHeight: 24,
+      navbarContentHeight: 44,
+      menuButtonInfo: { height: 32, top: 30 },
+      zIndex: 99,
+    });
+    expect(standardStyle).toEqual({
+      zIndex: '99',
+      top: '24px',
+      height: '44px',
+    });
+
+    // 2. 胶囊居中对齐 (capsuleAlign: true) - 存在胶囊信息
+    const capsuleStyle = resolvePageLeftSlotStyle({
+      capsuleAlign: true,
+      statusBarHeight: 24,
+      navbarContentHeight: 44,
+      menuButtonInfo: { height: 32, top: 30 },
+      zIndex: 100,
+    });
+    expect(capsuleStyle).toEqual({
+      zIndex: '100',
+      top: '30px',
+      height: '32px',
+    });
+
+    // 3. 胶囊居中对齐 (capsuleAlign: true) - 无胶囊信息 (H5/App Fallback)
+    const fallbackCapsuleStyle = resolvePageLeftSlotStyle({
+      capsuleAlign: true,
+      statusBarHeight: 0,
+      navbarContentHeight: 44,
+      menuButtonInfo: {},
+    });
+    expect(fallbackCapsuleStyle).toEqual({
+      top: '6px',
+      height: '32px',
+    });
+  });
+
+  it('builds root classes according to scrollable and customClass', () => {
+    // 可滚动模式
+    const scrollableClasses = resolvePageRootClass({
+      customClass: 'custom-page-class',
+      scrollable: true,
+    });
+    expect(scrollableClasses).toEqual([
+      'lk-page',
+      'custom-page-class',
+      {
+        'lk-page--non-scrollable': false,
+      },
+    ]);
+
+    // 非滚动全屏/原生滚动模式
+    const nonScrollableClasses = resolvePageRootClass({
+      scrollable: false,
+    });
+    expect(nonScrollableClasses).toEqual([
+      'lk-page',
+      undefined,
+      {
+        'lk-page--non-scrollable': true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## 背景

LkPage 需要同时支持组件详情中的独立全屏预览、原生页面流式布局、复杂滚动类名/样式，以及更贴近真实业务的多场景演示。

## 变更内容

- Page 详情页改为独立全屏渲染，不再套用通用 Navbar 和滚动容器
- 抽离状态栏、胶囊高度、左侧插槽和根类名计算工具
- 非 scrollable 模式支持原生流式高度与可见溢出
- scroll-class 支持字符串、对象和数组
- scroll-style 支持字符串和对象
- 新增 Page 背景、左右操作区层级等主题变量
- 重构 Page Demo，提供标准订单、沉浸大图、全屏结果和参数调试场景
- 新增 Page 布局工具单测
- 同步 Page 文档中的 Props 类型和 CSS Variables
- 保持 page.utils 为内部实现，不扩大组件公共导出

## 验证结果

- Page 单测 4/4 通过
- vue-tsc 类型检查通过
- ESLint 与 Stylelint 通过
- H5 构建通过
- 微信小程序构建通过
- git diff --check 与 git show --check 通过

## 验收说明

本 PR 保持现有 Page Props 默认值和插槽名称不变；scroll-class、scroll-style 仅做向后兼容的类型扩展。